### PR TITLE
Overhaul the sidebar panel UI

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2461,3 +2461,165 @@ body {
 }
 
 .data-\[selected\=\'true\'\]\:bg-accent[data-selected=true]{background-color:hsl(var(--accent))}.data-\[state\=active\]\:bg-background[data-state=active]{background-color:hsl(var(--background))}.data-\[state\=checked\]\:bg-primary[data-state=checked]{background-color:hsl(var(--primary))}.data-\[state\=on\]\:bg-accent[data-state=on],.data-\[state\=open\]\:bg-accent[data-state=open]{background-color:hsl(var(--accent))}.data-\[state\=open\]\:bg-accent\/50[data-state=open]{background-color:hsl(var(--accent) / .5)}.data-\[state\=open\]\:bg-secondary[data-state=open]{background-color:hsl(var(--secondary))}.data-\[state\=selected\]\:bg-muted[data-state=selected]{background-color:hsl(var(--muted))}.data-\[state\=unchecked\]\:bg-input[data-state=unchecked]{background-color:hsl(var(--input))}.data-\[active\=true\]\:font-medium[data-active=true]{font-weight:500}.data-\[active\=true\]\:text-sidebar-accent-foreground[data-active=true]{color:hsl(var(--sidebar-accent-foreground))}.data-\[selected\=true\]\:text-accent-foreground[data-selected=true]{color:hsl(var(--accent-foreground))}.data-\[state\=active\]\:text-foreground[data-state=active]{color:hsl(var(--foreground))}.data-\[state\=checked\]\:text-primary-foreground[data-state=checked]{color:hsl(var(--primary-foreground))}.data-\[state\=on\]\:text-accent-foreground[data-state=on],.data-\[state\=open\]\:text-accent-foreground[data-state=open]{color:hsl(var(--accent-foreground))}.data-\[state\=open\]\:text-muted-foreground[data-state=open]{color:hsl(var(--muted-foreground))}.data-\[disabled\=true\]\:opacity-50[data-disabled=true],.data-\[disabled\]\:opacity-50[data-disabled]{opacity:.5}.data-\[state\=open\]\:opacity-100[data-state=open]{opacity:1}.data-\[state\=active\]\:shadow-sm[data-state=active]{--tw-shadow: 0 1px 2px 0 rgb(0 0 0 / .05);--tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.data-\[swipe\=move\]\:transition-none[data-swipe=move]{transition-property:none}.data-\[state\=closed\]\:duration-300[data-state=closed]{transition-duration:.3s}.data-\[state\=open\]\:duration-500[data-state=open]{transition-duration:.5s}.data-\[motion\^\=from-\]\:animate-in[data-motion^=from-],.data-\[state\=open\]\:animate-in[data-state=open],.data-\[state\=visible\]\:animate-in[data-state=visible]{animation-name:enter;animation-duration:.15s;--tw-enter-opacity: initial;--tw-enter-scale: initial;--tw-enter-rotate: initial;--tw-enter-translate-x: initial;--tw-enter-translate-y: initial}.data-\[motion\^\=to-\]\:animate-out[data-motion^=to-],.data-\[state\=closed\]\:animate-out[data-state=closed],.data-\[state\=hidden\]\:animate-out[data-state=hidden],.data-\[swipe\=end\]\:animate-out[data-swipe=end]{animation-name:exit;animation-duration:.15s;--tw-exit-opacity: initial;--tw-exit-scale: initial;--tw-exit-rotate: initial;--tw-exit-translate-x: initial;--tw-exit-translate-y: initial}.data-\[motion\^\=from-\]\:fade-in[data-motion^=from-]{--tw-enter-opacity: 0}.data-\[motion\^\=to-\]\:fade-out[data-motion^=to-],.data-\[state\=closed\]\:fade-out-0[data-state=closed]{--tw-exit-opacity: 0}.data-\[state\=closed\]\:fade-out-80[data-state=closed]{--tw-exit-opacity: .8}.data-\[state\=hidden\]\:fade-out[data-state=hidden]{--tw-exit-opacity: 0}.data-\[state\=open\]\:fade-in-0[data-state=open],.data-\[state\=visible\]\:fade-in[data-state=visible]{--tw-enter-opacity: 0}.data-\[state\=closed\]\:zoom-out-95[data-state=closed]{--tw-exit-scale: .95}.data-\[state\=open\]\:zoom-in-90[data-state=open]{--tw-enter-scale: .9}.data-\[state\=open\]\:zoom-in-95[data-state=open]{--tw-enter-scale: .95}.data-\[motion\=from-end\]\:slide-in-from-right-52[data-motion=from-end]{--tw-enter-translate-x: 13rem}.data-\[motion\=from-start\]\:slide-in-from-left-52[data-motion=from-start]{--tw-enter-translate-x: -13rem}.data-\[motion\=to-end\]\:slide-out-to-right-52[data-motion=to-end]{--tw-exit-translate-x: 13rem}.data-\[motion\=to-start\]\:slide-out-to-left-52[data-motion=to-start]{--tw-exit-translate-x: -13rem}.data-\[side\=bottom\]\:slide-in-from-top-2[data-side=bottom]{--tw-enter-translate-y: -.5rem}.data-\[side\=left\]\:slide-in-from-right-2[data-side=left]{--tw-enter-translate-x: .5rem}.data-\[side\=right\]\:slide-in-from-left-2[data-side=right]{--tw-enter-translate-x: -.5rem}.data-\[side\=top\]\:slide-in-from-bottom-2[data-side=top]{--tw-enter-translate-y: .5rem}.data-\[state\=closed\]\:slide-out-to-bottom[data-state=closed]{--tw-exit-translate-y: 100%}.data-\[state\=closed\]\:slide-out-to-left[data-state=closed]{--tw-exit-translate-x: -100%}.data-\[state\=closed\]\:slide-out-to-left-1\/2[data-state=closed]{--tw-exit-translate-x: -50%}.data-\[state\=closed\]\:slide-out-to-right[data-state=closed],.data-\[state\=closed\]\:slide-out-to-right-full[data-state=closed]{--tw-exit-translate-x: 100%}.data-\[state\=closed\]\:slide-out-to-top[data-state=closed]{--tw-exit-translate-y: -100%}.data-\[state\=closed\]\:slide-out-to-top-\[48\%\][data-state=closed]{--tw-exit-translate-y: -48%}.data-\[state\=open\]\:slide-in-from-bottom[data-state=open]{--tw-enter-translate-y: 100%}.data-\[state\=open\]\:slide-in-from-left[data-state=open]{--tw-enter-translate-x: -100%}.data-\[state\=open\]\:slide-in-from-left-1\/2[data-state=open]{--tw-enter-translate-x: -50%}.data-\[state\=open\]\:slide-in-from-right[data-state=open]{--tw-enter-translate-x: 100%}.data-\[state\=open\]\:slide-in-from-top[data-state=open]{--tw-enter-translate-y: -100%}.data-\[state\=open\]\:slide-in-from-top-\[48\%\][data-state=open]{--tw-enter-translate-y: -48%}.data-\[state\=open\]\:slide-in-from-top-full[data-state=open]{--tw-enter-translate-y: -100%}.data-\[state\=closed\]\:duration-300[data-state=closed]{animation-duration:.3s}.data-\[state\=open\]\:duration-500[data-state=open]{animation-duration:.5s}.data-\[panel-group-direction\=vertical\]\:after\:left-0[data-panel-group-direction=vertical]:after{content:var(--tw-content);left:0}.data-\[panel-group-direction\=vertical\]\:after\:h-1[data-panel-group-direction=vertical]:after{content:var(--tw-content);height:.25rem}.data-\[panel-group-direction\=vertical\]\:after\:w-full[data-panel-group-direction=vertical]:after{content:var(--tw-content);width:100%}.data-\[panel-group-direction\=vertical\]\:after\:-translate-y-1\/2[data-panel-group-direction=vertical]:after{content:var(--tw-content);--tw-translate-y: -50%;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.data-\[panel-group-direction\=vertical\]\:after\:translate-x-0[data-panel-group-direction=vertical]:after{content:var(--tw-content);--tw-translate-x: 0px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.data-\[state\=open\]\:hover\:bg-sidebar-accent:hover[data-state=open]{background-color:hsl(var(--sidebar-accent))}.data-\[state\=open\]\:hover\:text-sidebar-accent-foreground:hover[data-state=open]{color:hsl(var(--sidebar-accent-foreground))}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:left-\[calc\(var\(--sidebar-width\)\*-1\)\]{left:calc(var(--sidebar-width) * -1)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:right-\[calc\(var\(--sidebar-width\)\*-1\)\]{right:calc(var(--sidebar-width) * -1)}.group[data-side=left] .group-data-\[side\=left\]\:-right-4{right:-1rem}.group[data-side=right] .group-data-\[side\=right\]\:left-0{left:0}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:-mt-8{margin-top:-2rem}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:hidden{display:none}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!size-8{width:2rem!important;height:2rem!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[--sidebar-width-icon\]{width:var(--sidebar-width-icon)}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[calc\(var\(--sidebar-width-icon\)_\+_theme\(spacing\.4\)\)\]{width:calc(var(--sidebar-width-icon) + 1rem)}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[calc\(var\(--sidebar-width-icon\)_\+_theme\(spacing\.4\)_\+2px\)\]{width:calc(var(--sidebar-width-icon) + 1rem + 2px)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:w-0{width:0px}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:translate-x-0{--tw-translate-x: 0px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.group[data-side=right] .group-data-\[side\=right\]\:rotate-180,.group[data-state=open] .group-data-\[state\=open\]\:rotate-180{--tw-rotate: 180deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:overflow-hidden{overflow:hidden}.group[data-variant=floating] .group-data-\[variant\=floating\]\:rounded-lg{border-radius:var(--radius)}.group[data-variant=floating] .group-data-\[variant\=floating\]\:border{border-width:1px}.group[data-side=left] .group-data-\[side\=left\]\:border-r{border-right-width:1px}.group[data-side=right] .group-data-\[side\=right\]\:border-l{border-left-width:1px}.group[data-variant=floating] .group-data-\[variant\=floating\]\:border-sidebar-border{border-color:hsl(var(--sidebar-border))}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!p-0{padding:0!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!p-2{padding:.5rem!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:opacity-0{opacity:0}.group[data-variant=floating] .group-data-\[variant\=floating\]\:shadow{--tw-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);--tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:after\:left-full:after{content:var(--tw-content);left:100%}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:hover\:bg-sidebar:hover{background-color:hsl(var(--sidebar-background))}.peer\/menu-button[data-size=default]~.peer-data-\[size\=default\]\/menu-button\:top-1\.5{top:.375rem}.peer\/menu-button[data-size=lg]~.peer-data-\[size\=lg\]\/menu-button\:top-2\.5{top:.625rem}.peer\/menu-button[data-size=sm]~.peer-data-\[size\=sm\]\/menu-button\:top-1{top:.25rem}.peer[data-variant=inset]~.peer-data-\[variant\=inset\]\:min-h-\[calc\(100svh-theme\(spacing\.4\)\)\]{min-height:calc(100svh - 1rem)}.peer\/menu-button[data-active=true]~.peer-data-\[active\=true\]\/menu-button\:text-sidebar-accent-foreground{color:hsl(var(--sidebar-accent-foreground))}.dark\:border-destructive:is(.dark *){border-color:hsl(var(--destructive))}@media (min-width: 640px){.sm\:bottom-0{bottom:0}.sm\:right-0{right:0}.sm\:top-auto{top:auto}.sm\:mt-0{margin-top:0}.sm\:flex{display:flex}.sm\:max-w-sm{max-width:24rem}.sm\:flex-row{flex-direction:row}.sm\:flex-col{flex-direction:column}.sm\:justify-end{justify-content:flex-end}.sm\:gap-2\.5{gap:.625rem}.sm\:space-x-2>:not([hidden])~:not([hidden]){--tw-space-x-reverse: 0;margin-right:calc(.5rem * var(--tw-space-x-reverse));margin-left:calc(.5rem * calc(1 - var(--tw-space-x-reverse)))}.sm\:space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse: 0;margin-right:calc(1rem * var(--tw-space-x-reverse));margin-left:calc(1rem * calc(1 - var(--tw-space-x-reverse)))}.sm\:space-y-0>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(0px * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0px * var(--tw-space-y-reverse))}.sm\:rounded-lg{border-radius:var(--radius)}.sm\:text-left{text-align:left}.data-\[state\=open\]\:sm\:slide-in-from-bottom-full[data-state=open]{--tw-enter-translate-y: 100%}}@media (min-width: 768px){.md\:absolute{position:absolute}.md\:block{display:block}.md\:flex{display:flex}.md\:w-\[var\(--radix-navigation-menu-viewport-width\)\]{width:var(--radix-navigation-menu-viewport-width)}.md\:w-auto{width:auto}.md\:max-w-\[420px\]{max-width:420px}.md\:text-sm{font-size:.875rem;line-height:1.25rem}.md\:opacity-0{opacity:0}.after\:md\:hidden:after{content:var(--tw-content);display:none}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:m-2{margin:.5rem}.peer[data-state=collapsed][data-variant=inset]~.md\:peer-data-\[state\=collapsed\]\:peer-data-\[variant\=inset\]\:ml-2{margin-left:.5rem}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:ml-0{margin-left:0}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:rounded-xl{border-radius:.75rem}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:shadow{--tw-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);--tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}}.\[\&\:has\(\[aria-selected\]\)\]\:bg-accent:has([aria-selected]){background-color:hsl(var(--accent))}.first\:\[\&\:has\(\[aria-selected\]\)\]\:rounded-l-md:has([aria-selected]):first-child{border-top-left-radius:calc(var(--radius) - 2px);border-bottom-left-radius:calc(var(--radius) - 2px)}.last\:\[\&\:has\(\[aria-selected\]\)\]\:rounded-r-md:has([aria-selected]):last-child{border-top-right-radius:calc(var(--radius) - 2px);border-bottom-right-radius:calc(var(--radius) - 2px)}.\[\&\:has\(\[aria-selected\]\.day-outside\)\]\:bg-accent\/50:has([aria-selected].day-outside){background-color:hsl(var(--accent) / .5)}.\[\&\:has\(\[aria-selected\]\.day-range-end\)\]\:rounded-r-md:has([aria-selected].day-range-end){border-top-right-radius:calc(var(--radius) - 2px);border-bottom-right-radius:calc(var(--radius) - 2px)}.\[\&\:has\(\[role\=checkbox\]\)\]\:pr-0:has([role=checkbox]){padding-right:0}.\[\&\>button\]\:hidden>button{display:none}.\[\&\>span\:last-child\]\:truncate>span:last-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.\[\&\>span\]\:line-clamp-1>span{overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1}.\[\&\>svg\+div\]\:translate-y-\[-3px\]>svg+div{--tw-translate-y: -3px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&\>svg\]\:absolute>svg{position:absolute}.\[\&\>svg\]\:left-4>svg{left:1rem}.\[\&\>svg\]\:top-4>svg{top:1rem}.\[\&\>svg\]\:size-3\.5>svg{width:.875rem;height:.875rem}.\[\&\>svg\]\:size-4>svg{width:1rem;height:1rem}.\[\&\>svg\]\:h-2\.5>svg{height:.625rem}.\[\&\>svg\]\:h-3>svg{height:.75rem}.\[\&\>svg\]\:w-2\.5>svg{width:.625rem}.\[\&\>svg\]\:w-3>svg{width:.75rem}.\[\&\>svg\]\:shrink-0>svg{flex-shrink:0}.\[\&\>svg\]\:text-destructive>svg{color:hsl(var(--destructive))}.\[\&\>svg\]\:text-foreground>svg{color:hsl(var(--foreground))}.\[\&\>svg\]\:text-muted-foreground>svg{color:hsl(var(--muted-foreground))}.\[\&\>svg\]\:text-sidebar-accent-foreground>svg{color:hsl(var(--sidebar-accent-foreground))}.\[\&\>svg\~\*\]\:pl-7>svg~*{padding-left:1.75rem}.\[\&\>tr\]\:last\:border-b-0:last-child>tr{border-bottom-width:0px}.\[\&\[data-panel-group-direction\=vertical\]\>div\]\:rotate-90[data-panel-group-direction=vertical]>div{--tw-rotate: 90deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&\[data-state\=open\]\>svg\]\:rotate-180[data-state=open]>svg{--tw-rotate: 180deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&_\.recharts-cartesian-axis-tick_text\]\:fill-muted-foreground .recharts-cartesian-axis-tick text{fill:hsl(var(--muted-foreground))}.\[\&_\.recharts-cartesian-grid_line\[stroke\=\'\#ccc\'\]\]\:stroke-border\/50 .recharts-cartesian-grid line[stroke="#ccc"]{stroke:hsl(var(--border) / .5)}.\[\&_\.recharts-curve\.recharts-tooltip-cursor\]\:stroke-border .recharts-curve.recharts-tooltip-cursor{stroke:hsl(var(--border))}.\[\&_\.recharts-dot\[stroke\=\'\#fff\'\]\]\:stroke-transparent .recharts-dot[stroke="#fff"]{stroke:transparent}.\[\&_\.recharts-layer\]\:outline-none .recharts-layer{outline:2px solid transparent;outline-offset:2px}.\[\&_\.recharts-polar-grid_\[stroke\=\'\#ccc\'\]\]\:stroke-border .recharts-polar-grid [stroke="#ccc"]{stroke:hsl(var(--border))}.\[\&_\.recharts-radial-bar-background-sector\]\:fill-muted .recharts-radial-bar-background-sector,.\[\&_\.recharts-rectangle\.recharts-tooltip-cursor\]\:fill-muted .recharts-rectangle.recharts-tooltip-cursor{fill:hsl(var(--muted))}.\[\&_\.recharts-reference-line_\[stroke\=\'\#ccc\'\]\]\:stroke-border .recharts-reference-line [stroke="#ccc"]{stroke:hsl(var(--border))}.\[\&_\.recharts-sector\[stroke\=\'\#fff\'\]\]\:stroke-transparent .recharts-sector[stroke="#fff"]{stroke:transparent}.\[\&_\.recharts-sector\]\:outline-none .recharts-sector,.\[\&_\.recharts-surface\]\:outline-none .recharts-surface{outline:2px solid transparent;outline-offset:2px}.\[\&_\[cmdk-group-heading\]\]\:px-2 [cmdk-group-heading]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-group-heading\]\]\:py-1\.5 [cmdk-group-heading]{padding-top:.375rem;padding-bottom:.375rem}.\[\&_\[cmdk-group-heading\]\]\:text-xs [cmdk-group-heading]{font-size:.75rem;line-height:1rem}.\[\&_\[cmdk-group-heading\]\]\:font-medium [cmdk-group-heading]{font-weight:500}.\[\&_\[cmdk-group-heading\]\]\:text-muted-foreground [cmdk-group-heading]{color:hsl(var(--muted-foreground))}.\[\&_\[cmdk-group\]\:not\(\[hidden\]\)_\~\[cmdk-group\]\]\:pt-0 [cmdk-group]:not([hidden])~[cmdk-group]{padding-top:0}.\[\&_\[cmdk-group\]\]\:px-2 [cmdk-group]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-input-wrapper\]_svg\]\:h-5 [cmdk-input-wrapper] svg{height:1.25rem}.\[\&_\[cmdk-input-wrapper\]_svg\]\:w-5 [cmdk-input-wrapper] svg{width:1.25rem}.\[\&_\[cmdk-input\]\]\:h-12 [cmdk-input]{height:3rem}.\[\&_\[cmdk-item\]\]\:px-2 [cmdk-item]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-item\]\]\:py-3 [cmdk-item]{padding-top:.75rem;padding-bottom:.75rem}.\[\&_\[cmdk-item\]_svg\]\:h-5 [cmdk-item] svg{height:1.25rem}.\[\&_\[cmdk-item\]_svg\]\:w-5 [cmdk-item] svg{width:1.25rem}.\[\&_p\]\:leading-relaxed p{line-height:1.625}.\[\&_svg\]\:pointer-events-none svg{pointer-events:none}.\[\&_svg\]\:size-4 svg{width:1rem;height:1rem}.\[\&_svg\]\:shrink-0 svg{flex-shrink:0}.\[\&_tr\:last-child\]\:border-0 tr:last-child{border-width:0px}.\[\&_tr\]\:border-b tr{border-bottom-width:1px}[data-side=left][data-collapsible=offcanvas] .\[\[data-side\=left\]\[data-collapsible\=offcanvas\]_\&\]\:-right-2{right:-.5rem}[data-side=left][data-state=collapsed] .\[\[data-side\=left\]\[data-state\=collapsed\]_\&\]\:cursor-e-resize{cursor:e-resize}[data-side=left] .\[\[data-side\=left\]_\&\]\:cursor-w-resize{cursor:w-resize}[data-side=right][data-collapsible=offcanvas] .\[\[data-side\=right\]\[data-collapsible\=offcanvas\]_\&\]\:-left-2{left:-.5rem}[data-side=right][data-state=collapsed] .\[\[data-side\=right\]\[data-state\=collapsed\]_\&\]\:cursor-w-resize{cursor:w-resize}[data-side=right] .\[\[data-side\=right\]_\&\]\:cursor-e-resize{cursor:e-resize}
+/* ==== BPS panel: dark theme + modern layout =============================== */
+html, body {
+    height: 100%;
+}
+body.dark {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    margin: 0;
+}
+.bps-app {
+    padding: 16px 20px 32px;
+}
+.bps-header h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 14px;
+}
+.bps-main {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+}
+.bps-content {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.bps-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    align-items: flex-end;
+    margin-bottom: 6px;
+}
+.bps-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+#mapname {
+    resize: none;
+    height: 40px;
+    min-width: 220px;
+}
+.bps-canvas-wrap {
+    margin-top: 8px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    background: #ffffff;
+}
+.bps-canvas-wrap canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+/* Right sidebar: zones with their receivers */
+.bps-sidebar {
+    flex: 0 0 320px;
+    position: sticky;
+    top: 12px;
+    max-height: calc(100vh - 24px);
+    overflow-y: auto;
+    background: hsl(var(--sidebar-background));
+    color: hsl(var(--sidebar-foreground));
+    border: 1px solid hsl(var(--sidebar-border));
+    border-radius: 12px;
+    padding: 14px;
+}
+.bps-sidebar h3 {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0 0 10px;
+}
+.bps-zone-group {
+    border: 1px solid hsl(var(--sidebar-border));
+    border-radius: 8px;
+    margin-bottom: 8px;
+    overflow: hidden;
+}
+.bps-zone-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: hsl(var(--sidebar-accent));
+    font-size: 13px;
+    font-weight: 600;
+}
+.bps-zone-head .bps-count {
+    color: hsl(var(--muted-foreground));
+    font-weight: 400;
+}
+.bps-zone-group ul {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+}
+.bps-zone-group li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 3px 10px;
+    font-size: 12.5px;
+}
+.bps-zone-group li span,
+.bps-zone-head span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.bps-zone-group li:hover {
+    background: hsl(var(--sidebar-accent));
+}
+.bps-icon-btn {
+    flex: 0 0 auto;
+    display: inline-flex;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+    padding: 2px;
+    border-radius: 6px;
+}
+.bps-icon-btn:hover {
+    color: hsl(0 84% 60%);
+    background: hsl(var(--sidebar-accent));
+}
+.bps-empty, .bps-hint {
+    color: hsl(var(--muted-foreground));
+    font-size: 12.5px;
+}
+.bps-hint {
+    margin-top: 10px;
+}
+.bps-scale-status {
+    margin-top: 8px;
+}
+
+/* Dark remaps for utility classes baked into markup and generated HTML */
+body.dark .text-gray-500 {
+    color: hsl(var(--muted-foreground));
+}
+body.dark .bg-gray-50 {
+    background: transparent;
+}
+body.dark input[type="checkbox"] {
+    accent-color: hsl(var(--sidebar-primary));
+}
+body.dark .tooltip-text {
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+}
+/* The floating pickers sit on the (light) floor plan; keep them readable */
+.rec-input, .zone-input, .scale-input {
+    background-color: #ffffff;
+    color: #111111;
+}

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -1,133 +1,131 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
     <meta charset="UTF-8">
     <title>BPS</title>
     <link rel="stylesheet" href="bpsstyle.css">
 </head>
