### PR TITLE
Auto-detect receiver status sensors and add receiver scale options

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,18 +127,35 @@ entities:
   - sensor.eriks_iphone_16
 show_receivers: true
 show_receiver_labels: true   # optional: print the receiver name next to the icon
+scale_receiver_icon: 100     # optional: receiver icon size (defaults to scale_icon)
+scale_receiver_labels: 75    # optional: receiver label size (defaults to scale_labels)
 receiver_status:             # optional: explicit status entity per receiver
   nsp_kitchen: binary_sensor.nsp_kitchen_status
 ```
 
-- Without `receiver_status`, a receiver counts as working when at least one
-  Bermuda `sensor.*_distance_to_<receiver>` entity reports a distance. Bermuda
-  keeps the last reading for roughly 30 seconds (its distance timeout) before
-  the sensor goes to `unknown`, so a dead proxy — or a receiver that no tracker
-  can reach — turns red after about half a minute.
-- With `receiver_status`, the mapped entity decides: states such as `off`,
-  `unavailable`, `unknown`, `not_home` or `offline` show the receiver in red,
-  anything else in black. An ESPHome `status` binary sensor works well here.
+The working/offline decision is made per receiver, in this order:
+
+1. **`receiver_status` mapping** (if given): the mapped entity decides — states
+   such as `off`, `unavailable`, `unknown`, `not_home` or `offline` show the
+   receiver in red, anything else in black. Mapping a receiver to `false` (or
+   `heuristic`) instead of an entity skips step 2 and forces the distance
+   heuristic for that receiver.
+2. **`binary_sensor.<receiver>_status`** (if that entity exists with device
+   class `connectivity`): the conventional ESPHome `status` sensor is used
+   automatically. It reports the device offline the moment it disconnects and
+   stays `on` even when no tracker is near the proxy — but note it proves API
+   connectivity only, so a proxy whose BLE scanner has wedged still shows
+   black (use the `false` opt-out above if you prefer the heuristic there).
+3. **Bermuda distance sensors** (fallback): the receiver counts as working when
+   at least one `sensor.*_distance_to_<receiver>` entity reports a distance.
+   Bermuda keeps the last reading for roughly 30 seconds (its distance timeout)
+   before the sensor goes to `unknown`, so a dead proxy — or a live proxy that
+   no tracker can currently reach — turns red after about half a minute.
+
+If a receiver shows red even though the device is online, it is on the fallback
+heuristic with no tracker in range: add the `status` binary sensor to its
+ESPHome config (`binary_sensor: - platform: status`), or map any entity of the
+device in `receiver_status`.
 
 The full card guide (all options, per-floor behavior, labels/icons/zones, and troubleshooting) is in the wiki:
 - [Wiki: Lovelace map card](https://github.com/Hogster/BPS/wiki/Lovelace-map-card)

--- a/README.md
+++ b/README.md
@@ -133,29 +133,40 @@ receiver_status:             # optional: explicit status entity per receiver
   nsp_kitchen: binary_sensor.nsp_kitchen_status
 ```
 
-The working/offline decision is made per receiver, in this order:
+The working/offline decision is made per receiver, first match wins:
 
 1. **`receiver_status` mapping** (if given): the mapped entity decides — states
    such as `off`, `unavailable`, `unknown`, `not_home` or `offline` show the
