### PR TITLE
Recreate sensors on boot even when their registry entries survived

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -526,7 +526,16 @@ async def async_setup(hass, config):
             old_task.cancel()
         hass.data["bps_update_task"] = hass.async_create_task(update_tracked_entities(hass, jinja_code))
 
-        hass.bus.async_listen_once("homeassistant_stop", lambda event: observer.stop())
+        async def handle_homeassistant_stop(event):
+            """Stop background work promptly so shutdown cannot drag or leave
+            the unload half-done (which strands stale registry entries)."""
+            observer.stop()
+            update_task = hass.data.pop("bps_update_task", None)
+            if update_task:
+                update_task.cancel()
+            await async_shutdown_calibration(hass)
+
+        hass.bus.async_listen_once("homeassistant_stop", handle_homeassistant_stop)
 
         await async_start_auto_if_enabled(hass)
 

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -15,15 +15,19 @@ SENSOR_KINDS = [
 ]
 
 
-def ensure_sensors_for_entity(entity, sensors_cache, existing_sensors, new_sensors):
-    """Create any missing BPS sensors for a tracked device."""
+def ensure_sensors_for_entity(entity, sensors_cache, new_sensors):
+    """Create any missing BPS sensors for a tracked device.
+
+    Only the in-memory cache decides whether a sensor exists. A registry
+    entry without a live entity object is exactly the situation to recover
+    from: it survives a reboot whenever the previous shutdown could not run
+    the unload cleanly, and skipping creation for it would leave the sensor
+    permanently dead (updates are dropped when the cache has no object).
+    async_add_entities re-claims the registry entry via unique_id.
+    """
     for suffix, label in SENSOR_KINDS:
         entity_id = f"sensor.{entity}_{suffix}"
-        exists = (
-            any(s.startswith(entity_id) for s in existing_sensors)
-            or entity_id in sensors_cache
-        )
-        if not exists:
+        if entity_id not in sensors_cache:
             sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id)
             sensors_cache[entity_id] = sensor
             new_sensors.append(sensor)
@@ -198,15 +202,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             _LOGGER.info("Removing stale BPS registry entity: %s", entity_id)
             entity_registry.async_remove(entity_id)
 
-    existing_sensors = {
-        entry.entity_id
-        for entry in entity_registry.entities.values()
-        if entry.platform == "bps"
-    }
-
     new_sensors = []
     for entity in entities:
-        ensure_sensors_for_entity(entity, hass.data["bps_sensors"], existing_sensors, new_sensors)
+        ensure_sensors_for_entity(entity, hass.data["bps_sensors"], new_sensors)
 
     if new_sensors:
         async_add_entities(new_sensors, update_before_add=True)
@@ -223,15 +221,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         new_entities = get_filtered_entities(hass)
         new_sensors = []
 
-        entity_registry = er.async_get(hass)
-        existing_sensors = {
-            entry.entity_id
-            for entry in entity_registry.entities.values()
-            if entry.platform == "bps"
-        }
-
         for entity in new_entities:
-            ensure_sensors_for_entity(entity, sensors_cache, existing_sensors, new_sensors)
+            ensure_sensors_for_entity(entity, sensors_cache, new_sensors)
 
         if new_sensors:
             async_add_entities(new_sensors, update_before_add=True)


### PR DESCRIPTION
Fixes "BPS provides no data after a complete reboot until the integration is reloaded".

**Root cause (diagnosed from the HA logs).** Sensor creation was skipped whenever the entity registry already contained the sensor's id. This worked by accident: `async_unload_entry` deletes every BPS entity from the registry, so a *clean* shutdown left the registry empty and the next boot recreated everything. The log from before the reported reboot shows the shutdown was not clean — BPS's update task and the auto-calibration loop were still running at the final-writes stage — so the registry entries survived the reboot. On the next boot, creation was skipped for all of them, `hass.data["bps_sensors"]` stayed empty, and `update_bps_sensor_state` silently dropped every update. Reloading the integration "fixed" it precisely because unload wipes the registry.

**Fix.**
- Sensor existence is now decided only by the in-memory sensor cache. A registry entry without a live entity object is exactly the state to recover from; `async_add_entities` safely re-claims the entry via `unique_id`, preserving any user customizations.
- The `homeassistant_stop` listener now also cancels the update task and shuts down calibration tasks (it previously only stopped the file watcher), addressing the shutdown warnings seen in the log ("Task … was still running after final writes shutdown stage") and making unclean shutdowns rarer in the first place.

After merging: HACS redownload + HA restart. Reboots should come up with working sensors from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)