-<body>
-    <div class="container bg-gray-50">
-        <h1 style="font-size: 24px; font-weight: bold;">BLE Positioning System</h1>
-        <div class="flex gap-4 items-center p-1">
-            <div class="flex-1">
-                <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Name</label>
-                <textarea id="mapname" placeholder="Map name" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs"></textarea>
-            </div>
-                <div class="flex-1">
-                    <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Plan Image</label>
-                    <input type="file" id="upload" accept="image/png, image/jpeg" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                    <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Select existing</label>
-                    <select id="mapSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                        <option value="">--Please choose an option--</option>
-                    </select>
+<body class="dark">
+    <div class="bps-app">
+        <header class="bps-header">
+            <h1>BLE Positioning System</h1>
+        </header>
+
+        <div class="bps-main">
+            <div class="bps-content container">
+                <div class="bps-controls">
+                    <div class="bps-field">
+                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Name</label>
+                        <textarea id="mapname" placeholder="Map name" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs"></textarea>
+                    </div>
+                    <div class="bps-field">
+                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Plan Image</label>
+                        <input type="file" id="upload" accept="image/png, image/jpeg" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                    </div>
+                    <div class="bps-field">
+                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Select existing</label>
+                        <select id="mapSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                            <option value="">--Please choose an option--</option>
+                        </select>
+                    </div>
+                    <div class="bps-field">
+                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Grid</label>
+                        <button type="button" id="gridToggle" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Grid: off</button>
+                    </div>
                 </div>
