### PR TITLE
Clear trackers from the map after five minutes out of range

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ Positions can never leave the floor: the trilateration solver is bounded to
 the extent of the floor's receivers and zones, and a fix that still lands
 outside every zone (BLE noise pushing it into a wall or off the apartment) is
 published at the nearest point on the nearest zone instead — on the map card,
-in `/api/bps/cords`, and for the zone sensors alike. It reports `unknown` only when the device is out of
-  range (no receiver currently measures a distance to it), so it is the
-  sensor to automate on when `_bps_zone` is too strict.
+in `/api/bps/cords`, and for the zone sensors alike.
+
+A tracker that no receiver has detected for 5 minutes disappears from the map
+and its `_bps_zone`, `_bps_floor` and `_bps_nearest_zone` sensors go to
+`unknown` (previously the last position and zone were kept forever after
+someone left home). The grace period can be tuned with a top-level
+`"position_timeout"` (seconds) in `bpsdata.txt`.
 ![Created entities](img/screenshots/entities.png)
 
 You will now also have a new panel in the side panel named "BPS"

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -1,5 +1,6 @@
 import aiofiles
 import aiofiles.os
+import time
 from pathlib import Path
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -52,6 +53,10 @@ tracked_entities = []
 new_global_data = {}
 secToUpdate = 1
 apitricords = []
+# A tracker not detected by any receiver for this long disappears from the
+# map and its zone/floor sensors go to unknown. Override with a top-level
+# "position_timeout" (seconds) in bpsdata.txt.
+STALE_POSITION_SECS = 300
 
 
 def cleanup_legacy_bps_registry_and_states(hass: HomeAssistant):
@@ -127,6 +132,8 @@ async def update_tracked_entities(hass, jinja_code):
         try:
             template = Template(jinja_code, hass)
             tracked_entities = template.async_render()
+
+            await prune_stale_positions(hass)
 
             num_points = len(tracked_entities)
             if num_points == 0:
@@ -267,7 +274,10 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
             avg_x, avg_y = float(snapped.x), float(snapped.y)
         zone = find_zone_for_point(new_global_data, entity, lowest_floor_name, test_point)
         nearest_zone = find_nearest_zone(new_global_data, entity, lowest_floor_name, test_point)
-        apitricords = update_or_add_entry(apitricords, {"ent": entity, "cords": [avg_x, avg_y], "zone": zone})
+        apitricords = update_or_add_entry(
+            apitricords,
+            {"ent": entity, "cords": [avg_x, avg_y], "zone": zone, "updated": time.time()},
+        )
         await update_apitricords(hass, apitricords)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", nearest_zone)
@@ -278,11 +288,38 @@ def update_or_add_entry(data, new_entry):
         if item["ent"] == new_entry["ent"]:  # Check if "ent" already exists
             item["cords"] = new_entry["cords"]  # Update "cords"
             item["zone"] = new_entry["zone"]  # Update "zone"
+            item["updated"] = new_entry["updated"]  # Freshness for pruning
             return data
 
     # If "ent" was not found, add as new post
     data.append(new_entry)
     return data
+
+
+async def prune_stale_positions(hass):
+    """Drop trackers not detected by any receiver for the timeout period.
+
+    Without this, a person who left home stayed on the map at their last
+    position forever, and the zone/floor sensors kept the stale values.
+    """
+    global apitricords
+    timeout = STALE_POSITION_SECS
+    if isinstance(global_data, dict):
+        configured = global_data.get("position_timeout")
+        if isinstance(configured, (int, float)) and configured > 0:
+            timeout = configured
+
+    now = time.time()
+    stale_ents = {e["ent"] for e in apitricords if now - e.get("updated", now) > timeout}
+    if not stale_ents:
+        return
+    apitricords = [e for e in apitricords if e["ent"] not in stale_ents]
+    await update_apitricords(hass, apitricords)
+    for ent in sorted(stale_ents):
+        _LOGGER.info("Tracker %s not seen for %ss; clearing its position", ent, timeout)
+        update_bps_sensor_state(hass, f"sensor.{ent}_bps_zone", "unknown")
+        update_bps_sensor_state(hass, f"sensor.{ent}_bps_floor", "unknown")
+        update_bps_sensor_state(hass, f"sensor.{ent}_bps_nearest_zone", "unknown")
 
 async def update_apitricords(hass, new_data):
     """Update apitricords in hass.data"""


### PR DESCRIPTION
People who left home stayed on the map at their last position indefinitely: the backend position list (`apitricords`) only ever added or updated entries, and the zone/floor sensors froze at their last values.

- Every successful fix now carries a timestamp, and the 1-second update loop prunes trackers whose last fix is older than **5 minutes** (override with a top-level `"position_timeout"` in `bpsdata.txt`).
- A pruned tracker vanishes from `/api/bps/cords` (map card and panel clear it — the card needs no update since the floor sensor going `unknown` already drops the marker) and its `_bps_zone`, `_bps_floor`, and `_bps_nearest_zone` sensors read `unknown`.
- The moment the person is back in range, the first fix restores everything.

Note the ordering with the existing behaviors: `_bps_nearest_zone` goes `unknown` ~30 s after leaving (Bermuda's distance timeout, immediate out-of-range detection), while the position and `_bps_zone`/`_bps_floor` get the 5-minute grace so brief detection gaps don't blink people off the map.

Backend-only: HA restart after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)