### PR TITLE
Persist calibration results and sample window across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ you prefer to calibrate at the source for all integrations at once.
 30 seconds into a rolling window (about six hours), re-solves every 15 minutes
 for **every** floor at once, and re-applies corrections automatically whenever
 they change by more than 1%. The toggle is stored in `bpsdata.txt`, so it
-survives Home Assistant restarts. With auto calibration on, the manual
+survives Home Assistant restarts. The latest
+solve results and the sample window are persisted too
+(`www/bps_maps/bps_calibration_state.json`), so the matrix reappears
+immediately after a reboot and the window resumes warm instead of rebuilding
+from zero. With auto calibration on, the manual
 controls are hidden — the matrix in the panel simply tracks the latest solve
 for the selected floor, and corrections keep adapting as the environment
 changes (furniture moves, probes are swapped, a door stays open).

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -32,6 +32,7 @@ from asyncio import Lock, Queue, wait_for, TimeoutError
 from .calibration import (
     BPS_FILE_LOCK,
     BPSCalibrationAPI,
+    async_restore_calibration_state,
     async_shutdown_calibration,
     async_start_auto_if_enabled,
 )
@@ -623,6 +624,7 @@ async def async_setup(hass, config):
 
         hass.bus.async_listen_once("homeassistant_stop", handle_homeassistant_stop)
 
+        await async_restore_calibration_state(hass)
         await async_start_auto_if_enabled(hass)
 
         _LOGGER.info("The BPS integration is fully initialized")

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -58,6 +58,8 @@ AUTO_SOLVE_INTERVAL = 900  # seconds between re-solves in continuous mode
 AUTO_MIN_WINDOW = 300  # seconds of data before the first auto solve
 APPLY_EPSILON = 0.01  # relative correction change worth persisting
 SAMPLES_MAXLEN = 720  # rolling window per pair (6 h at the auto interval)
+STATE_SAMPLES_PER_PAIR = 200  # samples persisted per pair (enough for a solve)
+STATE_MAX_AGE = SAMPLES_MAXLEN * AUTO_SAMPLE_INTERVAL  # drop older windows
 STALE_ADVERT_SECS = 30  # ignore adverts older than this within a dump
 MIN_SAMPLES_PER_PAIR = 5
 MIN_TRUE_DISTANCE_M = 0.3  # closer pairs carry no path-loss information
@@ -80,6 +82,68 @@ def _normalize(value):
 
 def _bpsdata_path(hass) -> Path:
     return Path(hass.config.path("www/bps_maps")) / "bpsdata.txt"
+
+
+def _state_path(hass) -> Path:
+    return Path(hass.config.path("www/bps_maps")) / "bps_calibration_state.json"
+
+
+async def save_calibration_state(hass) -> None:
+    """Persist the latest solves and the sample window across restarts.
+
+    The applied corrections live in bpsdata.txt and always survive; this file
+    only keeps the panel's matrix and the rolling window warm so a reboot does
+    not blank the display and restart the window from zero.
+    """
+    cal = get_calibration_state(hass)
+    payload = {
+        "saved_at": time.time(),
+        "results": cal["results"],
+        "applied": cal["applied"],
+        "samples": {
+            key: list(values)[-STATE_SAMPLES_PER_PAIR:]
+            for key, values in cal["samples"].items()
+        },
+    }
+    try:
+        async with BPS_FILE_LOCK:
+            async with aiofiles.open(_state_path(hass), "w") as f:
+                await f.write(json.dumps(payload))
+    except OSError as e:
+        _LOGGER.warning("Could not persist calibration state: %s", e)
+
+
+async def async_restore_calibration_state(hass) -> None:
+    """Reload the persisted solves and sample window at startup."""
+    cal = get_calibration_state(hass)
+    if cal["mode"] != "off":
+        return
+    try:
+        async with aiofiles.open(_state_path(hass), "r") as f:
+            payload = json.loads(await f.read())
+    except (OSError, json.JSONDecodeError):
+        return  # first run, or an unreadable state file: start cold
+
+    if isinstance(payload.get("results"), dict):
+        cal["results"] = payload["results"]
+    if isinstance(payload.get("applied"), dict):
+        cal["applied"] = payload["applied"]
+
+    saved_at = payload.get("saved_at")
+    fresh = isinstance(saved_at, (int, float)) and time.time() - saved_at <= STATE_MAX_AGE
+    if fresh and isinstance(payload.get("samples"), dict):
+        for key, values in payload["samples"].items():
+            if isinstance(values, list):
+                cal["samples"][key] = deque(
+                    (float(v) for v in values if isinstance(v, (int, float))),
+                    maxlen=SAMPLES_MAXLEN,
+                )
+    _LOGGER.info(
+        "Restored calibration state (%d floor results, %d sample pairs%s)",
+        len(cal["results"]),
+        len(cal["samples"]),
+        "" if fresh else ", window too old — dropped",
+    )
 
 
 async def _read_coords(hass):