-            </div>
-        
-        <div class="flex gap-2 items-center p-1">
-            <div class="flex gap-2" id="mapbuttondiv"></div>
-        </div>
-        <div class="flex gap-2 items-center p-1">
-            <div class="flex gap-2" id="savebuttondiv"></div>
-        </div>
-        <div id="trackdiv" style="display: none" class="flex gap-2 items-center p-1">
-            <div class="flex gap-2">
-                <select id="entSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                    <option value="">--Please choose an option--</option>
-                </select>
-                <select id="trackerIconSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                    <option value="/bps/person.svg">Person</option>
-                    <option value="/bps/beacon.svg">Beacon</option>
-                </select>
-                <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                <button type="button" id="uploadTrackerIcon" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
-                    Upload tracker icon
-                </button>
+
                 <div class="flex gap-2 items-center p-1">
-                    <input type="checkbox" id="myCheckbox">
-                    <label style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="myCheckbox">Real time track</label>
-                    <span class="tooltip">❓
-                        <span class="tooltip-text">Real time tracking uses your current Home Assistant session.</span>
-                    </span>
+                    <div class="flex gap-2" id="mapbuttondiv"></div>
                 </div>
-                <button style="display: none" type="button" id="starttrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                    <svg width="24" height="24" viewBox="0 0 1024 1024" class="icon"  version="1.1" xmlns="http://www.w3.org/2000/svg" fill="white" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-save w-4 h-4 mr-2" ><path d="M709.485714 277.942857C709.485714 160.914286 614.4 65.828571 497.371429 65.828571S292.571429 160.914286 292.571429 277.942857c0 73.142857 204.8 358.4 204.8 358.4s212.114286-277.942857 212.114285-358.4z" fill="white" /><path d="M497.371429 709.485714l-21.942858-29.257143c-36.571429-51.2-219.428571-307.2-219.428571-387.657142C256 160.914286 365.714286 51.2 497.371429 51.2s241.371429 109.714286 241.371428 241.371429c0 87.771429-182.857143 336.457143-226.742857 387.657142l-14.628571 29.257143z m0-607.085714C394.971429 102.4 307.2 182.857143 307.2 292.571429c0 43.885714 102.4 204.8 190.171429 321.828571C585.142857 497.371429 687.542857 336.457143 687.542857 292.571429c0-109.714286-87.771429-190.171429-190.171428-190.171429z"/><path d="M928.914286 819.2H102.4C58.514286 819.2 14.628571 782.628571 14.628571 731.428571s36.571429-87.771429 87.771429-87.771428h138.971429c14.628571 0 29.257143 14.628571 29.257142 29.257143s-7.314286 29.257143-21.942857 29.257143h-146.285714c-14.628571 0-29.257143 14.628571-29.257143 29.257142s14.628571 29.257143 29.257143 29.257143h819.2c14.628571 0 29.257143 14.628571 29.257143 29.257143s-7.314286 29.257143-21.942857 29.257143z"/><path d="M928.914286 936.228571H226.742857c-14.628571 0-29.257143-14.628571-29.257143-29.257142s14.628571-29.257143 29.257143-29.257143h694.857143c14.628571 0 29.257143-14.628571 29.257143-29.257143s-14.628571-29.257143-29.257143-29.257143H102.4c-14.628571 0-29.257143-14.628571-29.257143-29.257143s14.628571-29.257143 29.257143-29.257143h819.2c43.885714 0 87.771429 36.571429 87.771429 87.771429s-36.571429 87.771429-80.457143 87.771428z"/><path d="M497.371429 263.314286m-80.457143 0a80.457143 80.457143 0 1 0 160.914285 0 80.457143 80.457143 0 1 0-160.914285 0Z"/><path d="M497.371429 365.714286C438.857143 365.714286 394.971429 321.828571 394.971429 263.314286S438.857143 160.914286 497.371429 160.914286s102.4 43.885714 102.4 102.4S555.885714 365.714286 497.371429 365.714286z m0-153.6c-29.257143 0-51.2 21.942857-51.2 51.2s21.942857 51.2 51.2 51.2 51.2-21.942857 51.2-51.2-21.942857-51.2-51.2-51.2z"/></svg>
-                    Start tracking
-                </button>
-                <button style="display: none" type="button" id="stoptrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye w-4 h-4 mr-2"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"></path><circle cx="12" cy="12" r="3"></circle></svg>
-                    Stop tracking
-                </button>
-            </div>
-        </div>
-        <div style="display: none" id="zonediv" class="flex gap-2 items-center p-1">
-            <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Current zone:</label>
-            <label id="zonevalue" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">xxx</label>
-        </div>
-        <canvas id="canvas"></canvas>
+                <div class="flex gap-2 items-center p-1">
+                    <div class="flex gap-2" id="savebuttondiv"></div>
+                </div>
+                <div id="trackdiv" style="display: none" class="flex gap-2 items-center p-1">
+                    <div class="flex gap-2">
+                        <select id="entSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                            <option value="">--Please choose an option--</option>
+                        </select>
+                        <select id="trackerIconSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                            <option value="/bps/person.svg">Person</option>
+                            <option value="/bps/beacon.svg">Beacon</option>
+                        </select>
+                        <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
+                        <button type="button" id="uploadTrackerIcon" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                            Upload tracker icon
+                        </button>
+                        <div class="flex gap-2 items-center p-1">
+                            <input type="checkbox" id="myCheckbox">
+                            <label style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="myCheckbox">Real time track</label>
+                            <span class="tooltip">❓
+                                <span class="tooltip-text">Real time tracking uses your current Home Assistant session.</span>
+                            </span>
+                        </div>
+                        <button style="display: none" type="button" id="starttrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                            Start tracking
+                        </button>
+                        <button style="display: none" type="button" id="stoptrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                            Stop tracking
+                        </button>
+                    </div>
+                </div>
+                <div style="display: none" id="zonediv" class="flex gap-2 items-center p-1">
+                    <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Current zone:</label>
+                    <label id="zonevalue" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">xxx</label>
+                </div>
 
