### PR TITLE
Modernize the panel UI and split calibration into its own tab

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2462,58 +2462,201 @@ body {
 
 .data-\[selected\=\'true\'\]\:bg-accent[data-selected=true]{background-color:hsl(var(--accent))}.data-\[state\=active\]\:bg-background[data-state=active]{background-color:hsl(var(--background))}.data-\[state\=checked\]\:bg-primary[data-state=checked]{background-color:hsl(var(--primary))}.data-\[state\=on\]\:bg-accent[data-state=on],.data-\[state\=open\]\:bg-accent[data-state=open]{background-color:hsl(var(--accent))}.data-\[state\=open\]\:bg-accent\/50[data-state=open]{background-color:hsl(var(--accent) / .5)}.data-\[state\=open\]\:bg-secondary[data-state=open]{background-color:hsl(var(--secondary))}.data-\[state\=selected\]\:bg-muted[data-state=selected]{background-color:hsl(var(--muted))}.data-\[state\=unchecked\]\:bg-input[data-state=unchecked]{background-color:hsl(var(--input))}.data-\[active\=true\]\:font-medium[data-active=true]{font-weight:500}.data-\[active\=true\]\:text-sidebar-accent-foreground[data-active=true]{color:hsl(var(--sidebar-accent-foreground))}.data-\[selected\=true\]\:text-accent-foreground[data-selected=true]{color:hsl(var(--accent-foreground))}.data-\[state\=active\]\:text-foreground[data-state=active]{color:hsl(var(--foreground))}.data-\[state\=checked\]\:text-primary-foreground[data-state=checked]{color:hsl(var(--primary-foreground))}.data-\[state\=on\]\:text-accent-foreground[data-state=on],.data-\[state\=open\]\:text-accent-foreground[data-state=open]{color:hsl(var(--accent-foreground))}.data-\[state\=open\]\:text-muted-foreground[data-state=open]{color:hsl(var(--muted-foreground))}.data-\[disabled\=true\]\:opacity-50[data-disabled=true],.data-\[disabled\]\:opacity-50[data-disabled]{opacity:.5}.data-\[state\=open\]\:opacity-100[data-state=open]{opacity:1}.data-\[state\=active\]\:shadow-sm[data-state=active]{--tw-shadow: 0 1px 2px 0 rgb(0 0 0 / .05);--tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.data-\[swipe\=move\]\:transition-none[data-swipe=move]{transition-property:none}.data-\[state\=closed\]\:duration-300[data-state=closed]{transition-duration:.3s}.data-\[state\=open\]\:duration-500[data-state=open]{transition-duration:.5s}.data-\[motion\^\=from-\]\:animate-in[data-motion^=from-],.data-\[state\=open\]\:animate-in[data-state=open],.data-\[state\=visible\]\:animate-in[data-state=visible]{animation-name:enter;animation-duration:.15s;--tw-enter-opacity: initial;--tw-enter-scale: initial;--tw-enter-rotate: initial;--tw-enter-translate-x: initial;--tw-enter-translate-y: initial}.data-\[motion\^\=to-\]\:animate-out[data-motion^=to-],.data-\[state\=closed\]\:animate-out[data-state=closed],.data-\[state\=hidden\]\:animate-out[data-state=hidden],.data-\[swipe\=end\]\:animate-out[data-swipe=end]{animation-name:exit;animation-duration:.15s;--tw-exit-opacity: initial;--tw-exit-scale: initial;--tw-exit-rotate: initial;--tw-exit-translate-x: initial;--tw-exit-translate-y: initial}.data-\[motion\^\=from-\]\:fade-in[data-motion^=from-]{--tw-enter-opacity: 0}.data-\[motion\^\=to-\]\:fade-out[data-motion^=to-],.data-\[state\=closed\]\:fade-out-0[data-state=closed]{--tw-exit-opacity: 0}.data-\[state\=closed\]\:fade-out-80[data-state=closed]{--tw-exit-opacity: .8}.data-\[state\=hidden\]\:fade-out[data-state=hidden]{--tw-exit-opacity: 0}.data-\[state\=open\]\:fade-in-0[data-state=open],.data-\[state\=visible\]\:fade-in[data-state=visible]{--tw-enter-opacity: 0}.data-\[state\=closed\]\:zoom-out-95[data-state=closed]{--tw-exit-scale: .95}.data-\[state\=open\]\:zoom-in-90[data-state=open]{--tw-enter-scale: .9}.data-\[state\=open\]\:zoom-in-95[data-state=open]{--tw-enter-scale: .95}.data-\[motion\=from-end\]\:slide-in-from-right-52[data-motion=from-end]{--tw-enter-translate-x: 13rem}.data-\[motion\=from-start\]\:slide-in-from-left-52[data-motion=from-start]{--tw-enter-translate-x: -13rem}.data-\[motion\=to-end\]\:slide-out-to-right-52[data-motion=to-end]{--tw-exit-translate-x: 13rem}.data-\[motion\=to-start\]\:slide-out-to-left-52[data-motion=to-start]{--tw-exit-translate-x: -13rem}.data-\[side\=bottom\]\:slide-in-from-top-2[data-side=bottom]{--tw-enter-translate-y: -.5rem}.data-\[side\=left\]\:slide-in-from-right-2[data-side=left]{--tw-enter-translate-x: .5rem}.data-\[side\=right\]\:slide-in-from-left-2[data-side=right]{--tw-enter-translate-x: -.5rem}.data-\[side\=top\]\:slide-in-from-bottom-2[data-side=top]{--tw-enter-translate-y: .5rem}.data-\[state\=closed\]\:slide-out-to-bottom[data-state=closed]{--tw-exit-translate-y: 100%}.data-\[state\=closed\]\:slide-out-to-left[data-state=closed]{--tw-exit-translate-x: -100%}.data-\[state\=closed\]\:slide-out-to-left-1\/2[data-state=closed]{--tw-exit-translate-x: -50%}.data-\[state\=closed\]\:slide-out-to-right[data-state=closed],.data-\[state\=closed\]\:slide-out-to-right-full[data-state=closed]{--tw-exit-translate-x: 100%}.data-\[state\=closed\]\:slide-out-to-top[data-state=closed]{--tw-exit-translate-y: -100%}.data-\[state\=closed\]\:slide-out-to-top-\[48\%\][data-state=closed]{--tw-exit-translate-y: -48%}.data-\[state\=open\]\:slide-in-from-bottom[data-state=open]{--tw-enter-translate-y: 100%}.data-\[state\=open\]\:slide-in-from-left[data-state=open]{--tw-enter-translate-x: -100%}.data-\[state\=open\]\:slide-in-from-left-1\/2[data-state=open]{--tw-enter-translate-x: -50%}.data-\[state\=open\]\:slide-in-from-right[data-state=open]{--tw-enter-translate-x: 100%}.data-\[state\=open\]\:slide-in-from-top[data-state=open]{--tw-enter-translate-y: -100%}.data-\[state\=open\]\:slide-in-from-top-\[48\%\][data-state=open]{--tw-enter-translate-y: -48%}.data-\[state\=open\]\:slide-in-from-top-full[data-state=open]{--tw-enter-translate-y: -100%}.data-\[state\=closed\]\:duration-300[data-state=closed]{animation-duration:.3s}.data-\[state\=open\]\:duration-500[data-state=open]{animation-duration:.5s}.data-\[panel-group-direction\=vertical\]\:after\:left-0[data-panel-group-direction=vertical]:after{content:var(--tw-content);left:0}.data-\[panel-group-direction\=vertical\]\:after\:h-1[data-panel-group-direction=vertical]:after{content:var(--tw-content);height:.25rem}.data-\[panel-group-direction\=vertical\]\:after\:w-full[data-panel-group-direction=vertical]:after{content:var(--tw-content);width:100%}.data-\[panel-group-direction\=vertical\]\:after\:-translate-y-1\/2[data-panel-group-direction=vertical]:after{content:var(--tw-content);--tw-translate-y: -50%;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.data-\[panel-group-direction\=vertical\]\:after\:translate-x-0[data-panel-group-direction=vertical]:after{content:var(--tw-content);--tw-translate-x: 0px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.data-\[state\=open\]\:hover\:bg-sidebar-accent:hover[data-state=open]{background-color:hsl(var(--sidebar-accent))}.data-\[state\=open\]\:hover\:text-sidebar-accent-foreground:hover[data-state=open]{color:hsl(var(--sidebar-accent-foreground))}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:left-\[calc\(var\(--sidebar-width\)\*-1\)\]{left:calc(var(--sidebar-width) * -1)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:right-\[calc\(var\(--sidebar-width\)\*-1\)\]{right:calc(var(--sidebar-width) * -1)}.group[data-side=left] .group-data-\[side\=left\]\:-right-4{right:-1rem}.group[data-side=right] .group-data-\[side\=right\]\:left-0{left:0}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:-mt-8{margin-top:-2rem}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:hidden{display:none}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!size-8{width:2rem!important;height:2rem!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[--sidebar-width-icon\]{width:var(--sidebar-width-icon)}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[calc\(var\(--sidebar-width-icon\)_\+_theme\(spacing\.4\)\)\]{width:calc(var(--sidebar-width-icon) + 1rem)}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:w-\[calc\(var\(--sidebar-width-icon\)_\+_theme\(spacing\.4\)_\+2px\)\]{width:calc(var(--sidebar-width-icon) + 1rem + 2px)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:w-0{width:0px}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:translate-x-0{--tw-translate-x: 0px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.group[data-side=right] .group-data-\[side\=right\]\:rotate-180,.group[data-state=open] .group-data-\[state\=open\]\:rotate-180{--tw-rotate: 180deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:overflow-hidden{overflow:hidden}.group[data-variant=floating] .group-data-\[variant\=floating\]\:rounded-lg{border-radius:var(--radius)}.group[data-variant=floating] .group-data-\[variant\=floating\]\:border{border-width:1px}.group[data-side=left] .group-data-\[side\=left\]\:border-r{border-right-width:1px}.group[data-side=right] .group-data-\[side\=right\]\:border-l{border-left-width:1px}.group[data-variant=floating] .group-data-\[variant\=floating\]\:border-sidebar-border{border-color:hsl(var(--sidebar-border))}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!p-0{padding:0!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:\!p-2{padding:.5rem!important}.group[data-collapsible=icon] .group-data-\[collapsible\=icon\]\:opacity-0{opacity:0}.group[data-variant=floating] .group-data-\[variant\=floating\]\:shadow{--tw-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);--tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:after\:left-full:after{content:var(--tw-content);left:100%}.group[data-collapsible=offcanvas] .group-data-\[collapsible\=offcanvas\]\:hover\:bg-sidebar:hover{background-color:hsl(var(--sidebar-background))}.peer\/menu-button[data-size=default]~.peer-data-\[size\=default\]\/menu-button\:top-1\.5{top:.375rem}.peer\/menu-button[data-size=lg]~.peer-data-\[size\=lg\]\/menu-button\:top-2\.5{top:.625rem}.peer\/menu-button[data-size=sm]~.peer-data-\[size\=sm\]\/menu-button\:top-1{top:.25rem}.peer[data-variant=inset]~.peer-data-\[variant\=inset\]\:min-h-\[calc\(100svh-theme\(spacing\.4\)\)\]{min-height:calc(100svh - 1rem)}.peer\/menu-button[data-active=true]~.peer-data-\[active\=true\]\/menu-button\:text-sidebar-accent-foreground{color:hsl(var(--sidebar-accent-foreground))}.dark\:border-destructive:is(.dark *){border-color:hsl(var(--destructive))}@media (min-width: 640px){.sm\:bottom-0{bottom:0}.sm\:right-0{right:0}.sm\:top-auto{top:auto}.sm\:mt-0{margin-top:0}.sm\:flex{display:flex}.sm\:max-w-sm{max-width:24rem}.sm\:flex-row{flex-direction:row}.sm\:flex-col{flex-direction:column}.sm\:justify-end{justify-content:flex-end}.sm\:gap-2\.5{gap:.625rem}.sm\:space-x-2>:not([hidden])~:not([hidden]){--tw-space-x-reverse: 0;margin-right:calc(.5rem * var(--tw-space-x-reverse));margin-left:calc(.5rem * calc(1 - var(--tw-space-x-reverse)))}.sm\:space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse: 0;margin-right:calc(1rem * var(--tw-space-x-reverse));margin-left:calc(1rem * calc(1 - var(--tw-space-x-reverse)))}.sm\:space-y-0>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(0px * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0px * var(--tw-space-y-reverse))}.sm\:rounded-lg{border-radius:var(--radius)}.sm\:text-left{text-align:left}.data-\[state\=open\]\:sm\:slide-in-from-bottom-full[data-state=open]{--tw-enter-translate-y: 100%}}@media (min-width: 768px){.md\:absolute{position:absolute}.md\:block{display:block}.md\:flex{display:flex}.md\:w-\[var\(--radix-navigation-menu-viewport-width\)\]{width:var(--radix-navigation-menu-viewport-width)}.md\:w-auto{width:auto}.md\:max-w-\[420px\]{max-width:420px}.md\:text-sm{font-size:.875rem;line-height:1.25rem}.md\:opacity-0{opacity:0}.after\:md\:hidden:after{content:var(--tw-content);display:none}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:m-2{margin:.5rem}.peer[data-state=collapsed][data-variant=inset]~.md\:peer-data-\[state\=collapsed\]\:peer-data-\[variant\=inset\]\:ml-2{margin-left:.5rem}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:ml-0{margin-left:0}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:rounded-xl{border-radius:.75rem}.peer[data-variant=inset]~.md\:peer-data-\[variant\=inset\]\:shadow{--tw-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);--tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}}.\[\&\:has\(\[aria-selected\]\)\]\:bg-accent:has([aria-selected]){background-color:hsl(var(--accent))}.first\:\[\&\:has\(\[aria-selected\]\)\]\:rounded-l-md:has([aria-selected]):first-child{border-top-left-radius:calc(var(--radius) - 2px);border-bottom-left-radius:calc(var(--radius) - 2px)}.last\:\[\&\:has\(\[aria-selected\]\)\]\:rounded-r-md:has([aria-selected]):last-child{border-top-right-radius:calc(var(--radius) - 2px);border-bottom-right-radius:calc(var(--radius) - 2px)}.\[\&\:has\(\[aria-selected\]\.day-outside\)\]\:bg-accent\/50:has([aria-selected].day-outside){background-color:hsl(var(--accent) / .5)}.\[\&\:has\(\[aria-selected\]\.day-range-end\)\]\:rounded-r-md:has([aria-selected].day-range-end){border-top-right-radius:calc(var(--radius) - 2px);border-bottom-right-radius:calc(var(--radius) - 2px)}.\[\&\:has\(\[role\=checkbox\]\)\]\:pr-0:has([role=checkbox]){padding-right:0}.\[\&\>button\]\:hidden>button{display:none}.\[\&\>span\:last-child\]\:truncate>span:last-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.\[\&\>span\]\:line-clamp-1>span{overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:1}.\[\&\>svg\+div\]\:translate-y-\[-3px\]>svg+div{--tw-translate-y: -3px;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&\>svg\]\:absolute>svg{position:absolute}.\[\&\>svg\]\:left-4>svg{left:1rem}.\[\&\>svg\]\:top-4>svg{top:1rem}.\[\&\>svg\]\:size-3\.5>svg{width:.875rem;height:.875rem}.\[\&\>svg\]\:size-4>svg{width:1rem;height:1rem}.\[\&\>svg\]\:h-2\.5>svg{height:.625rem}.\[\&\>svg\]\:h-3>svg{height:.75rem}.\[\&\>svg\]\:w-2\.5>svg{width:.625rem}.\[\&\>svg\]\:w-3>svg{width:.75rem}.\[\&\>svg\]\:shrink-0>svg{flex-shrink:0}.\[\&\>svg\]\:text-destructive>svg{color:hsl(var(--destructive))}.\[\&\>svg\]\:text-foreground>svg{color:hsl(var(--foreground))}.\[\&\>svg\]\:text-muted-foreground>svg{color:hsl(var(--muted-foreground))}.\[\&\>svg\]\:text-sidebar-accent-foreground>svg{color:hsl(var(--sidebar-accent-foreground))}.\[\&\>svg\~\*\]\:pl-7>svg~*{padding-left:1.75rem}.\[\&\>tr\]\:last\:border-b-0:last-child>tr{border-bottom-width:0px}.\[\&\[data-panel-group-direction\=vertical\]\>div\]\:rotate-90[data-panel-group-direction=vertical]>div{--tw-rotate: 90deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&\[data-state\=open\]\>svg\]\:rotate-180[data-state=open]>svg{--tw-rotate: 180deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.\[\&_\.recharts-cartesian-axis-tick_text\]\:fill-muted-foreground .recharts-cartesian-axis-tick text{fill:hsl(var(--muted-foreground))}.\[\&_\.recharts-cartesian-grid_line\[stroke\=\'\#ccc\'\]\]\:stroke-border\/50 .recharts-cartesian-grid line[stroke="#ccc"]{stroke:hsl(var(--border) / .5)}.\[\&_\.recharts-curve\.recharts-tooltip-cursor\]\:stroke-border .recharts-curve.recharts-tooltip-cursor{stroke:hsl(var(--border))}.\[\&_\.recharts-dot\[stroke\=\'\#fff\'\]\]\:stroke-transparent .recharts-dot[stroke="#fff"]{stroke:transparent}.\[\&_\.recharts-layer\]\:outline-none .recharts-layer{outline:2px solid transparent;outline-offset:2px}.\[\&_\.recharts-polar-grid_\[stroke\=\'\#ccc\'\]\]\:stroke-border .recharts-polar-grid [stroke="#ccc"]{stroke:hsl(var(--border))}.\[\&_\.recharts-radial-bar-background-sector\]\:fill-muted .recharts-radial-bar-background-sector,.\[\&_\.recharts-rectangle\.recharts-tooltip-cursor\]\:fill-muted .recharts-rectangle.recharts-tooltip-cursor{fill:hsl(var(--muted))}.\[\&_\.recharts-reference-line_\[stroke\=\'\#ccc\'\]\]\:stroke-border .recharts-reference-line [stroke="#ccc"]{stroke:hsl(var(--border))}.\[\&_\.recharts-sector\[stroke\=\'\#fff\'\]\]\:stroke-transparent .recharts-sector[stroke="#fff"]{stroke:transparent}.\[\&_\.recharts-sector\]\:outline-none .recharts-sector,.\[\&_\.recharts-surface\]\:outline-none .recharts-surface{outline:2px solid transparent;outline-offset:2px}.\[\&_\[cmdk-group-heading\]\]\:px-2 [cmdk-group-heading]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-group-heading\]\]\:py-1\.5 [cmdk-group-heading]{padding-top:.375rem;padding-bottom:.375rem}.\[\&_\[cmdk-group-heading\]\]\:text-xs [cmdk-group-heading]{font-size:.75rem;line-height:1rem}.\[\&_\[cmdk-group-heading\]\]\:font-medium [cmdk-group-heading]{font-weight:500}.\[\&_\[cmdk-group-heading\]\]\:text-muted-foreground [cmdk-group-heading]{color:hsl(var(--muted-foreground))}.\[\&_\[cmdk-group\]\:not\(\[hidden\]\)_\~\[cmdk-group\]\]\:pt-0 [cmdk-group]:not([hidden])~[cmdk-group]{padding-top:0}.\[\&_\[cmdk-group\]\]\:px-2 [cmdk-group]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-input-wrapper\]_svg\]\:h-5 [cmdk-input-wrapper] svg{height:1.25rem}.\[\&_\[cmdk-input-wrapper\]_svg\]\:w-5 [cmdk-input-wrapper] svg{width:1.25rem}.\[\&_\[cmdk-input\]\]\:h-12 [cmdk-input]{height:3rem}.\[\&_\[cmdk-item\]\]\:px-2 [cmdk-item]{padding-left:.5rem;padding-right:.5rem}.\[\&_\[cmdk-item\]\]\:py-3 [cmdk-item]{padding-top:.75rem;padding-bottom:.75rem}.\[\&_\[cmdk-item\]_svg\]\:h-5 [cmdk-item] svg{height:1.25rem}.\[\&_\[cmdk-item\]_svg\]\:w-5 [cmdk-item] svg{width:1.25rem}.\[\&_p\]\:leading-relaxed p{line-height:1.625}.\[\&_svg\]\:pointer-events-none svg{pointer-events:none}.\[\&_svg\]\:size-4 svg{width:1rem;height:1rem}.\[\&_svg\]\:shrink-0 svg{flex-shrink:0}.\[\&_tr\:last-child\]\:border-0 tr:last-child{border-width:0px}.\[\&_tr\]\:border-b tr{border-bottom-width:1px}[data-side=left][data-collapsible=offcanvas] .\[\[data-side\=left\]\[data-collapsible\=offcanvas\]_\&\]\:-right-2{right:-.5rem}[data-side=left][data-state=collapsed] .\[\[data-side\=left\]\[data-state\=collapsed\]_\&\]\:cursor-e-resize{cursor:e-resize}[data-side=left] .\[\[data-side\=left\]_\&\]\:cursor-w-resize{cursor:w-resize}[data-side=right][data-collapsible=offcanvas] .\[\[data-side\=right\]\[data-collapsible\=offcanvas\]_\&\]\:-left-2{left:-.5rem}[data-side=right][data-state=collapsed] .\[\[data-side\=right\]\[data-state\=collapsed\]_\&\]\:cursor-w-resize{cursor:w-resize}[data-side=right] .\[\[data-side\=right\]_\&\]\:cursor-e-resize{cursor:e-resize}
 /* ==== BPS panel: dark theme + modern layout =============================== */
-html, body {
-    height: 100%;
-}
+html, body { height: 100%; }
 body.dark {
     background: hsl(var(--background));
     color: hsl(var(--foreground));
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     margin: 0;
 }
-.bps-app {
-    padding: 16px 20px 32px;
-}
+.bps-app { padding: 16px 22px 40px; max-width: 1600px; }
 .bps-header h1 {
     font-size: 22px;
     font-weight: 700;
     letter-spacing: -0.01em;
-    margin: 0 0 14px;
+    margin: 0 0 12px;
 }
-.bps-main {
+
+/* Tabs */
+.bps-tabs {
     display: flex;
-    gap: 16px;
-    align-items: flex-start;
+    gap: 4px;
+    border-bottom: 1px solid hsl(var(--border));
+    margin-bottom: 18px;
 }
-.bps-content {
-    flex: 1 1 auto;
-    min-width: 0;
+.bps-tab {
+    appearance: none;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    padding: 10px 18px;
+    font-size: 14px;
+    font-weight: 600;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    transition: color .12s, border-color .12s;
 }
-.bps-controls {
+.bps-tab:hover { color: hsl(var(--foreground)); }
+.bps-tab.active {
+    color: hsl(var(--foreground));
+    border-bottom-color: hsl(var(--sidebar-primary));
+}
+.bps-tabpanel { display: none; }
+.bps-tabpanel.active { display: block; }
+
+/* Main split: content + sidebar */
+.bps-main { display: flex; gap: 16px; align-items: flex-start; }
+.bps-content { flex: 1 1 auto; min-width: 0; }
+
+/* Toolbar card */
+.bps-toolbar {
     display: flex;
     flex-wrap: wrap;
-    gap: 14px;
     align-items: flex-end;
-    margin-bottom: 6px;
+    gap: 16px;
+    padding: 14px 16px;
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
 }
-.bps-field {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+.bps-field { display: flex; flex-direction: column; gap: 6px; }
+.bps-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
 }
-#mapname {
-    resize: none;
+.bps-toolsep { width: 1px; align-self: stretch; background: hsl(var(--border)); margin: 2px 2px; }
+.bps-viewrow { display: flex; align-items: center; gap: 10px; height: 40px; }
+
+/* Inputs */
+.bps-input {
     height: 40px;
-    min-width: 220px;
+    padding: 0 12px;
+    min-width: 200px;
+    border: 1px solid hsl(var(--input));
+    border-radius: 8px;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 13px;
+    font-family: inherit;
 }
+.bps-input:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 1px;
+}
+textarea#mapname { resize: none; line-height: 38px; overflow: hidden; }
+input.bps-input[type="file"] { padding: 8px 12px; height: 40px; }
+select.bps-input { cursor: pointer; }
+
+/* Buttons */
+.bps-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 16px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background .12s, border-color .12s, filter .12s;
+}
+.bps-btn-outline {
+    border-color: hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+.bps-btn-outline:hover { background: hsl(var(--accent)); }
+.bps-btn-primary { background: hsl(var(--sidebar-primary)); color: #fff; }
+.bps-btn-primary:hover { filter: brightness(1.12); }
+
+/* The tool buttons injected by script.js keep their utility classes; just
+   line them up. */
+.bps-actionbar { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 12px; }
+.bps-btnrow { display: flex; flex-wrap: wrap; gap: 8px; }
+
+/* Tracking + zone bars */
+.bps-trackbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 14px;
+    margin-top: 12px;
+    padding: 12px 16px;
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+}
+.bps-zonebar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+    font-size: 13px;
+}
+.bps-zonevalue { font-weight: 600; color: hsl(var(--foreground)); }
+
+/* Toggle switch */
+.bps-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+.bps-switch input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.bps-slider {
+    position: relative;
+    flex: 0 0 auto;
+    width: 38px;
+    height: 22px;
+    border-radius: 999px;
+    background: hsl(var(--muted));
+    transition: background .15s;
+}
+.bps-slider::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform .15s;
+}
+.bps-switch input:checked + .bps-slider { background: hsl(var(--sidebar-primary)); }
+.bps-switch input:checked + .bps-slider::after { transform: translateX(16px); }
+.bps-switch input:focus-visible + .bps-slider {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+}
+
+/* Canvas */
 .bps-canvas-wrap {
     position: relative;
-    margin-top: 8px;
+    margin-top: 14px;
     border: 1px solid hsl(var(--border));
     border-radius: 12px;
     overflow: hidden;
     background: #ffffff;
 }
+.bps-canvas-wrap canvas { display: block; width: 100%; height: auto; }
 #viewReset {
     position: absolute;
     left: 10px;
@@ -2523,20 +2666,13 @@ body.dark {
     font-weight: 600;
     border-radius: 8px;
     border: 1px solid hsl(var(--border));
-    background: hsl(var(--background) / 0.9);
+    background: hsl(var(--background) / 0.92);
     color: hsl(var(--foreground));
     cursor: pointer;
 }
-#viewReset:hover {
-    background: hsl(var(--accent));
-}
-.bps-canvas-wrap canvas {
-    display: block;
-    width: 100%;
-    height: auto;
-}
+#viewReset:hover { background: hsl(var(--accent)); }
 
-/* Right sidebar: zones with their receivers */
+/* Sidebar: zones with their receivers */
 .bps-sidebar {
     flex: 0 0 320px;
     position: sticky;
@@ -2549,11 +2685,7 @@ body.dark {
     border-radius: 12px;
     padding: 14px;
 }
-.bps-sidebar h3 {
-    font-size: 14px;
-    font-weight: 600;
-    margin: 0 0 10px;
-}
+.bps-sidebar h3 { font-size: 14px; font-weight: 600; margin: 0 0 10px; }
 .bps-zone-group {
     border: 1px solid hsl(var(--sidebar-border));
     border-radius: 8px;
@@ -2570,15 +2702,8 @@ body.dark {
     font-size: 13px;
     font-weight: 600;
 }
-.bps-zone-head .bps-count {
-    color: hsl(var(--muted-foreground));
-    font-weight: 400;
-}
-.bps-zone-group ul {
-    list-style: none;
-    margin: 0;
-    padding: 4px 0;
-}
+.bps-zone-head .bps-count { color: hsl(var(--muted-foreground)); font-weight: 400; }
+.bps-zone-group ul { list-style: none; margin: 0; padding: 4px 0; }
 .bps-zone-group li {
     display: flex;
     justify-content: space-between;
@@ -2588,14 +2713,8 @@ body.dark {
     font-size: 12.5px;
 }
 .bps-zone-group li span,
-.bps-zone-head span:first-child {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-.bps-zone-group li:hover {
-    background: hsl(var(--sidebar-accent));
-}
+.bps-zone-head span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bps-zone-group li:hover { background: hsl(var(--sidebar-accent)); }
 .bps-icon-btn {
     flex: 0 0 auto;
     display: inline-flex;
@@ -2606,37 +2725,53 @@ body.dark {
     padding: 2px;
     border-radius: 6px;
 }
-.bps-icon-btn:hover {
-    color: hsl(0 84% 60%);
-    background: hsl(var(--sidebar-accent));
-}
-.bps-empty, .bps-hint {
+.bps-icon-btn:hover { color: hsl(0 84% 60%); background: hsl(var(--sidebar-accent)); }
+.bps-empty, .bps-hint { color: hsl(var(--muted-foreground)); font-size: 12.5px; }
+.bps-hint { margin-top: 10px; }
+.bps-scale-status { margin-top: 10px; }
+.bps-scale-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 13px;
     color: hsl(var(--muted-foreground));
-    font-size: 12.5px;
-}
-.bps-hint {
-    margin-top: 10px;
-}
-.bps-scale-status {
-    margin-top: 8px;
+    margin: 4px 0;
 }
 
-/* Dark remaps for utility classes baked into markup and generated HTML */
-body.dark .text-gray-500 {
-    color: hsl(var(--muted-foreground));
+/* Calibration tab */
+.bps-card {
+    padding: 18px;
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
 }
-body.dark .bg-gray-50 {
-    background: transparent;
+.bps-section-head { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.bps-section-head h3 { font-size: 16px; font-weight: 600; margin: 0; }
+.bps-calib-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px;
+    margin-bottom: 10px;
 }
-body.dark input[type="checkbox"] {
-    accent-color: hsl(var(--sidebar-primary));
-}
-body.dark .tooltip-text {
-    background: hsl(var(--secondary));
-    color: hsl(var(--secondary-foreground));
-}
+.bps-calib-status { font-size: 13px; color: hsl(var(--muted-foreground)); margin: 6px 0 12px; }
+.bps-calib-matrix { overflow-x: auto; }
+
+/* Dark remaps for utility classes baked into generated HTML */
+body.dark .text-gray-500 { color: hsl(var(--muted-foreground)); }
+body.dark .bg-gray-50 { background: transparent; }
+body.dark input[type="checkbox"] { accent-color: hsl(var(--sidebar-primary)); }
+body.dark .tooltip-text { background: hsl(var(--secondary)); color: hsl(var(--secondary-foreground)); }
+
 /* The floating pickers sit on the (light) floor plan; keep them readable */
 .rec-input, .zone-input, .scale-input {
     background-color: #ffffff;
     color: #111111;
+}
+
+/* Small screens: sidebar drops under the map */
+@media (max-width: 1100px) {
+    .bps-main { flex-direction: column; }
+    .bps-sidebar { flex: 1 1 auto; width: 100%; position: static; max-height: none; }
 }

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -11,132 +11,152 @@
             <h1>BLE Positioning System</h1>
         </header>
 
-        <div class="bps-main">
-            <div class="bps-content container">
-                <div class="bps-controls">
-                    <div class="bps-field">
-                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Name</label>
-                        <textarea id="mapname" placeholder="Map name" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs"></textarea>
-                    </div>
-                    <div class="bps-field">
-                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Floor Plan Image</label>
-                        <input type="file" id="upload" accept="image/png, image/jpeg" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                    </div>
-                    <div class="bps-field">
-                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Select existing</label>
-                        <select id="mapSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                            <option value="">--Please choose an option--</option>
-                        </select>
-                    </div>
-                    <div class="bps-field">
-                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Move receivers</label>
-                        <div class="flex gap-2 items-center" style="height: 40px">
-                            <input type="checkbox" id="moveToggle">
-                            <span class="tooltip">❓
-                                <span class="tooltip-text">When enabled, drag receivers on the map to move them. When disabled, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
-                            </span>
+        <nav class="bps-tabs" role="tablist">
+            <button type="button" class="bps-tab active" data-tab="map" role="tab">Map &amp; Setup</button>
+            <button type="button" class="bps-tab" data-tab="calibration" role="tab">Receiver Calibration</button>
+        </nav>
+
+        <!-- ============================ MAP & SETUP ============================ -->
+        <section class="bps-tabpanel active" data-tabpanel="map">
+            <div class="bps-main">
+                <div class="bps-content">
+                    <div class="bps-toolbar">
+                        <div class="bps-field">
+                            <label class="bps-label">Floor name</label>
+                            <textarea id="mapname" placeholder="e.g. Ground floor" class="bps-input" rows="1"></textarea>
+                        </div>
+                        <div class="bps-field">
+                            <label class="bps-label">Floor plan image</label>
+                            <input type="file" id="upload" accept="image/png, image/jpeg" class="bps-input">
+                        </div>
+                        <div class="bps-field">
+                            <label class="bps-label">Select existing</label>
+                            <select id="mapSelector" class="bps-input">
+                                <option value="">-- Please choose an option --</option>
+                            </select>
+                        </div>
+                        <div class="bps-toolsep"></div>
+                        <div class="bps-field">
+                            <label class="bps-label">View</label>
+                            <div class="bps-viewrow">
+                                <label class="bps-switch">
+                                    <input type="checkbox" id="moveToggle">
+                                    <span class="bps-slider"></span>
+                                    <span>Move receivers</span>
+                                </label>
+                                <span class="tooltip">❓
+                                    <span class="tooltip-text">When on, drag receivers on the map to move them. When off, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
+                                </span>
+                                <button type="button" id="gridToggle" class="bps-btn bps-btn-outline">Grid: off</button>
+                            </div>
                         </div>
                     </div>
-                    <div class="bps-field">
-                        <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Grid</label>
-                        <button type="button" id="gridToggle" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Grid: off</button>
-                    </div>
-                </div>
 
-                <div class="flex gap-2 items-center p-1">
-                    <div class="flex gap-2" id="mapbuttondiv"></div>
-                </div>
-                <div class="flex gap-2 items-center p-1">
-                    <div class="flex gap-2" id="savebuttondiv"></div>
-                </div>
-                <div id="trackdiv" style="display: none" class="flex gap-2 items-center p-1">
-                    <div class="flex gap-2">
-                        <select id="entSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                            <option value="">--Please choose an option--</option>
-                        </select>
-                        <select id="trackerIconSelector" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                            <option value="/bps/person.svg">Person</option>
-                            <option value="/bps/beacon.svg">Beacon</option>
-                        </select>
-                        <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-xs">
-                        <button type="button" id="uploadTrackerIcon" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
-                            Upload tracker icon
-                        </button>
-                        <div class="flex gap-2 items-center p-1">
-                            <input type="checkbox" id="circleToggle">
-                            <label style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="circleToggle">Distance circles</label>
+                    <div class="bps-actionbar">
+                        <div class="bps-btnrow" id="mapbuttondiv"></div>
+                        <div class="bps-btnrow" id="savebuttondiv"></div>
+                    </div>
+
+                    <div id="trackdiv" class="bps-trackbar" style="display: none">
+                        <div class="bps-field">
+                            <label class="bps-label">Track device</label>
+                            <select id="entSelector" class="bps-input">
+                                <option value="">-- Please choose an option --</option>
+                            </select>
+                        </div>
+                        <div class="bps-field">
+                            <label class="bps-label">Tracker icon</label>
+                            <select id="trackerIconSelector" class="bps-input">
+                                <option value="/bps/person.svg">Person</option>
+                                <option value="/bps/beacon.svg">Beacon</option>
+                            </select>
+                        </div>
+                        <div class="bps-field">
+                            <label class="bps-label">Upload icon</label>
+                            <div class="bps-viewrow">
+                                <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="bps-input">
+                                <button type="button" id="uploadTrackerIcon" class="bps-btn bps-btn-outline">Upload</button>
+                            </div>
+                        </div>
+                        <div class="bps-toolsep"></div>
+                        <div class="bps-viewrow">
+                            <label class="bps-switch">
+                                <input type="checkbox" id="circleToggle">
+                                <span class="bps-slider"></span>
+                                <span>Distance circles</span>
+                            </label>
                             <span class="tooltip">❓
                                 <span class="tooltip-text">Draw each receiver's measured distance as a circle around it — where the circles intersect is where the trilateration places the device.</span>
                             </span>
+                            <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
+                            <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                         </div>
-                        <button style="display: none" type="button" id="starttrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                            Start tracking
-                        </button>
-                        <button style="display: none" type="button" id="stoptrack" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                            Stop tracking
-                        </button>
+                    </div>
+
+                    <div id="zonediv" class="bps-zonebar" style="display: none">
+                        <span class="bps-label">Current zone:</span>
+                        <span id="zonevalue" class="bps-zonevalue">xxx</span>
+                    </div>
+
+                    <div class="bps-canvas-wrap">
+                        <canvas id="canvas"></canvas>
+                        <button type="button" id="viewReset" title="Reset zoom and position">⤢ Reset view</button>
                     </div>
                 </div>
-                <div style="display: none" id="zonediv" class="flex gap-2 items-center p-1">
-                    <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Current zone:</label>
-                    <label id="zonevalue" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">xxx</label>
-                </div>
 
-                <div class="bps-canvas-wrap">
-                    <canvas id="canvas"></canvas>
-                    <button type="button" id="viewReset" title="Reset zoom and position">⤢ Reset view</button>
-                </div>
-
-                <div id="calibrationdiv" class="p-1" style="margin-top: 12px">
-                    <div class="flex items-center gap-2 mb-2">
-                        <h3 class="font-semibold">Receiver Calibration</h3>
-                        <span class="tooltip">❓
-                            <span class="tooltip-text">Compares the distances receivers measure between each other (each probe advertises an iBeacon) with their placed positions, and fits a per-receiver distance correction. Select the floor first, then sample while the house is quiet.</span>
-                        </span>
+                <aside class="bps-sidebar">
+                    <h3>Zones &amp; Receivers</h3>
+                    <div id="entitytree">
+                        <p class="bps-empty">Select a floor to see its zones and receivers.</p>
                     </div>
-                    <div class="flex gap-2 items-center p-1">
+                    <p class="bps-hint">Enable “Move receivers”, drag one on the map, then Save Floor Plan.</p>
+                    <div class="bps-scale-status">
+                        <p id="scaleok" class="bps-scale-line" style="display: none">Scale set
+                            <svg width="18" height="18" fill="hsl(142 71% 45%)" viewBox="0 0 24 24"><path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M10.8,16.8l-3.7-3.7l1.4-1.4l2.2,2.2l5.8-6.1L18,9.3L10.8,16.8z"/></svg>
+                        </p>
+                        <p id="scalenok" class="bps-scale-line" style="display: none">Scale not set
+                            <svg width="18" height="18" fill="hsl(0 84% 60%)" viewBox="0 0 32 32"><path d="M16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13zM21.961 12.209c0.244-0.244 0.244-0.641 0-0.885l-1.328-1.327c-0.244-0.244-0.641-0.244-0.885 0l-3.761 3.761-3.761-3.761c-0.244-0.244-0.641-0.244-0.885 0l-1.328 1.327c-0.244 0.244-0.244 0.641 0 0.885l3.762 3.762-3.762 3.76c-0.244 0.244-0.244 0.641 0 0.885l1.328 1.328c0.244 0.244 0.641 0.244 0.885 0l3.761-3.762 3.761 3.762c0.244 0.244 0.641 0.244 0.885 0l1.328-1.328c0.244-0.244 0.244-0.641 0-0.885l-3.762-3.76 3.762-3.762z"/></svg>
+                        </p>
+                    </div>
+                    <div id="message"></div>
+                </aside>
+            </div>
+        </section>
+
+        <!-- ============================ CALIBRATION ============================ -->
+        <section class="bps-tabpanel" data-tabpanel="calibration">
+            <div id="calibrationdiv" class="bps-card">
+                <div class="bps-section-head">
+                    <h3>Receiver Calibration</h3>
+                    <span class="tooltip">❓
+                        <span class="tooltip-text">Compares the distances receivers measure between each other (each probe advertises an iBeacon) with their placed positions, and fits a per-receiver distance correction. Select the floor first, then sample while the house is quiet.</span>
+                    </span>
+                </div>
+                <div class="bps-calib-controls">
+                    <label class="bps-switch">
                         <input type="checkbox" id="calibAuto">
-                        <label for="calibAuto" style="white-space: nowrap" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Auto calibration</label>
-                        <span class="tooltip">❓
-                            <span class="tooltip-text">Continuously samples in the background, re-solves every 15 minutes for every floor, and re-applies corrections whenever they change. Survives Home Assistant restarts.</span>
-                        </span>
-                    </div>
-                    <div class="flex gap-2 items-center p-1" id="calibManualControls">
-                        <select id="calibDuration" class="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                        <span class="bps-slider"></span>
+                        <span>Auto calibration</span>
+                    </label>
+                    <span class="tooltip">❓
+                        <span class="tooltip-text">Continuously samples in the background, re-solves every 15 minutes for every floor, and re-applies corrections whenever they change. Survives Home Assistant restarts.</span>
+                    </span>
+                    <div class="bps-btnrow" id="calibManualControls">
+                        <select id="calibDuration" class="bps-input">
                             <option value="300">Sample 5 minutes</option>
                             <option value="600" selected>Sample 10 minutes</option>
                             <option value="1800">Sample 30 minutes</option>
                         </select>
-                        <button type="button" id="calibStart" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Start calibration</button>
-                        <button type="button" id="calibCancel" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Cancel</button>
-                        <button type="button" id="calibApply" style="display: none" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Apply corrections</button>
-                        <button type="button" id="calibReset" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Reset corrections</button>
+                        <button type="button" id="calibStart" class="bps-btn bps-btn-outline">Start calibration</button>
+                        <button type="button" id="calibCancel" class="bps-btn bps-btn-outline" style="display: none">Cancel</button>
+                        <button type="button" id="calibApply" class="bps-btn bps-btn-primary" style="display: none">Apply corrections</button>
+                        <button type="button" id="calibReset" class="bps-btn bps-btn-outline">Reset corrections</button>
                     </div>
-                    <div id="calibStatus" class="text-sm text-gray-500 p-1"></div>
-                    <div id="calibResults" style="overflow-x: auto"></div>
                 </div>
+                <div id="calibStatus" class="bps-calib-status"></div>
+                <div id="calibResults" class="bps-calib-matrix"></div>
             </div>
-
-            <aside class="bps-sidebar">
-                <h3>Zones &amp; Receivers</h3>
-                <div id="entitytree">
-                    <p class="bps-empty">Select a floor to see its zones and receivers.</p>
-                </div>
-                <p class="bps-hint">Drag a receiver on the map to move it, then Save Floor Plan.</p>
-                <div class="bps-scale-status">
-                    <p id="scaleok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale set
-                        <svg width="24px" height="24px" fill="green" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" xml:space="preserve">
-                            <path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M10.8,16.8l-3.7-3.7l1.4-1.4l2.2,2.2l5.8-6.1L18,9.3L10.8,16.8z"/></svg>
-                    </p>
-                    <p id="scalenok" class="text-sm items-center justify-between text-gray-500 space-y-2 flex" style="display: none">Scale not set
-                        <svg fill="red" width="24px" height="24px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13zM21.961 12.209c0.244-0.244 0.244-0.641 0-0.885l-1.328-1.327c-0.244-0.244-0.641-0.244-0.885 0l-3.761 3.761-3.761-3.761c-0.244-0.244-0.641-0.244-0.885 0l-1.328 1.327c-0.244 0.244-0.244 0.641 0 0.885l3.762 3.762-3.762 3.76c-0.244 0.244-0.244 0.641 0 0.885l1.328 1.328c0.244 0.244 0.641 0.244 0.885 0l3.761-3.762 3.761 3.762c0.244 0.244 0.641 0.244 0.885 0l1.328-1.328c0.244-0.244 0.244-0.641 0-0.885l-3.762-3.76 3.762-3.762z"></path>
-                        </svg>
-                    </p>
-                </div>
-                <div id="message"></div>
-            </aside>
-        </div>
+        </section>
     </div>
 
     <script src="script.js"></script>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2074,6 +2074,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     pollCalibration();
 
+    // Tab switching: show one panel at a time. The Map tab is active in the
+    // markup so the canvas is visible (and sized) on load; the calibration
+    // poll keeps running regardless of which tab is showing.
+    const tabButtons = document.querySelectorAll(".bps-tab");
+    const tabPanels = document.querySelectorAll(".bps-tabpanel");
+    tabButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+            const name = btn.dataset.tab;
+            tabButtons.forEach((b) => b.classList.toggle("active", b === btn));
+            tabPanels.forEach((pnl) => pnl.classList.toggle("active", pnl.dataset.tabpanel === name));
+        });
+    });
+
     // With a single configured floor there is nothing to choose: open it
     // right away. This must run LAST — drawElements touches state declared
     // throughout this closure, so everything has to be initialized first.


### PR DESCRIPTION
Reworks the BPS side panel into a modern, tabbed layout and moves the calibration matrix off the main page.

**Tabs**
- **Map & Setup** — the floor picker, tools, tracking controls, canvas, and the Zones & Receivers sidebar.
- **Receiver Calibration** — the auto-calibration toggle, controls, status line, and the full matrix, on its own tab so it no longer crowds the setup page. Its background poll keeps running regardless of which tab is showing, so the matrix is up to date whenever you open the tab.

**Modernization**
- Controls grouped into a proper **toolbar card** (floor name / image / select + a "View" group), a clear **action row** for the tool buttons, and a dedicated **tracking bar** with labeled fields.
- The three checkboxes (Move receivers, Distance circles, Auto calibration) are now real **toggle switches**.
- Consistent dark-theme inputs and buttons; a responsive breakpoint drops the sidebar under the map on narrow screens.

**Safety**
- Every element id the script depends on is preserved; the tool buttons are still injected into `#mapbuttondiv`/`#savebuttondiv`. The only `script.js` change is a small tab-switching handler.
- The Map tab is active in the markup so the canvas is visible and sized on load; switching tabs and back doesn't disturb its coordinate math.
- Verified two ways: a static render of both tabs (screenshotted), and an adversarial review of the wiring (ids, injected-button containers, display-toggle/CSS compatibility, canvas sizing, switch label semantics) — which came back clean.

Panel-only: hard-refresh the panel after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)