### PR TITLE
Add a bps_nearest_zone sensor per tracked device

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,17 @@ After installing, the integration should be visible in Settings, Devices & Servi
 ![The integration, in Settings, Devices & Services](img/screenshots/integration1.png)
 ![The integration, in Settings, Devices & Services](img/screenshots/integration2.png)
 
-The integration has now, if you are tracking devices, created 2 sensors for each device you are tracking. One for tracking device floor and another for tracking device zone
+The integration has now, if you are tracking devices, created 3 sensors for each device you are tracking:
+
+- `sensor.<device>_bps_floor` — the floor the device is on.
+- `sensor.<device>_bps_zone` — the zone the device is in; `unknown` when the
+  position falls outside every zone (trilateration jitter can land a fix
+  between two zones or off the map).
+- `sensor.<device>_bps_nearest_zone` — always the *closest* zone on that
+  floor, even when the fix is between zones or outside the map; inside a zone
+  it matches `_bps_zone`. It reports `unknown` only when the device is out of
+  range (no receiver currently measures a distance to it), so it is the
+  sensor to automate on when `_bps_zone` is too strict.
 ![Created entities](img/screenshots/entities.png)
 
 You will now also have a new panel in the side panel named "BPS"

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -194,6 +194,13 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     lowest_floor_name, filtered_cords = extract_floor_and_receivers(new_global_data, entity)
     # filtered_cords: list of (x, y, r)
 
+    if lowest_floor_name is None:
+        # No receiver reports any distance for this device: it is out of
+        # range. The zone/floor sensors keep their last value (historical
+        # behavior), but nearest-zone explicitly reports unknown.
+        update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", "unknown")
+        return
+
     if not hasattr(update_trilateration_and_zone, "last_floor"):
         update_trilateration_and_zone.last_floor = {}
     if update_trilateration_and_zone.last_floor.get(entity) != lowest_floor_name:
@@ -237,9 +244,11 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
 
         test_point = Point(float(avg_x), float(avg_y))
         zone = find_zone_for_point(new_global_data, entity, lowest_floor_name, test_point)
+        nearest_zone = find_nearest_zone(new_global_data, entity, lowest_floor_name, test_point)
         apitricords = update_or_add_entry(apitricords, {"ent": entity, "cords": [avg_x, avg_y], "zone": zone})
         await update_apitricords(hass, apitricords)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)
+        update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", nearest_zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_floor", lowest_floor_name)
 
 def update_or_add_entry(data, new_entry):
@@ -313,10 +322,9 @@ def extract_floor_and_receivers(new_global_data, tmpentity):
     ]
     return lowest_floor["name"], filtered_cords
 
-def find_zone_for_point(data, entity, floor_name, point):
-    """Find zone for point, prioritize correct polygon, select nearest buffer if no correct zone matches."""
+def _floor_zone_polygons(data, entity, floor_name):
+    """Yield (zone entity_id, polygon, buffer_size) for the entity's floor."""
     buffer_percent = 0.05  # set to 5%