-        <div id="calibrationdiv" class="p-1" style="margin-top: 12px">
-            <div class="flex items-center gap-2 mb-2">
-                <h3 class="font-semibold">Receiver Calibration</h3>
-                <span class="tooltip">❓
-                    <span class="tooltip-text">Compares the distances receivers measure between each other (each probe advertises an iBeacon) with their placed positions, and fits a per-receiver distance correction. Select the floor first, then sample while the house is quiet.</span>
-                </span>
-            </div>
-            <div class="flex gap-2 items-center p-1">
-                <input type="checkbox" id="calibAuto">
-                <label for="calibAuto" style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Auto calibration</label>
-                <span class="tooltip">❓
-                    <span class="tooltip-text">Continuously samples in the background, re-solves every 15 minutes for every floor, and re-applies corrections whenever they change. Survives Home Assistant restarts.</span>
-                </span>
-            </div>
-            <div class="flex gap-2 items-center p-1" id="calibManualControls">
-                <select id="calibDuration" class="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                    <option value="300">Sample 5 minutes</option>
-                    <option value="600" selected>Sample 10 minutes</option>
-                    <option value="1800">Sample 30 minutes</option>
-                </select>
-                <button type="button" id="calibStart" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Start calibration</button>
-                <button type="button" id="calibCancel" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Cancel</button>
-                <button type="button" id="calibApply" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Apply corrections</button>
-                <button type="button" id="calibReset" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Reset corrections</button>
-            </div>
-            <div id="calibStatus" class="text-sm text-gray-500 p-1"></div>
-            <div id="calibResults" style="overflow-x: auto"></div>
-        </div>
-    </div>
+                <div class="bps-canvas-wrap">
+                    <canvas id="canvas"></canvas>
+                </div>
 