-   receiver in red, anything else in black. Mapping a receiver to `false` (or
-   `heuristic`) instead of an entity skips step 2 and forces the distance
-   heuristic for that receiver.
-2. **`binary_sensor.<receiver>_status`** (if that entity exists with device
-   class `connectivity`): the conventional ESPHome `status` sensor is used
-   automatically. It reports the device offline the moment it disconnects and
-   stays `on` even when no tracker is near the proxy — but note it proves API
-   connectivity only, so a proxy whose BLE scanner has wedged still shows
-   black (use the `false` opt-out above if you prefer the heuristic there).
-3. **Bermuda distance sensors** (fallback): the receiver counts as working when
+   receiver in red, anything else in black. Any entity of the device works
+   (e.g. an uptime sensor: it goes `unavailable` when the device drops off).
+   Mapping a receiver to `false` (or `heuristic`) instead of an entity skips
+   steps 2-4 and forces the distance heuristic for that receiver.
+2. **Bermuda scanner liveness** (automatic): the card asks Bermuda directly
+   (`bermuda.dump_devices`) and matches scanners to receivers by name. A
+   receiver is working while its scanner heard *any* BLE advertisement within
+   `receiver_timeout` seconds (default 30, minimum 10) — the same signal as
+   the scanner table in Bermuda's configure dialog. This is the strongest
+   tier: it proves the proxy is actually receiving, and catches a proxy whose
+   BLE scanning died while its network connection stayed up.
+3. **`binary_sensor.<receiver>_status`** (if that entity exists with device
+   class `connectivity`): the conventional ESPHome `status` sensor.
+4. **Device availability** (automatic): the HA device whose name matches the
+   receiver is online while any of its entities is not `unavailable` — an
+   uptime sensor is enough. If the device has a connectivity-class entity
+   (like the ESPHome `status` sensor), that entity's state decides instead,
+   since ESPHome keeps it available (state `off`) when the device dies.
+5. **Bermuda distance sensors** (fallback): the receiver counts as working when
    at least one `sensor.*_distance_to_<receiver>` entity reports a distance.
    Bermuda keeps the last reading for roughly 30 seconds (its distance timeout)
    before the sensor goes to `unknown`, so a dead proxy — or a live proxy that
    no tracker can currently reach — turns red after about half a minute.
 