-    buffer_candidates = []
 
     def order_zone_points(coords):
         """Order polygon points clockwise around centroid to avoid self-intersections.
@@ -368,19 +376,42 @@ def find_zone_for_point(data, entity, floor_name, point):
                         width = max(xs) - min(xs)
                         height = max(ys) - min(ys)
                         buffer_size = ((width + height) / 2) * buffer_percent
-                        # covers() also matches points on the polygon boundary.
-                        if polygon.covers(point):
-                            return zone["entity_id"]  # Prioritize correct polygon
-                        elif polygon.buffer(buffer_size).contains(point):
-                            # Save candidate: (distance to edge, entity_id)
-                            # boundary works for Polygon and MultiPolygon alike.
-                            distance_to_edge = polygon.boundary.distance(point)
-                            buffer_candidates.append((distance_to_edge, zone["entity_id"]))
+                        yield zone["entity_id"], polygon, buffer_size
+
+
+def find_zone_for_point(data, entity, floor_name, point):
+    """Find zone for point, prioritize correct polygon, select nearest buffer if no correct zone matches."""
+    buffer_candidates = []
+    for zone_id, polygon, buffer_size in _floor_zone_polygons(data, entity, floor_name):
+        # covers() also matches points on the polygon boundary.
+        if polygon.covers(point):
+            return zone_id  # Prioritize correct polygon
+        if polygon.buffer(buffer_size).contains(point):
+            # Save candidate: (distance to edge, entity_id)
+            # boundary works for Polygon and MultiPolygon alike.
+            buffer_candidates.append((polygon.boundary.distance(point), zone_id))
     if buffer_candidates:
         # Select zone whose edge is closest to the point
         buffer_candidates.sort()
         return buffer_candidates[0][1]
     return "unknown"
+
+
+def find_nearest_zone(data, entity, floor_name, point):
+    """The zone closest to the point, no matter how far away.
+
+    Trilateration jitter can land a fix between two zones or outside the map
+    entirely; this always names the closest zone on the elected floor (a point
+    inside a zone has distance 0, so it matches find_zone_for_point there).
+    Returns "unknown" only when the floor has no usable zones.
+    """
+    nearest_id = "unknown"
+    nearest_distance = None
+    for zone_id, polygon, _buffer_size in _floor_zone_polygons(data, entity, floor_name):
+        distance = polygon.distance(point)
+        if nearest_distance is None or distance < nearest_distance:
+            nearest_id, nearest_distance = zone_id, distance
+    return nearest_id
 
 async def async_setup(hass, config):
     """Set up the BPS integration."""
@@ -566,7 +597,8 @@ async def async_unload_entry(hass: HomeAssistant, entry):
     bps_state_ids = [
         state.entity_id
         for state in hass.states.async_all()
-        if state.entity_id.startswith("sensor.") and state.entity_id.endswith(("_bps_zone", "_bps_floor"))
+        if state.entity_id.startswith("sensor.")
+        and state.entity_id.endswith(("_bps_zone", "_bps_floor", "_bps_nearest_zone"))
     ]
     for entity_id in bps_state_ids:
         hass.states.async_remove(entity_id)

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -7,6 +7,27 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bps_sensors"
 
+# (entity_id suffix / unique_id prefix, display label) per tracked device.
+SENSOR_KINDS = [
+    ("bps_zone", "BPS Zone"),
+    ("bps_floor", "BPS Floor"),
+    ("bps_nearest_zone", "BPS Nearest Zone"),
+]
+
+
+def ensure_sensors_for_entity(entity, sensors_cache, existing_sensors, new_sensors):
+    """Create any missing BPS sensors for a tracked device."""
+    for suffix, label in SENSOR_KINDS:
+        entity_id = f"sensor.{entity}_{suffix}"
+        exists = (
+            any(s.startswith(entity_id) for s in existing_sensors)
+            or entity_id in sensors_cache
+        )
+        if not exists:
+            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id)
+            sensors_cache[entity_id] = sensor
+            new_sensors.append(sensor)
+
 
 def is_legacy_bps_entity_id(entity_id):
     """Detect old duplicated-name entity IDs like sensor.name_name_bps_floor."""
@@ -92,8 +113,8 @@ def normalize_bps_registry_entity_ids(hass, entities):
     entity_registry = er.async_get(hass)
     expected_by_uid = {}
     for entity in entities:
-        expected_by_uid[f"bps_zone_{entity}"] = f"sensor.{entity}_bps_zone"
-        expected_by_uid[f"bps_floor_{entity}"] = f"sensor.{entity}_bps_floor"
+        for suffix, _label in SENSOR_KINDS:
+            expected_by_uid[f"{suffix}_{entity}"] = f"sensor.{entity}_{suffix}"
 
     for entry in list(entity_registry.entities.values()):
         expected_entity_id = expected_by_uid.get(entry.unique_id)
@@ -162,8 +183,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     expected_entity_ids = set()
     for entity in entities:
-        expected_entity_ids.add(f"sensor.{entity}_bps_zone")
-        expected_entity_ids.add(f"sensor.{entity}_bps_floor")
+        for suffix, _label in SENSOR_KINDS:
+            expected_entity_ids.add(f"sensor.{entity}_{suffix}")
 
     # Remove stale BPS registry entries that are no longer expected.
     entity_registry = er.async_get(hass)
@@ -185,28 +206,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     new_sensors = []
     for entity in entities:
-        unique_zone_id = f"sensor.{entity}_bps_zone"
-        unique_zone_uid = f"bps_zone_{entity}"
-        unique_floor_id = f"sensor.{entity}_bps_floor"
-        unique_floor_uid = f"bps_floor_{entity}"
-
-        zone_exists = (
-            any(s.startswith(unique_zone_id) for s in existing_sensors)
-            or unique_zone_id in hass.data["bps_sensors"]
-        )
-        if not zone_exists:
-            sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid, unique_zone_id)
-            hass.data["bps_sensors"][unique_zone_id] = sensor
-            new_sensors.append(sensor)
-
-        floor_exists = (
-            any(s.startswith(unique_floor_id) for s in existing_sensors)
-            or unique_floor_id in hass.data["bps_sensors"]
-        )
-        if not floor_exists:
-            sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid, unique_floor_id)
-            hass.data["bps_sensors"][unique_floor_id] = sensor
-            new_sensors.append(sensor)
+        ensure_sensors_for_entity(entity, hass.data["bps_sensors"], existing_sensors, new_sensors)
 
     if new_sensors:
         async_add_entities(new_sensors, update_before_add=True)
@@ -231,28 +231,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         }
 
         for entity in new_entities:
-            unique_zone_id = f"sensor.{entity}_bps_zone"
-            unique_zone_uid = f"bps_zone_{entity}"
-            unique_floor_id = f"sensor.{entity}_bps_floor"
-            unique_floor_uid = f"bps_floor_{entity}"
-
-            zone_exists = (
-                any(s.startswith(unique_zone_id) for s in existing_sensors)
-                or unique_zone_id in sensors_cache
-            )
-            if not zone_exists:
-                sensor = CustomDistanceSensor(f"{entity} BPS Zone", unique_zone_uid, unique_zone_id)
-                sensors_cache[unique_zone_id] = sensor
-                new_sensors.append(sensor)
-
-            floor_exists = (
-                any(s.startswith(unique_floor_id) for s in existing_sensors)
-                or unique_floor_id in sensors_cache
-            )
-            if not floor_exists:
-                sensor = CustomDistanceSensor(f"{entity} BPS Floor", unique_floor_uid, unique_floor_id)
-                sensors_cache[unique_floor_id] = sensor
-                new_sensors.append(sensor)
+            ensure_sensors_for_entity(entity, sensors_cache, existing_sensors, new_sensors)
 
         if new_sensors:
             async_add_entities(new_sensors, update_before_add=True)


### PR DESCRIPTION
Trilateration jitter sometimes places a fix in the gap between two zones or outside the map, leaving `_bps_zone` at `unknown`. Each tracked device now gets a third sensor:

**`sensor.<device>_bps_nearest_zone`** — the closest zone on the elected floor, no matter how far the fix drifted. Inside a zone it matches `_bps_zone` (the containing polygon has distance 0). It reports `unknown` only when the device is **out of range** — no receiver currently measures any distance to it — which makes it the sensor to automate on when `_bps_zone` is too strict. The zone and floor sensors keep their existing behavior untouched.

Implementation notes:
- The zone polygon construction (legacy scan-order rectangles, `make_valid` repair from #7) is factored into one shared helper used by both the in-zone and nearest-zone lookups.
- Sensor creation in `sensor.py` is now driven by a single kind list, so registry normalization and the stale-entity purge automatically cover the new sensor — without that, the purge would have deleted it on every restart.
- Verified with shapely tests: agreement inside a zone, correct nearest pick on both sides of a gap, off-map points, midpoint ties, and no-zones floors.

Needs an HA restart after updating (backend + sensor platform changed). The new sensors appear automatically for every tracked device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)