### PR TITLE
Lay setup controls in columns and cap the sidebar height

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2509,17 +2509,29 @@ body.dark {
 .bps-main { display: flex; gap: 16px; align-items: flex-start; }
 .bps-content { flex: 1 1 auto; min-width: 0; }
 
-/* Toolbar card */
-.bps-toolbar {
+/* Setup: three side-by-side column cards (Floor / Tools / Tracking) */
+.bps-setup-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: stretch; }
+.bps-setup-col {
+    flex: 1 1 300px;
+    min-width: 0;
     display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 16px;
+    flex-direction: column;
+    gap: 12px;
     padding: 14px 16px;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: 12px;
 }
+.bps-col-title {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+}
+.bps-setup-col .bps-input { width: 100%; min-width: 0; }
+.bps-field-row { display: flex; gap: 10px; }
+.bps-field-row .bps-field { flex: 1 1 0; min-width: 0; }
 .bps-field { display: flex; flex-direction: column; gap: 6px; }
 .bps-label {
     font-size: 11px;
@@ -2528,8 +2540,7 @@ body.dark {
     text-transform: uppercase;
     color: hsl(var(--muted-foreground));
 }
-.bps-toolsep { width: 1px; align-self: stretch; background: hsl(var(--border)); margin: 2px 2px; }
-.bps-viewrow { display: flex; align-items: center; gap: 10px; height: 40px; }
+.bps-viewrow { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; min-height: 40px; }
 
 /* Inputs */
 .bps-input {
@@ -2577,23 +2588,11 @@ select.bps-input { cursor: pointer; }
 .bps-btn-primary { background: hsl(var(--sidebar-primary)); color: #fff; }
 .bps-btn-primary:hover { filter: brightness(1.12); }
 
-/* The tool buttons injected by script.js keep their utility classes; just
-   line them up. */
-.bps-actionbar { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 12px; }
+/* The tool buttons injected by script.js keep their utility classes; they
+   wrap inside the Tools column. */
 .bps-btnrow { display: flex; flex-wrap: wrap; gap: 8px; }
 
-/* Tracking + zone bars */
-.bps-trackbar {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 14px;
-    margin-top: 12px;
-    padding: 12px 16px;
-    background: hsl(var(--card));
-    border: 1px solid hsl(var(--border));
-    border-radius: 12px;
-}
+/* Zone bar */
 .bps-zonebar {
     display: flex;
     align-items: center;
@@ -2677,7 +2676,7 @@ select.bps-input { cursor: pointer; }
     flex: 0 0 320px;
     position: sticky;
     top: 12px;
-    max-height: calc(100vh - 24px);
+    max-height: calc(100vh - 24px); /* refined at runtime to the viewport bottom */
     overflow-y: auto;
     background: hsl(var(--sidebar-background));
     color: hsl(var(--sidebar-foreground));

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -20,76 +20,83 @@
         <section class="bps-tabpanel active" data-tabpanel="map">
             <div class="bps-main">
                 <div class="bps-content">
-                    <div class="bps-toolbar">
-                        <div class="bps-field">
-                            <label class="bps-label">Floor name</label>
-                            <textarea id="mapname" placeholder="e.g. Ground floor" class="bps-input" rows="1"></textarea>
+                    <div class="bps-setup-row">
+                        <div class="bps-setup-col">
+                            <div class="bps-col-title">Floor</div>
+                            <div class="bps-field">
+                                <label class="bps-label">Floor name</label>
+                                <textarea id="mapname" placeholder="e.g. Ground floor" class="bps-input" rows="1"></textarea>
+                            </div>
+                            <div class="bps-field">
+                                <label class="bps-label">Floor plan image</label>
+                                <input type="file" id="upload" accept="image/png, image/jpeg" class="bps-input">
+                            </div>
+                            <div class="bps-field">
+                                <label class="bps-label">Select existing</label>
+                                <select id="mapSelector" class="bps-input">
+                                    <option value="">-- Please choose an option --</option>
+                                </select>
+                            </div>
+                            <div class="bps-field">
+                                <label class="bps-label">View</label>
+                                <div class="bps-viewrow">
+                                    <label class="bps-switch">
+                                        <input type="checkbox" id="moveToggle">
+                                        <span class="bps-slider"></span>
+                                        <span>Move receivers</span>
+                                    </label>
+                                    <span class="tooltip">❓
+                                        <span class="tooltip-text">When on, drag receivers on the map to move them. When off, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
+                                    </span>
+                                    <button type="button" id="gridToggle" class="bps-btn bps-btn-outline">Grid: off</button>
+                                </div>
+                            </div>
                         </div>
-                        <div class="bps-field">
-                            <label class="bps-label">Floor plan image</label>
-                            <input type="file" id="upload" accept="image/png, image/jpeg" class="bps-input">
+
+                        <div class="bps-setup-col">
+                            <div class="bps-col-title">Tools</div>
+                            <div class="bps-btnrow" id="mapbuttondiv"></div>
+                            <div class="bps-btnrow" id="savebuttondiv"></div>
                         </div>
-                        <div class="bps-field">
-                            <label class="bps-label">Select existing</label>
-                            <select id="mapSelector" class="bps-input">
-                                <option value="">-- Please choose an option --</option>
-                            </select>
-                        </div>
-                        <div class="bps-toolsep"></div>
-                        <div class="bps-field">
-                            <label class="bps-label">View</label>
+
+                        <div id="trackdiv" class="bps-setup-col" style="display: none">
+                            <div class="bps-col-title">Tracking</div>
+                            <div class="bps-field-row">
+                                <div class="bps-field">
+                                    <label class="bps-label">Track device</label>
+                                    <select id="entSelector" class="bps-input">
+                                        <option value="">-- Please choose an option --</option>
+                                    </select>
+                                </div>
+                                <div class="bps-field">
+                                    <label class="bps-label">Tracker icon</label>
+                                    <select id="trackerIconSelector" class="bps-input">
+                                        <option value="/bps/person.svg">Person</option>
+                                        <option value="/bps/beacon.svg">Beacon</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="bps-field">
+                                <label class="bps-label">Upload icon</label>
+                                <div class="bps-viewrow">
+                                    <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="bps-input">
+                                    <button type="button" id="uploadTrackerIcon" class="bps-btn bps-btn-outline">Upload</button>
+                                </div>
+                            </div>
                             <div class="bps-viewrow">
                                 <label class="bps-switch">
-                                    <input type="checkbox" id="moveToggle">
+                                    <input type="checkbox" id="circleToggle">
                                     <span class="bps-slider"></span>
-                                    <span>Move receivers</span>
+                                    <span>Distance circles</span>
                                 </label>
                                 <span class="tooltip">❓
-                                    <span class="tooltip-text">When on, drag receivers on the map to move them. When off, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
+                                    <span class="tooltip-text">Draw each receiver's measured distance as a circle around it — where the circles intersect is where the trilateration places the device.</span>
                                 </span>
-                                <button type="button" id="gridToggle" class="bps-btn bps-btn-outline">Grid: off</button>
                             </div>
-                        </div>
-                    </div>
-
-                    <div class="bps-actionbar">
-                        <div class="bps-btnrow" id="mapbuttondiv"></div>
-                        <div class="bps-btnrow" id="savebuttondiv"></div>
-                    </div>
-
-                    <div id="trackdiv" class="bps-trackbar" style="display: none">
-                        <div class="bps-field">
-                            <label class="bps-label">Track device</label>
-                            <select id="entSelector" class="bps-input">
-                                <option value="">-- Please choose an option --</option>
-                            </select>
-                        </div>
-                        <div class="bps-field">
-                            <label class="bps-label">Tracker icon</label>
-                            <select id="trackerIconSelector" class="bps-input">
-                                <option value="/bps/person.svg">Person</option>
-                                <option value="/bps/beacon.svg">Beacon</option>
-                            </select>
-                        </div>
-                        <div class="bps-field">
-                            <label class="bps-label">Upload icon</label>
                             <div class="bps-viewrow">
-                                <input type="file" id="trackerIconUpload" accept="image/png, image/jpeg, image/webp, image/svg+xml" class="bps-input">
-                                <button type="button" id="uploadTrackerIcon" class="bps-btn bps-btn-outline">Upload</button>
+                                <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
+                                <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>
-                        </div>
-                        <div class="bps-toolsep"></div>
-                        <div class="bps-viewrow">
-                            <label class="bps-switch">
-                                <input type="checkbox" id="circleToggle">
-                                <span class="bps-slider"></span>
-                                <span>Distance circles</span>
-                            </label>
-                            <span class="tooltip">❓
-                                <span class="tooltip-text">Draw each receiver's measured distance as a circle around it — where the circles intersect is where the trilateration places the device.</span>
-                            </span>
-                            <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
-                            <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                         </div>
                     </div>
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2084,8 +2084,31 @@ document.addEventListener('DOMContentLoaded', async () => {
             const name = btn.dataset.tab;
             tabButtons.forEach((b) => b.classList.toggle("active", b === btn));
             tabPanels.forEach((pnl) => pnl.classList.toggle("active", pnl.dataset.tabpanel === name));
+            scheduleSidebarSync(); // sidebar becomes visible/hidden with the tab
         });
     });
+
+    // Cap the Zones & Receivers sidebar at the bottom of the viewport so a long
+    // receiver list scrolls inside it instead of running off-screen. In the
+    // stacked (narrow) layout the sidebar isn't sticky, so leave it uncapped.
+    let sidebarRaf = null;
+    function syncSidebarHeight() {
+        const sb = document.querySelector(".bps-sidebar");
+        if (!sb) return;
+        if (getComputedStyle(sb).position !== "sticky") {
+            sb.style.maxHeight = "";
+            return;
+        }
+        const top = sb.getBoundingClientRect().top;
+        sb.style.maxHeight = Math.max(200, window.innerHeight - top - 12) + "px";
+    }
+    function scheduleSidebarSync() {
+        if (sidebarRaf) return;
+        sidebarRaf = requestAnimationFrame(() => { sidebarRaf = null; syncSidebarHeight(); });
+    }
+    window.addEventListener("resize", scheduleSidebarSync);
+    window.addEventListener("scroll", scheduleSidebarSync, { passive: true });
+    syncSidebarHeight();
 
     // With a single configured floor there is nothing to choose: open it
     // right away. This must run LAST — drawElements touches state declared


### PR DESCRIPTION
Two panel-layout improvements on top of the tabbed UI (#21):

- **Three setup sections side by side.** Floor, Tools, and Tracking are now column cards in a row instead of three stacked full-width bars, reclaiming a lot of vertical space so the floor plan is larger. Inside the Tracking column, the **Track device** and **Tracker icon** selectors share one row.
- **Sidebar capped at the viewport bottom.** The Zones & Receivers list no longer runs off-screen — its height is pinned so the bottom sits at the viewport edge and the list scrolls internally. The cap is computed at runtime from the sidebar's position (rAF-throttled on scroll/resize) and cleared in the narrow stacked layout where the sidebar isn't sticky.

All element ids are preserved; the tool buttons still inject into the Tools column. Verified with a static render (screenshotted — three columns, side-by-side track fields, internally-scrolling sidebar) and an adversarial review of the sidebar JS and integration (no TDZ, no scroll feedback loop, no dead class refs) — both clean.

Panel-only: hard-refresh after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)