-    <div class="fixed right-4 top-4 w-64 bg-white p-4 rounded-lg shadow-lg max-h-[80vh] overflow-y-auto">
-        <div class="flex items-center gap-2 mb-4" data-type="collapse">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list w-4 h-4" data-component-name="List" data-component-line="27"><path d="M3 12h.01"></path><path d="M3 18h.01"></path><path d="M3 6h.01"></path><path d="M8 12h13"></path><path d="M8 18h13"></path><path d="M8 6h13"></path></svg>
-            <h3 class="font-semibold">Entities List</h3>
-        </div>
-        <div class="space-y-4">
-            <div>
-                <h4 class="font-medium mb-2">Receivers</h4>
-                <div id="divrec">
-                    <p class="text-sm text-gray-500">No receivers placed</p>
+                <div id="calibrationdiv" class="p-1" style="margin-top: 12px">
+                    <div class="flex items-center gap-2 mb-2">
+                        <h3 class="font-semibold">Receiver Calibration</h3>
+                        <span class="tooltip">❓
+                            <span class="tooltip-text">Compares the distances receivers measure between each other (each probe advertises an iBeacon) with their placed positions, and fits a per-receiver distance correction. Select the floor first, then sample while the house is quiet.</span>
+                        </span>
+                    </div>
+                    <div class="flex gap-2 items-center p-1">
+                        <input type="checkbox" id="calibAuto">
+                        <label for="calibAuto" style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Auto calibration</label>
+                        <span class="tooltip">❓
+                            <span class="tooltip-text">Continuously samples in the background, re-solves every 15 minutes for every floor, and re-applies corrections whenever they change. Survives Home Assistant restarts.</span>
+                        </span>
+                    </div>
+                    <div class="flex gap-2 items-center p-1" id="calibManualControls">
+                        <select id="calibDuration" class="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                            <option value="300">Sample 5 minutes</option>
+                            <option value="600" selected>Sample 10 minutes</option>
+                            <option value="1800">Sample 30 minutes</option>
+                        </select>
+                        <button type="button" id="calibStart" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Start calibration</button>
+                        <button type="button" id="calibCancel" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Cancel</button>
+                        <button type="button" id="calibApply" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Apply corrections</button>
+                        <button type="button" id="calibReset" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Reset corrections</button>
+                    </div>
+                    <div id="calibStatus" class="text-sm text-gray-500 p-1"></div>
+                    <div id="calibResults" style="overflow-x: auto"></div>
                 </div>
             </div>
-            <div>
-                <h4 class="font-medium mb-2">Zones</h4>
-                <div id="divzones">
-                    <p class="text-sm text-gray-500">No zones drawn</p>
+
+            <aside class="bps-sidebar">
+                <h3>Zones &amp; Receivers</h3>
+                <div id="entitytree">
+                    <p class="bps-empty">Select a floor to see its zones and receivers.</p>
                 </div>
