### PR TITLE
Report median calibration error and keep auto status visible

### DIFF
--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -313,11 +313,14 @@ def solve(cal: dict, floor_name: str):
         if not (0.5 <= corrections[slug] <= 2.0) or pair_count.get(slug, 0) < 3
     )
 
-    def rms(values):
-        return float(np.sqrt(np.mean(np.square(values)))) if len(values) else 0.0
+    # Median, not RMS: the asymmetric loss deliberately leaves through-wall
+    # pairs unexplained, and their large residuals would dominate an RMS and
+    # can even make "after" read worse than "before" while the fit is fine.
+    def typical(values):
+        return float(np.median(np.abs(values))) if len(values) else 0.0
 
-    before = rms(y)
-    after = rms(y - (rx[rx_idx] + tx[tx_idx]))
+    before = typical(y)
+    after = typical(y - (rx[rx_idx] + tx[tx_idx]))
 
     matrix = [
         {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1777,13 +1777,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const pairs = Object.keys(status.pair_counts || {}).length;
         if (auto) {
+            if (result) renderCalibrationResult(result);
+            else calibResults.innerHTML = '';
+            // Set the status line AFTER rendering the result, which writes its
+            // own summary into it; the auto line carries the result summary too.
             let line = `Auto calibration running · ${pairs} receiver pairs in the window`;
             if (status.error) line += ` · ${status.error}`;
             else if (status.last_solved_at) line += ` · last solve ${status.last_solved_at}`;
             else line += ' · first solve after a few minutes of data';
+            if (result) {
+                line += ` · floor ${result.floor}: ${result.pairs_used} pairs used, `
+                    + `typical error ×${result.error_factor_before} → ×${result.error_factor_after}`;
+            }
             calibStatus.textContent = line;
-            if (result) renderCalibrationResult(result);
-            else calibResults.innerHTML = '';
             return;
         }
         if (manualSampling) {


### PR DESCRIPTION
Two display fixes prompted by a real calibration run:

- **"typical error ×2.008 → ×2.152" could read as the fit making things worse.** The number was an RMS over log residuals, and the solver's asymmetric loss deliberately refuses to explain through-wall pairs — their large residuals dominate an RMS. The reported before/after factors now use the **median absolute residual**, which reflects what the correction does to typical pairs (verified on synthetic data with 35% walls: ×1.61 → ×1.17).
- **Auto mode hid its own status**: the line with the last-solve timestamp and any sampling errors was immediately overwritten by the result summary. The auto status line now carries both.

Also documents the intended behavior that prompted the question: matrix tooltip sample counts are snapshots taken at each 15-minute re-solve; the rolling window keeps accumulating underneath (capped at ~6 h per pair), confirmed against the live `/api/bps/calibration` endpoint.

Panel + backend metric only; HA restart + panel hard-refresh after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)