-If a receiver shows red even though the device is online, it is on the fallback
-heuristic with no tracker in range: add the `status` binary sensor to its
-ESPHome config (`binary_sensor: - platform: status`), or map any entity of the
-device in `receiver_status`.
+Tiers 2-4 need no configuration. Tier 2 requires a Bermuda version that
+supports service response data; when unavailable the card silently falls
+through. Tiers 2 and 3 match by name: they follow the receiver name you used
+in the BPS panel, which normally equals the proxy's device name in HA. If a
+receiver still shows red while the device is online, map it explicitly in
+`receiver_status`.
 
 The full card guide (all options, per-floor behavior, labels/icons/zones, and troubleshooting) is in the wiki:
 - [Wiki: Lovelace map card](https://github.com/Hogster/BPS/wiki/Lovelace-map-card)

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -21,19 +21,29 @@
  *   show_receiver_labels: false
  *   scale_receiver_icon: 100   (defaults to scale_icon)
  *   scale_receiver_labels: 100 (defaults to scale_labels)
+ *   receiver_timeout: 30       (seconds without adverts before a receiver is offline; min 10)
  *   receiver_status:
  *     nsp_kitchen: binary_sensor.nsp_kitchen_status
  *
  * Receivers placed on this floor in the BPS panel are drawn with the beacon
  * icon: black when the receiver is working, red when it is offline/unavailable.
- * Status is resolved in this order:
+ * Status is resolved per receiver, first match wins:
  *   1. The entity mapped in receiver_status, when given. Mapping a receiver
- *      to false (or "heuristic") skips step 2 and forces the heuristic.
- *   2. binary_sensor.<receiver>_status, when it exists with device_class
- *      connectivity (the conventional ESPHome status sensor) — this knows the
- *      device is online even when no tracker is in range, but it only proves
- *      API connectivity, not that the BLE scanner is actually working.
- *   3. Otherwise a receiver counts as working when at least one Bermuda
+ *      to false (or "heuristic") skips steps 2-4 and forces the heuristic.
+ *   2. Bermuda scanner liveness: the card calls the bermuda.dump_devices
+ *      service and matches scanners by name slug. The receiver is working
+ *      while the scanner heard any BLE advertisement within receiver_timeout
+ *      seconds — the same signal as Bermuda's own scanner-status table, and
+ *      the only tier that catches a proxy whose BLE scanning has wedged.
+ *   3. binary_sensor.<receiver>_status, when it exists with device_class
+ *      connectivity (the conventional ESPHome status sensor). Checked before
+ *      tier 4 because ESPHome keeps this sensor available with state "off"
+ *      when the device disconnects.
+ *   4. Device availability: the HA device whose name slugifies to the
+ *      receiver id (hass.devices) is online while any of its entities is not
+ *      unavailable — works with any entity, e.g. an uptime sensor. A
+ *      connectivity-class entity of the device is authoritative instead.
+ *   5. Otherwise a receiver counts as working when at least one Bermuda
  *      sensor.*_distance_to_<receiver> entity reports a distance (Bermuda
  *      holds the last reading for its ~30 s distance timeout before the
  *      sensor goes to unknown, so a dead proxy turns red after about half a
@@ -79,6 +89,14 @@ class BpsMapCard extends HTMLElement {
     this._tintedIconCache = new Map();
     this._receivers = [];
     this._receiverStatuses = new Map();
+    this._bermudaScanners = null;
+    this._bermudaDumpAt = 0;
+    this._nextBermudaDumpAt = 0;
+    this._bermudaNewest = 0;
+    this._devicesRef = null;
+    this._deviceSlugMap = new Map();
+    this._entitiesRef = null;
+    this._deviceEntitiesMap = new Map();
 
     this._pollTimer = null;
 
@@ -110,6 +128,8 @@ class BpsMapCard extends HTMLElement {
       show_receiver_labels: Boolean(config.show_receiver_labels),
       scale_receiver_icon: BpsMapCard.inheritPercent(config.scale_receiver_icon, config.scale_icon),
       scale_receiver_labels: BpsMapCard.inheritPercent(config.scale_receiver_labels, config.scale_labels),
+      receiver_timeout:
+        Number(config.receiver_timeout) > 0 ? Math.max(10, Number(config.receiver_timeout)) : 30,
       receiver_status:
         config.receiver_status && typeof config.receiver_status === "object"
           ? config.receiver_status
@@ -125,6 +145,9 @@ class BpsMapCard extends HTMLElement {
     this._positions.clear();
     this._receivers = [];
     this._receiverStatuses = new Map();
+    // A reconfigure gets an immediate dump attempt; the previous scanner map
+    // is kept to bridge the gap until it lands.
+    this._nextBermudaDumpAt = 0;
     this._lastZoneLabelSignature = "";
     this._lastFloorPresenceSignature = "";
     this._baseImage = null;
@@ -286,6 +309,133 @@ class BpsMapCard extends HTMLElement {
     this._setStatus(`Floor: ${this._config.floor} · ${n}/${tot} tracker(s) on this floor.`);
   }
 
+  // Close JS approximation of homeassistant.util.slugify (python-slugify with
+  // separator "_"): the same transform HA used to build the entity-id slugs
+  // the receiver ids come from. Exact for Latin names; exotic unicode may
+  // differ and simply falls through to the next status tier.
+  static haSlugify(text) {
+    if (!text) return "";
+    let s = String(text).replace(/'+/g, "-");
+    s = s.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+    return s
+      .toLowerCase()
+      .replace(/'+/g, "")
+      .replace(/(\d),(?=\d)/g, "$1")
+      .replace(/[^-a-z0-9]+/g, "-")
+      .replace(/-{2,}/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .replace(/-/g, "_");
+  }
+
+  async _refreshBermudaScanners() {
+    const hass = this._hass;
+    if (!hass?.callWS || !this._config?.show_receivers) return;
+    const now = Date.now();
+    if (now < this._nextBermudaDumpAt) return;
+    // Keep the refresh shorter than the offline threshold: between dumps a
+    // scanner's age grows by the elapsed wall time, so a healthy scanner must
+    // be re-anchored before it can cross receiver_timeout.
+    this._nextBermudaDumpAt = now + Math.min(15, Math.max(5, this._config.receiver_timeout / 2)) * 1000;
+    try {
+      const resp = await hass.callWS({
+        type: "call_service",
+        domain: "bermuda",
+        service: "dump_devices",
+        service_data: { configured_devices: true },
+        return_response: true,
+      });
+      const devices = resp?.response;
+      if (!devices || typeof devices !== "object") return;
+      // last_seen stamps are monotonic (seconds since HA host boot), not
+      // epoch. The freshest stamp in the payload serves as "now" on that
+      // clock — but only while adverts keep arriving.
+      let newest = 0;
+      for (const dev of Object.values(devices)) {
+        const ls = dev?.last_seen;
+        if (typeof ls === "number" && ls > newest) newest = ls;
+      }
+      // Re-anchor only when the payload aged forward. If no stamp advanced —
+      // every scanner stopped hearing adverts, e.g. the only proxy wedged or
+      // a fleet-wide outage — keep the previous map and anchor so ages keep
+      // growing with wall time and cross receiver_timeout. A large backward
+      // jump means the monotonic clock reset (HA reboot): accept it.
+      if (this._bermudaScanners && newest <= this._bermudaNewest && newest > this._bermudaNewest - 60) {
+        return;
+      }
+      this._bermudaNewest = newest;
+      const bySlug = new Map();
+      for (const dev of Object.values(devices)) {
+        if (!dev || (dev._is_scanner !== true && dev.is_scanner !== true)) continue;
+        const slug = BpsMapCard.haSlugify(dev.name);
+        if (!slug) continue;
+        const age = typeof dev.last_seen === "number" ? newest - dev.last_seen : Infinity;
+        bySlug.set(slug, age);
+      }
+      this._bermudaScanners = bySlug;
+      this._bermudaDumpAt = now;
+    } catch (e) {
+      // Bermuda missing, too old for service response data, or a transient
+      // websocket error. Keep any previously working map — wall-clock aging
+      // degrades it gracefully toward offline — and back off harder only
+      // when the tier never worked.
+      this._nextBermudaDumpAt = now + (this._bermudaScanners ? 60000 : 300000);
+    }
+  }
+
+  // Availability of the HA device whose name slug matches the receiver id:
+  // true/false when the device was found and has states, null to fall through.
+  _deviceOnlineBySlug(receiverId) {
+    const devices = this._hass?.devices;
+    const entities = this._hass?.entities;
+    const states = this._hass?.states;
+    if (!devices || !entities || !states) return null;
+    if (this._devicesRef !== devices) {
+      this._devicesRef = devices;
+      this._deviceSlugMap = new Map();
+      const ambiguous = new Set();
+      for (const dev of Object.values(devices)) {
+        const slug = BpsMapCard.haSlugify(dev?.name_by_user || dev?.name);
+        if (!slug) continue;
+        if (this._deviceSlugMap.has(slug)) ambiguous.add(slug);
+        else this._deviceSlugMap.set(slug, dev.id);
+      }
+      // Two devices with the same name slug: picking one would be a guess.
+      for (const slug of ambiguous) this._deviceSlugMap.delete(slug);
+    }
+    if (this._entitiesRef !== entities) {
+      this._entitiesRef = entities;
+      this._deviceEntitiesMap = new Map();
+      for (const [entityId, ent] of Object.entries(entities)) {
+        if (!ent?.device_id) continue;
+        let list = this._deviceEntitiesMap.get(ent.device_id);
+        if (!list) this._deviceEntitiesMap.set(ent.device_id, (list = []));
+        list.push(entityId);
+      }
+    }
+    const deviceId = this._deviceSlugMap.get(receiverId);
+    if (!deviceId) return null;
+    const entityIds = this._deviceEntitiesMap.get(deviceId);
+    if (!entityIds || entityIds.length === 0) return null;
+    // A connectivity sensor is authoritative: ESPHome's status sensor stays
+    // available with state "off" when the device dies, so its state — not its
+    // mere availability — decides, and it must be checked before any other
+    // entity can count as proof of life.
+    for (const entityId of entityIds) {
+      const stateObj = states[entityId];
+      if (stateObj?.state != null && stateObj.attributes?.device_class === "connectivity") {
+        return BpsMapCard.stateLooksOnline(stateObj.state);
+      }
+    }
+    let sawState = false;
+    for (const entityId of entityIds) {
+      const st = states[entityId]?.state;
+      if (st == null) continue;
+      sawState = true;
+      if (st !== "unavailable") return true;
+    }
+    return sawState ? false : null;
+  }
+
   static stateLooksOnline(state) {
     if (state == null) return false;
     const s = String(state).trim().toLowerCase();
@@ -314,13 +464,33 @@ class BpsMapCard extends HTMLElement {
         statuses.set(id, BpsMapCard.stateLooksOnline(states[statusEntity]?.state));
         continue;
       }
-      // The conventional ESPHome status sensor knows the device is online
-      // even when no tracker is currently within range of it. Require the
+      // Bermuda's own scanner liveness: last advertisement heard within
+      // receiver_timeout seconds. Ages were anchored when the dump was
+      // fetched, so add the wall time elapsed since.
+      if (this._bermudaScanners) {
+        const ageAtDump = this._bermudaScanners.get(id);
+        if (ageAtDump != null) {
+          const age = ageAtDump + (Date.now() - this._bermudaDumpAt) / 1000;
+          statuses.set(id, age <= this._config.receiver_timeout);
+          continue;
+        }
+      }
+      // The conventional ESPHome status sensor. This must run BEFORE the
+      // generic device-availability tier: ESPHome keeps this sensor available
+      // with state "off" when the device disconnects, so "any entity not
+      // unavailable" would report a dead proxy as online. Require the
       // connectivity device_class so an unrelated entity that merely shares
       // the binary_sensor.<id>_status slug does not hijack the status.
       const autoStatus = states[`binary_sensor.${id}_status`];
       if (autoStatus && autoStatus.attributes?.device_class === "connectivity") {
         statuses.set(id, BpsMapCard.stateLooksOnline(autoStatus.state));
+        continue;
+      }
+      // The receiver's HA device: online while any of its entities has a
+      // state other than unavailable.
+      const deviceOnline = this._deviceOnlineBySlug(id);
+      if (deviceOnline != null) {
+        statuses.set(id, deviceOnline);
         continue;
       }
       statuses.set(id, false);
@@ -443,6 +613,7 @@ class BpsMapCard extends HTMLElement {
     this._receivers = Array.isArray(floor.receivers)
       ? floor.receivers.filter((r) => r && r.entity_id && r.cords && r.cords.x != null && r.cords.y != null)
       : [];
+    await this._refreshBermudaScanners();
     this._receiverStatuses = this._computeReceiverStatuses();
     if (expectedGen !== this._runGeneration) {
       return;
@@ -656,6 +827,7 @@ class BpsMapCard extends HTMLElement {
         }
       }
       if (this._config.show_receivers) {
+        await this._refreshBermudaScanners();
         this._receiverStatuses = this._computeReceiverStatuses();
       }
       this._redraw();
@@ -711,9 +883,11 @@ class BpsMapCardEditor extends HTMLElement {
       inp.value = this._config[key] != null ? this._config[key] : "";
       inp.addEventListener("change", () => {
         if (type === "number") {
-          // A cleared field means "unset" (inherit/default), not 0.
-          if (inp.value.trim() === "") delete this._config[key];
-          else this._config[key] = Number(inp.value);
+          // A cleared or non-positive field means "unset" (inherit/default),
+          // not 0 — every number option coerces to a default at setConfig.
+          const n = Number(inp.value);
+          if (inp.value.trim() === "" || !Number.isFinite(n) || n <= 0) delete this._config[key];
+          else this._config[key] = n;
         } else if (type === "checkbox") this._config[key] = inp.checked;
         else this._config[key] = inp.value;
         this._fire();
@@ -754,6 +928,7 @@ class BpsMapCardEditor extends HTMLElement {
     mk("Icon scale (percent, e.g. 100 or 200)", "scale_icon", "number", "100");
     mk("Receiver icon scale (percent, empty = icon scale)", "scale_receiver_icon", "number", "");
     mk("Receiver label scale (percent, empty = label scale)", "scale_receiver_labels", "number", "");
+    mk("Receiver timeout (seconds without adverts, min 10, default 30)", "receiver_timeout", "number", "30");
 
     const labelsRow = document.createElement("div");
     labelsRow.style.marginBottom = "8px";

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -19,16 +19,25 @@
  *   map_file: livingroom.jpg
  *   show_receivers: true
  *   show_receiver_labels: false
+ *   scale_receiver_icon: 100   (defaults to scale_icon)
+ *   scale_receiver_labels: 100 (defaults to scale_labels)
  *   receiver_status:
  *     nsp_kitchen: binary_sensor.nsp_kitchen_status
  *
  * Receivers placed on this floor in the BPS panel are drawn with the beacon
  * icon: black when the receiver is working, red when it is offline/unavailable.
- * Status comes from the entity mapped in receiver_status when given, otherwise
- * a receiver counts as working when at least one Bermuda
- * sensor.*_distance_to_<receiver> entity reports a distance (Bermuda holds the
- * last reading for its ~30 s distance timeout before the sensor goes to
- * unknown, so a dead proxy turns red after about half a minute).
+ * Status is resolved in this order:
+ *   1. The entity mapped in receiver_status, when given. Mapping a receiver
+ *      to false (or "heuristic") skips step 2 and forces the heuristic.
+ *   2. binary_sensor.<receiver>_status, when it exists with device_class
+ *      connectivity (the conventional ESPHome status sensor) — this knows the
+ *      device is online even when no tracker is in range, but it only proves
+ *      API connectivity, not that the BLE scanner is actually working.
+ *   3. Otherwise a receiver counts as working when at least one Bermuda
+ *      sensor.*_distance_to_<receiver> entity reports a distance (Bermuda
+ *      holds the last reading for its ~30 s distance timeout before the
+ *      sensor goes to unknown, so a dead proxy turns red after about half a
+ *      minute — and a live proxy with no tracker in range shows red).
  */
 class BpsMapCard extends HTMLElement {
   constructor() {
@@ -99,6 +108,8 @@ class BpsMapCard extends HTMLElement {
       map_file: config.map_file || "",
       show_receivers: Boolean(config.show_receivers),
       show_receiver_labels: Boolean(config.show_receiver_labels),
+      scale_receiver_icon: BpsMapCard.inheritPercent(config.scale_receiver_icon, config.scale_icon),
+      scale_receiver_labels: BpsMapCard.inheritPercent(config.scale_receiver_labels, config.scale_labels),
       receiver_status:
         config.receiver_status && typeof config.receiver_status === "object"
           ? config.receiver_status
@@ -211,8 +222,12 @@ class BpsMapCard extends HTMLElement {
     return this._hass.states[ent].attributes?.friendly_name || ent;
   }
 
-  static normalizePercent(value) {
-    if (value == null || value === "") return 100;
+  static inheritPercent(value, fallback) {
+    return BpsMapCard.normalizePercent(value, BpsMapCard.normalizePercent(fallback));
+  }
+
+  static normalizePercent(value, fallback = 100) {
+    if (value == null || value === "") return fallback;
     if (typeof value === "number" && Number.isFinite(value) && value > 0) {
       return value;
     }
@@ -220,9 +235,9 @@ class BpsMapCard extends HTMLElement {
     const m = s.match(/^(\d+(?:\.\d+)?)\s*%?\s*$/);
     if (m) {
       const n = Number(m[1]);
-      return Number.isFinite(n) && n > 0 ? n : 100;
+      return Number.isFinite(n) && n > 0 ? n : fallback;
     }
-    return 100;
+    return fallback;
   }
 
   _zoneLabelSignature() {
@@ -287,12 +302,29 @@ class BpsMapCard extends HTMLElement {
     for (const rec of this._receivers) {
       const id = rec.entity_id;
       const statusEntity = this._config.receiver_status[id];
-      if (statusEntity) {
-        statuses.set(id, BpsMapCard.stateLooksOnline(states[statusEntity]?.state));
-      } else {
+      if (statusEntity === false || statusEntity === "heuristic") {
+        // Explicit opt-out from the status sensor: the ESPHome status
+        // platform only reports API connectivity, so a proxy whose BLE stack
+        // has wedged still reads "on"; this forces the distance heuristic.
         statuses.set(id, false);
         heuristic.push({ id, suffix: `_distance_to_${id}` });
+        continue;
       }
+      if (statusEntity) {
+        statuses.set(id, BpsMapCard.stateLooksOnline(states[statusEntity]?.state));
+        continue;
+      }
+      // The conventional ESPHome status sensor knows the device is online
+      // even when no tracker is currently within range of it. Require the
+      // connectivity device_class so an unrelated entity that merely shares
+      // the binary_sensor.<id>_status slug does not hijack the status.
+      const autoStatus = states[`binary_sensor.${id}_status`];
+      if (autoStatus && autoStatus.attributes?.device_class === "connectivity") {
+        statuses.set(id, BpsMapCard.stateLooksOnline(autoStatus.state));
+        continue;
+      }
+      statuses.set(id, false);
+      heuristic.push({ id, suffix: `_distance_to_${id}` });
     }
     if (heuristic.length > 0) {
       // A receiver is working when at least one tracker got a distance
@@ -547,7 +579,7 @@ class BpsMapCard extends HTMLElement {
     const ctx = this._canvas.getContext("2d");
     const minSide = Math.min(this._canvas.width, this._canvas.height);
     const baseIconSize = Math.max(12, minSide * 0.04);
-    const iconSize = baseIconSize * (this._config.scale_icon / 100);
+    const iconSize = baseIconSize * (this._config.scale_receiver_icon / 100);
     const ONLINE_COLOR = "#000000";
     const OFFLINE_COLOR = "#d32f2f";
     ctx.save();
@@ -567,7 +599,7 @@ class BpsMapCard extends HTMLElement {
         ctx.fill();
       }
       if (this._config.show_receiver_labels) {
-        const scale = this._config.scale_labels / 100;
+        const scale = this._config.scale_receiver_labels / 100;
         const fontPx = Math.max(11, iconSize * 0.35) * scale;
         ctx.font = `bold ${fontPx}px sans-serif`;
         ctx.fillStyle = color;
@@ -678,8 +710,11 @@ class BpsMapCardEditor extends HTMLElement {
       inp.style.width = "100%";
       inp.value = this._config[key] != null ? this._config[key] : "";
       inp.addEventListener("change", () => {
-        if (type === "number") this._config[key] = Number(inp.value);
-        else if (type === "checkbox") this._config[key] = inp.checked;
+        if (type === "number") {
+          // A cleared field means "unset" (inherit/default), not 0.
+          if (inp.value.trim() === "") delete this._config[key];
+          else this._config[key] = Number(inp.value);
+        } else if (type === "checkbox") this._config[key] = inp.checked;
         else this._config[key] = inp.value;
         this._fire();
       });
@@ -717,6 +752,8 @@ class BpsMapCardEditor extends HTMLElement {
     mk("Poll interval (seconds)", "poll_interval", "number", "3");
     mk("Label scale (percent, e.g. 100 or 200)", "scale_labels", "number", "100");
     mk("Icon scale (percent, e.g. 100 or 200)", "scale_icon", "number", "100");
+    mk("Receiver icon scale (percent, empty = icon scale)", "scale_receiver_icon", "number", "");
+    mk("Receiver label scale (percent, empty = label scale)", "scale_receiver_labels", "number", "");
 
     const labelsRow = document.createElement("div");
     labelsRow.style.marginBottom = "8px";


### PR DESCRIPTION
Follow-up to #1, addressing two issues found in real use:

**Receivers showing red while the proxy is online.** The distance heuristic can only see trackers, so a live proxy with no tracker in range showed red. Status now resolves in three tiers:
1. explicit `receiver_status` entity (mapping a receiver to `false`/`heuristic` forces tier 3),
2. auto-detected `binary_sensor.<receiver>_status` when it has the `connectivity` device class (conventional ESPHome status sensor),
3. the Bermuda distance heuristic.

**Beacon icon/label sizing.** New `scale_receiver_icon` / `scale_receiver_labels` options, defaulting to `scale_icon` / `scale_labels`. The editor now unsets a cleared number field instead of storing `0`, and malformed scale values fall back to the inherited scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)