-            </div>
-            <div>
-                <p id="scaleok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale set
-                    <svg width="24px" height="24px" fill="green" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" xml:space="preserve">
-                        <path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M10.8,16.8l-3.7-3.7l1.4-1.4l2.2,2.2l5.8-6.1L18,9.3L10.8,16.8z"/>
-                </p>
-
-                <p id="scalenok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale not set
-                    <svg fill="red" width="24px" height="24px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13zM21.961 12.209c0.244-0.244 0.244-0.641 0-0.885l-1.328-1.327c-0.244-0.244-0.641-0.244-0.885 0l-3.761 3.761-3.761-3.761c-0.244-0.244-0.641-0.244-0.885 0l-1.328 1.327c-0.244 0.244-0.244 0.641 0 0.885l3.762 3.762-3.762 3.76c-0.244 0.244-0.244 0.641 0 0.885l1.328 1.328c0.244 0.244 0.641 0.244 0.885 0l3.761-3.762 3.761 3.762c0.244 0.244 0.641 0.244 0.885 0l1.328-1.328c0.244-0.244 0.244-0.641 0-0.885l-3.762-3.76 3.762-3.762z"></path>
-                    </svg>
-                </p>
-                
-
-            </div>
-            <div id="message"></div>
+                <p class="bps-hint">Drag a receiver on the map to move it, then Save Floor Plan.</p>
+                <div class="bps-scale-status">
+                    <p id="scaleok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale set
+                        <svg width="24px" height="24px" fill="green" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve">
+                            <path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M10.8,16.8l-3.7-3.7l1.4-1.4l2.2,2.2l5.8-6.1L18,9.3L10.8,16.8z"/></svg>
+                    </p>
+                    <p id="scalenok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale not set
+                        <svg fill="red" width="24px" height="24px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13zM21.961 12.209c0.244-0.244 0.244-0.641 0-0.885l-1.328-1.327c-0.244-0.244-0.641-0.244-0.885 0l-3.761 3.761-3.761-3.761c-0.244-0.244-0.641-0.244-0.885 0l-1.328 1.327c-0.244 0.244-0.244 0.641 0 0.885l3.762 3.762-3.762 3.76c-0.244 0.244-0.244 0.641 0 0.885l1.328 1.328c0.244 0.244 0.641 0.244 0.885 0l3.761-3.762 3.761 3.762c0.244 0.244 0.641 0.244 0.885 0l1.328-1.328c0.244-0.244 0.244-0.641 0-0.885l-3.762-3.76 3.762-3.762z"></path>
+                        </svg>
+                    </p>
+                </div>
+                <div id="message"></div>
+            </aside>
         </div>
     </div>
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -47,6 +47,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // them normalized (the map card does the same).
     const sameFloorName = (a, b) =>
         String(a || "").trim().toLowerCase() === String(b || "").trim().toLowerCase();