@@ -391,6 +455,7 @@ async def _sample_loop(hass, cal: dict) -> None:
         cal["last_solved_at"] = result["solved_at"]
         cal["state"] = "done"
         cal["mode"] = "off"
+        await save_calibration_state(hass)
     except ValueError as e:
         cal["state"] = "error"
         cal["mode"] = "off"
@@ -425,6 +490,7 @@ async def _auto_loop(hass, cal: dict) -> None:
                 last_solve = now
                 try:
                     await _auto_solve_and_apply(hass, cal)
+                    await save_calibration_state(hass)
                 except Exception as e:
                     _LOGGER.exception("Auto-calibration solve failed")
                     cal["error"] = str(e)
@@ -559,6 +625,8 @@ async def set_auto_calibration(hass, enabled: bool) -> None:
 
     await _stop_task(cal)
     if enabled:
+        # Deliberately keeps cal["samples"]: a restored or still-warm window
+        # means the first solve after enabling has history to work with.
         cal.update(
             {
                 "state": "sampling",
@@ -567,7 +635,6 @@ async def set_auto_calibration(hass, enabled: bool) -> None:
                 "started_at": time.time(),
                 "ends_at": None,
                 "duration": None,
-                "samples": {},
                 "receivers": _build_receiver_map(coords),
                 "error": None,
             }
@@ -596,6 +663,8 @@ async def async_shutdown_calibration(hass) -> None:
         await _stop_task(state)
         state["state"] = "idle"
         state["mode"] = "off"
+        if state["samples"] or state["results"]:
+            await save_calibration_state(hass)
 
 
 async def apply_corrections(hass, cal: dict, floor_name: str) -> int:
@@ -723,9 +792,11 @@ class BPSCalibrationAPI(HomeAssistantView):
                 cal["error"] = None
             elif action == "apply":
                 updated = await apply_corrections(hass, cal, data.get("floor") or cal.get("floor"))
+                await save_calibration_state(hass)
                 return web.json_response({"applied": updated, **_status_payload(cal)})
             elif action == "reset":
                 removed = await reset_corrections(hass, cal, data.get("floor") or cal.get("floor"))
+                await save_calibration_state(hass)
                 return web.json_response({"reset": removed, **_status_payload(cal)})
             else:
                 return web.json_response({"error": f"Unknown action {action!r}"}, status=400)


### PR DESCRIPTION
The applied corrections always survived reboots — they live in `bpsdata.txt` and are applied from there on every cycle (verified against a live install). What did **not** survive was the display state: the panel's calibration matrix and the rolling sample window were in-memory only, so a reboot blanked the graph until the first post-boot solve (~5 minutes) and restarted the six-hour window from zero.

- The latest per-floor solve results, the applied-corrections map, and up to 200 samples per pair are persisted to `www/bps_maps/bps_calibration_state.json` — written after every auto/manual solve, on user apply/reset, and at graceful shutdown.
- Restored during integration startup before the auto loop resumes: the matrix reappears immediately, and the first post-boot solve works from a warm window instead of cold-starting.
- A persisted window older than its own span (6 h) is dropped on restore; solved results are kept regardless, so the panel always shows the last known matrix.
- Enabling auto calibration no longer wipes an existing window — toggling it off/on or resuming after a restart keeps accumulated history (a manual Start still begins a fresh window).

Verified with round-trip tests: fresh restore (results + applied + capped samples as bounded deques), stale-window restore (results kept, samples dropped), and cold start with no state file.

Backend-only: HA restart after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)