+    // Receiver/zone ids can be user-typed (Custom name…); never trust them in HTML.
+    const escHtml = s => String(s).replace(/[&<>"']/g,
+        c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
     const createZoneId = () => `zone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let isDrawing = false;
     let SelMapName = "";
@@ -123,19 +126,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    const newelement = `
-                <ul class="space-y-2" id="idxxx">
-                        <li class="flex items-center justify-between bg-gray-50 p-2 rounded">
-                            <span class="text-sm truncate">typename</span>
-                            <div class="flex gap-2">
-                                <button data-type="removexxx" data-id="idxxx" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground w-10">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trash w-4 h-4"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
-                                </button>
-                            </div>
-                        </li>
-                    </ul>
-                `;
-
     // =================================================================
     // Fetch existing maps
     // =================================================================
@@ -164,7 +154,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await loadTrackerIcons();
         let tmpsaved = await getSavedMaps();
         if (tmpsaved){
-            fetchBPSData();
+            await fetchBPSData();
         }
 
         let socket = null;
@@ -365,13 +355,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         let stoptrackstat = false;
+        let pollTrackActive = false; // interval-based tracking session running
         function startTrackfunc(){
             stoptrackstat = false;
+            pollTrackActive = true;
             starttrackbtn.style.display = "none";
             stoptrackbtn.style.display = "";
             const interval = setInterval(async () => {
                 if (stoptrackstat) {
                     clearInterval(interval);
+                    pollTrackActive = false;
                     stoptrackstat = false;
                     starttrackbtn.style.display = "";
                     stoptrackbtn.style.display = "none";
@@ -672,46 +665,34 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (event.target.closest('[data-type="removerec"]')) {
             const button = event.target.closest('[data-type="removerec"]'); // Get the button that was pressed
             const idToRemove = button.getAttribute('data-id'); // Get the value from data-id
-            const elementToRemove = document.getElementById(idToRemove); // Find the element with the specific ID
-            if (elementToRemove) { // Remove element if it exists
-                console.log(`Receiver with ID "${idToRemove}" was removed.`);
-                elementToRemove.remove();
-            } else {
-                console.log(`Receiver with ID "${idToRemove}" was not found.`);
-                return;
-            }
+            // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
+            if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
             // Loop through each floor and remove receivers where the entity_id matches
             finalcords.floor.forEach(floor => {
                 if (sameFloorName(floor.name, SelMapName)) {
                     floor.receivers = floor.receivers.filter(receiver => receiver.entity_id !== idToRemove);
                 }
             });
-            console.log("Removed receiver");
+            console.log(`Removed receiver "${idToRemove}"`);
             savebuttondiv.appendChild(saveButton);
             clearCanvas();
-            drawElements();
+            drawElements(); // re-renders the sidebar tree too
         }
         if (event.target.closest('[data-type="removezone"]')) {
             const button = event.target.closest('[data-type="removezone"]'); // Get the button that was pressed
             const idToRemove = button.getAttribute('data-id'); // Get the value from data-id
-            const elementToRemove = document.getElementById(idToRemove); // Find the element with the specific ID
-            if (elementToRemove) { // Remove element if it exists
-                elementToRemove.remove();
-                console.log(`Zone with ID "${idToRemove}" was removed.`);
-            } else {
-                console.log(`Zone with ID "${idToRemove}" was not found.`);
-                return;
-            }
+            // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
+            if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
             // Loop through each floor and remove zones where the internal zone id matches
             finalcords.floor.forEach(floor => {
                 if (sameFloorName(floor.name, SelMapName)) {
                     floor.zones = floor.zones.filter(zone => (zone.zone_id || zone.entity_id) !== idToRemove);
                 }
             });
-            console.log("Removed zone");
+            console.log(`Removed zone "${idToRemove}"`);
             savebuttondiv.appendChild(saveButton);
             clearCanvas();
-            drawElements();
+            drawElements(); // re-renders the sidebar tree too
         }
         if (event.target.closest('[data-type="collapse"]')) {
             const collapseDiv = event.target.closest('[data-type="collapse"]');
@@ -757,6 +738,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         SelMapName = "";
         buttonreset();
         mapSelector.selectedIndex = 0;
+        renderEntityTree(null);
     });
 
     function clearCanvas(){
@@ -1262,6 +1244,65 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // =================================================================
+    // Move existing receivers by dragging them on the map
+    // =================================================================
+
+    let dragReceiverRef = null;
+    let dragOffset = null;
+    let dragMoved = false;
+
+    function anyToolActive() {
+        return drawAreaButton.dataset.active === 'true'
+            || addDeviceButton.dataset.active === 'true'
+            || SetScaleButton.dataset.active === 'true'
+            || socket !== null // real-time (websocket) tracking session
+            || pollTrackActive; // interval tracking session
+    }
+
+    function endReceiverDrag() {
+        if (!dragReceiverRef) return;
+        dragReceiverRef = null;
+        dragOffset = null;
+        if (dragMoved) {
+            savebuttondiv.appendChild(saveButton);
+        }
+        dragMoved = false;
+    }
+
+    canvas.addEventListener("mousedown", (event) => {
+        if (anyToolActive() || dragReceiverRef) return;
+        const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+        if (!floor) return;
+        const pos = zoneMousePos(event);
+        const hitRadius = canvas.width * 0.02 + 10; // icon radius plus slack
+        dragReceiverRef = (floor.receivers || []).find(r =>
+            r.cords && Math.hypot(r.cords.x - pos.x, r.cords.y - pos.y) <= hitRadius) || null;
+        if (dragReceiverRef) {
+            // Grab offset: the receiver moves with the cursor instead of
+            // teleporting its center onto it.
+            dragOffset = { x: dragReceiverRef.cords.x - pos.x, y: dragReceiverRef.cords.y - pos.y };
+            dragMoved = false;
+        }
+    });
+
+    canvas.addEventListener("mousemove", (event) => {
+        if (!dragReceiverRef) return;
+        if (event.buttons === 0) {
+            // The button was released outside the canvas/iframe.
+            endReceiverDrag();
+            return;
+        }
+        const pos = zoneMousePos(event);
+        dragReceiverRef.cords.x = Math.max(0, Math.min(canvas.width, pos.x + dragOffset.x));
+        dragReceiverRef.cords.y = Math.max(0, Math.min(canvas.height, pos.y + dragOffset.y));
+        dragMoved = true;
+        clearCanvas();
+        drawElements();
+    });
+
+    document.addEventListener("mouseup", endReceiverDrag);
+
+    // =================================================================
     // Add data to array
     // =================================================================
 
@@ -1340,26 +1381,52 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    // Text with a light halo, horizontally centered on cx and clamped to the
+    // canvas so labels stay fully readable at the edges.
+    function drawCenteredLabel(text, cx, baselineY, font, color) {
+        if (!text) return;
+        ctx.font = font;
+        const width = ctx.measureText(text).width;
+        let lx = cx - width / 2;
+        lx = Math.max(4, Math.min(canvas.width - width - 4, lx));
+        ctx.lineJoin = "round";
+        ctx.lineWidth = 5;
+        ctx.strokeStyle = "rgba(255, 255, 255, 0.85)";
+        ctx.strokeText(text, lx, baselineY);
+        ctx.fillStyle = color;
+        ctx.fillText(text, lx, baselineY);
+    }
+
     function drawElements(xp, yp, type){
         const rect = canvas.getBoundingClientRect();
         const tmpdrawcords = [];
         const iconSize = canvas.width * 0.04; // Adjust size as needed
         deleteButton.remove();
+        drawGrid();
 
         // Beräkna skalning mellan CSS-storlek och ritningsstorlek
         const scaleX = canvas.width / rect.width; // Horisontal scale
         const scaleY = canvas.height / rect.height; // Vertical scale
 
-        const x = (xp - rect.left) * scaleX;
-        const y = (yp - rect.top) * scaleY;
-
-        tmpcords = { x, y };
-        let newReceiver = {
-            entity_id: receiverName,
-            type: type,
-            cords: tmpcords
-          };
-        tmpdrawcords.push(newReceiver); // Add new coordinates
+        // Only a placement click (placeReceiver passes xp/yp) may update the
+        // pending receiver coordinates; plain redraws (grid toggle, sidebar
+        // deletes) must not clobber them.
+        if (xp !== undefined && yp !== undefined) {
+            tmpcords = {
+                x: (xp - rect.left) * scaleX,
+                y: (yp - rect.top) * scaleY,
+            };
+        }
+        // Keep the pending (unsaved) receiver marker visible across repaints
+        // while Place Receiver mode is active.
+        if (addDeviceButton.dataset.active === 'true' && tmpcords
+            && Number.isFinite(tmpcords.x) && Number.isFinite(tmpcords.y)) {
+            tmpdrawcords.push({
+                entity_id: receiverName,
+                type: "receiver",
+                cords: tmpcords,
+            });
+        }
 
         let floor = finalcords.floor.find(floor => sameFloorName(floor.name, SelMapName)); //Add all existing
 
@@ -1393,8 +1460,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             trackdiv.style.display = "none";
         }
 
-        let tmpHTMLrec = ""; 
-        let tmpHTMLzone = "";
         tmpdrawcords.forEach((item, index) => {
 
             if (item.type == "receiver"){
@@ -1406,19 +1471,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     ctx.drawImage(icon, x - iconSize / 2, y - iconSize / 2, iconSize, iconSize);
                 };
 
-                // Show id for receiver
-                ctx.font = "bold 25px Arial";
-                ctx.fillStyle = "black";
-                ctx.fillText(item.entity_id, x + iconSize / 2 + 5, y);
-                if(item.entity_id){
-                    tmpHTMLrec = tmpHTMLrec + newelement.replace("typename", item.entity_id).replace("removexxx", "removerec").replace("idxxx", item.entity_id).replace("idxxx", item.entity_id);
+                // Name centered above the icon; below it when too close to
+                // the top edge.
+                let labelY = y - iconSize / 2 - 8;
+                if (labelY < 24) {
+                    labelY = y + iconSize / 2 + 24;
                 }
+                drawCenteredLabel(item.entity_id, x, labelY, "600 22px system-ui, sans-serif", "#111111");
             }
             if (item.type == "zone"){
                 const pts = zonePerimeterPoints(item);
                 if (pts.length < 3) return;
-                const x = pts[0].x;
-                const y = pts[0].y;
 
                 // Draw polygon
                 ctx.beginPath();
@@ -1431,38 +1494,129 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ctx.lineWidth = 2;
                 ctx.stroke();
 
-                // Show id for Zone
-                ctx.font = "25px Arial";
-                ctx.fillStyle = "red";
-                ctx.fillText(item.entity_id, x + 10, y + iconSize / 4);
-                if(item.entity_id){
-                    const zoneDomId = item.zone_id || item.entity_id;
-                    tmpHTMLzone = tmpHTMLzone + newelement.replace("typename", item.entity_id).replace("removexxx", "removezone").replace("idxxx", zoneDomId).replace("idxxx", zoneDomId);
-                }
+                // Zone name centered in the room
+                const cx = pts.reduce((s, p) => s + p.x, 0) / pts.length;
+                const cy = pts.reduce((s, p) => s + p.y, 0) / pts.length;
+                drawCenteredLabel(item.entity_id, cx, cy + 8, "600 24px system-ui, sans-serif", "#d32f2f");
             }
         });
-        if(tmpHTMLrec !== ""){
-            document.getElementById('divrec').innerHTML = tmpHTMLrec;
-        } else{
-            document.getElementById('divrec').innerHTML = '<p class="text-sm text-gray-500">No receivers placed</p>';
-        }
-        if(tmpHTMLzone !== ""){
-            document.getElementById('divzones').innerHTML = tmpHTMLzone;
-        } else{
-            document.getElementById('divzones').innerHTML = '<p class="text-sm text-gray-500">No zones drawn</p>';
-        }
 
+        renderEntityTree(floor);
+    }
+
+    // Sidebar: one section per zone with the receivers placed inside it.
+    function renderEntityTree(floor) {
+        const tree = document.getElementById("entitytree");
+        if (!floor) {
+            tree.innerHTML = '<p class="bps-empty">Select a floor to see its zones and receivers.</p>';
+            return;
+        }
+        const trashSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>';
+        const receiverRow = r =>
+            `<li><span title="${escHtml(r.entity_id)}">${escHtml(r.entity_id)}</span>`
+            + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
+
+        const receivers = (floor.receivers || []).filter(r => r && r.entity_id && r.cords);
+        const claimed = new Set();
+        let html = "";
+        (floor.zones || []).forEach(zone => {
+            const pts = zonePerimeterPoints(zone);
+            const inside = pts.length >= 3
+                ? receivers.filter(r => !claimed.has(r.entity_id) && pointInPolygon(r.cords.x, r.cords.y, pts))
+                : [];
+            inside.forEach(r => claimed.add(r.entity_id));
+            const zoneDomId = zone.zone_id || zone.entity_id;
+            html += '<div class="bps-zone-group">'
+                + `<div class="bps-zone-head"><span title="${escHtml(zone.entity_id)}">${escHtml(zone.entity_id)}<span class="bps-count"> · ${inside.length}</span></span>`
+                + `<button class="bps-icon-btn" title="Remove zone" data-type="removezone" data-id="${escHtml(zoneDomId)}">${trashSvg}</button></div>`;
+            if (inside.length) {
+                html += "<ul>" + inside.map(receiverRow).join("") + "</ul>";
+            }
+            html += "</div>";
+        });
+        const unzoned = receivers.filter(r => !claimed.has(r.entity_id));
+        if (unzoned.length) {
+            html += '<div class="bps-zone-group">'
+                + `<div class="bps-zone-head"><span>No zone<span class="bps-count"> · ${unzoned.length}</span></span></div>`
+                + "<ul>" + unzoned.map(receiverRow).join("") + "</ul></div>";
+        }
+        tree.innerHTML = html || '<p class="bps-empty">No zones or receivers on this floor yet.</p>';
+    }
+
+    // =================================================================
+    // Distance grid overlay (toggleable, meters or feet)
+    // =================================================================
+
+    let gridUnit = localStorage.getItem("bpsGridUnit") || "off"; // off | m | ft
+    const gridToggle = document.getElementById("gridToggle");
+
+    function updateGridButton() {
+        gridToggle.textContent = gridUnit === "off" ? "Grid: off"
+            : gridUnit === "m" ? "Grid: meters" : "Grid: feet";
+    }
+    updateGridButton();
+
+    gridToggle.addEventListener("click", () => {
+        gridUnit = gridUnit === "off" ? "m" : gridUnit === "m" ? "ft" : "off";
+        localStorage.setItem("bpsGridUnit", gridUnit);
+        updateGridButton();
+        // Redraw only when a floor plan is actually loaded; the preference
+        // itself always cycles and persists.
+        if (img.naturalWidth > 0) {
+            clearCanvas();
+            drawElements();
+        }
+    });
+
+    function drawGrid() {
+        if (gridUnit === "off") return;
+        const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+        const scale = floor && floor.scale; // pixels per meter
+        if (!scale) return;
+        const unitPx = gridUnit === "m" ? scale : scale * 0.3048;
+        // Thin the grid out when single units would be too dense to read.
+        let step = unitPx;
+        let unitsPerLine = 1;
+        while (step < 45) {
+            step += unitPx;
+            unitsPerLine += 1;
+        }
+        ctx.save();
+        ctx.strokeStyle = "rgba(30, 60, 120, 0.18)";
+        ctx.lineWidth = 1;
+        ctx.fillStyle = "rgba(30, 60, 120, 0.75)";
+        ctx.font = "14px system-ui, sans-serif";
+        for (let gx = step, i = unitsPerLine; gx < canvas.width; gx += step, i += unitsPerLine) {
+            ctx.beginPath();
+            ctx.moveTo(gx, 0);
+            ctx.lineTo(gx, canvas.height);
+            ctx.stroke();
+            ctx.fillText(`${i}${gridUnit}`, gx + 3, 16);
+        }
+        for (let gy = step, i = unitsPerLine; gy < canvas.height; gy += step, i += unitsPerLine) {
+            ctx.beginPath();
+            ctx.moveTo(0, gy);
+            ctx.lineTo(canvas.width, gy);
+            ctx.stroke();
+            ctx.fillText(`${i}${gridUnit}`, 3, gy - 4);
+        }
+        ctx.restore();
     }
 
     // Display selected map
-    mapSelector.addEventListener('change', async () => {
-        img.src = `/local/bps_maps/${mapSelector.value}`;
-        imgfilename = mapSelector.value;
-        mapname.value = removeExtension(mapSelector.value);
+    async function selectExistingMap(value) {
+        img.src = `/local/bps_maps/${value}`;
+        imgfilename = value;
+        mapname.value = removeExtension(value);
         SelMapName = mapname.value;
         await setupCanvasWithImage(img, canvas);
         new_floor = false;
         drawElements();
+    }
+
+    mapSelector.addEventListener('change', async () => {
+        if (!mapSelector.value) return;
+        await selectExistingMap(mapSelector.value);
     });
 
     upload.addEventListener('change', event => {
@@ -1501,6 +1655,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             img.onload = () => {
                 setupImageSize(img, canvas);
                 resolve(); // Resolve when completed
+            };
+            img.onerror = () => {
+                // Settle the promise so callers (including the startup
+                // auto-open) continue instead of hanging forever.
+                console.error(`Failed to load floor image: ${img.src}`);
+                messdiv.innerHTML = '<p class="text-sm text-gray-500">Could not load the floor image for this map. Re-select it or upload a new image.</p>';
+                resolve();
             };
     
             // Add the buttons
@@ -1719,10 +1880,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         return data;
     }
 
-    // Receiver ids can be user-typed (Custom name…); never trust them in HTML.
-    const escHtml = s => String(s).replace(/[&<>"']/g,
-        c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-
     function renderCalibrationResult(result) {
         calibStatus.textContent =
             `Floor ${result.floor}: ${result.pairs_used} pairs (${result.bidirectional_pairs} bidirectional), ` +
@@ -1902,5 +2059,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     pollCalibration();
+
+    // With a single configured floor there is nothing to choose: open it
+    // right away. This must run LAST — drawElements touches state declared
+    // throughout this closure, so everything has to be initialized first.
+    if (tmpsaved) {
+        const savedMaps = Array.from(mapSelector.options)
+            .map(option => option.value)
+            .filter(Boolean);
+        if (savedMaps.length === 1) {
+            mapSelector.value = savedMaps[0];
+            await selectExistingMap(savedMaps[0]);
+        }
+    }
 
 });


### PR DESCRIPTION
Full UX pass on the BPS sidebar panel, per the wishlist:

- **Auto-open**: with exactly one saved floor, the panel loads it immediately.
- **Dark theme**: the stylesheet already shipped a dormant shadcn-style dark palette; the panel now runs on it, with a header, card-style canvas container, and dark-styled inputs/buttons throughout.
- **Sidebar**: the floating collapsible entities card is replaced by a sticky right column spanning from the picker row down — **one section per zone**, each listing the receivers geometrically inside it (point-in-polygon against the drawn zone), a "No zone" bucket, per-zone receiver counts, and per-row delete buttons.
- **Movable receivers**: drag a receiver directly on the map when no drawing tool or tracking session is active. Grab-offset dragging (no teleporting the icon to the cursor), drag ends on release anywhere (including outside the canvas), and the Save prompt only appears when something actually moved.
- **Distance grid**: `Grid: off → meters → feet` toggle; spacing from the floor's calibration scale, auto-thinning when lines would be dense, axis labels, persisted in localStorage.
- **Labels**: zone names centered in their room (polygon centroid), receiver names centered above their icon, both haloed for readability and clamped to the canvas so they never overflow.

An adversarial review pass on the diff confirmed and fixed 7 integration issues before this PR, most notably: the auto-open originally ran before the closure finished initializing and crashed the entire panel via a temporal-dead-zone read **precisely when one floor exists**; receiver dragging wasn't blocked during interval-based tracking; drags never ended when released outside the canvas; the grid toggle corrupted the canvas before a floor was loaded and clobbered pending receiver placements; a failed floor-image load hung startup forever; Clear Canvas left a stale sidebar whose delete buttons faked a save prompt.

Panel-only (no backend changes): merge, redownload, hard-refresh the panel (Ctrl+Shift+R on the iframe page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)