### PR TITLE
Halve the setup columns' height and remove the page title

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2469,7 +2469,7 @@ body.dark {
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     margin: 0;
 }
-.bps-app { padding: 16px 22px 40px; max-width: 1600px; }
+.bps-app { padding: 12px 22px 40px; max-width: 1600px; }
 .bps-header h1 {
     font-size: 22px;
     font-weight: 700;
@@ -2482,7 +2482,7 @@ body.dark {
     display: flex;
     gap: 4px;
     border-bottom: 1px solid hsl(var(--border));
-    margin-bottom: 18px;
+    margin-bottom: 14px;
 }
 .bps-tab {
     appearance: none;
@@ -2516,12 +2516,15 @@ body.dark {
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    padding: 14px 16px;
+    gap: 6px;
+    padding: 8px 12px;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: 12px;
 }
+/* Tool buttons: two per row, compact height */
+.bps-setup-col .bps-btnrow { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.bps-setup-col .bps-btnrow button { height: 30px; padding-top: 0; padding-bottom: 0; }
 .bps-col-title {
     font-size: 12px;
     font-weight: 700;
@@ -2532,7 +2535,7 @@ body.dark {
 .bps-setup-col .bps-input { width: 100%; min-width: 0; }
 .bps-field-row { display: flex; gap: 10px; }
 .bps-field-row .bps-field { flex: 1 1 0; min-width: 0; }
-.bps-field { display: flex; flex-direction: column; gap: 6px; }
+.bps-field { display: flex; flex-direction: column; gap: 3px; }
 .bps-label {
     font-size: 11px;
     font-weight: 600;
@@ -2540,13 +2543,13 @@ body.dark {
     text-transform: uppercase;
     color: hsl(var(--muted-foreground));
 }
-.bps-viewrow { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; min-height: 40px; }
+.bps-viewrow { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; min-height: 30px; }
 
 /* Inputs */
 .bps-input {
-    height: 40px;
-    padding: 0 12px;
-    min-width: 200px;
+    height: 30px;
+    padding: 0 10px;
+    min-width: 160px;
     border: 1px solid hsl(var(--input));
     border-radius: 8px;
     background: hsl(var(--background));
@@ -2558,8 +2561,8 @@ body.dark {
     outline: 2px solid hsl(var(--ring));
     outline-offset: 1px;
 }
-textarea#mapname { resize: none; line-height: 38px; overflow: hidden; }
-input.bps-input[type="file"] { padding: 8px 12px; height: 40px; }
+textarea#mapname { resize: none; line-height: 28px; overflow: hidden; }
+input.bps-input[type="file"] { padding: 4px 10px; height: 30px; }
 select.bps-input { cursor: pointer; }
 
 /* Buttons */
@@ -2568,8 +2571,8 @@ select.bps-input { cursor: pointer; }
     align-items: center;
     justify-content: center;
     gap: 8px;
-    height: 40px;
-    padding: 0 16px;
+    height: 30px;
+    padding: 0 12px;
     border-radius: 8px;
     border: 1px solid transparent;
     font-size: 13px;
@@ -2622,8 +2625,8 @@ select.bps-input { cursor: pointer; }
 .bps-slider {
     position: relative;
     flex: 0 0 auto;
-    width: 38px;
-    height: 22px;
+    width: 34px;
+    height: 20px;
     border-radius: 999px;
     background: hsl(var(--muted));
     transition: background .15s;
@@ -2633,14 +2636,13 @@ select.bps-input { cursor: pointer; }
     position: absolute;
     top: 2px;
     left: 2px;
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     background: #fff;
     transition: transform .15s;
 }
-.bps-switch input:checked + .bps-slider { background: hsl(var(--sidebar-primary)); }
-.bps-switch input:checked + .bps-slider::after { transform: translateX(16px); }
+.bps-switch input:checked + .bps-slider::after { transform: translateX(14px); }
 .bps-switch input:focus-visible + .bps-slider {
     outline: 2px solid hsl(var(--ring));
     outline-offset: 2px;
@@ -2649,7 +2651,7 @@ select.bps-input { cursor: pointer; }
 /* Canvas */
 .bps-canvas-wrap {
     position: relative;
-    margin-top: 14px;
+    margin-top: 10px;
     border: 1px solid hsl(var(--border));
     border-radius: 12px;
     overflow: hidden;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -7,10 +7,6 @@
 </head>
 <body class="dark">
     <div class="bps-app">
-        <header class="bps-header">
-            <h1>BLE Positioning System</h1>
-        </header>
-
         <nav class="bps-tabs" role="tablist">
             <button type="button" class="bps-tab active" data-tab="map" role="tab">Map &amp; Setup</button>
             <button type="button" class="bps-tab" data-tab="calibration" role="tab">Receiver Calibration</button>
@@ -23,32 +19,36 @@
                     <div class="bps-setup-row">
                         <div class="bps-setup-col">
                             <div class="bps-col-title">Floor</div>
-                            <div class="bps-field">
-                                <label class="bps-label">Floor name</label>
-                                <textarea id="mapname" placeholder="e.g. Ground floor" class="bps-input" rows="1"></textarea>
+                            <div class="bps-field-row">
+                                <div class="bps-field">
+                                    <label class="bps-label">Floor name</label>
+                                    <textarea id="mapname" placeholder="e.g. Ground floor" class="bps-input" rows="1"></textarea>
+                                </div>
+                                <div class="bps-field">
+                                    <label class="bps-label">Select existing</label>
+                                    <select id="mapSelector" class="bps-input">
+                                        <option value="">-- Please choose an option --</option>
+                                    </select>
+                                </div>
                             </div>
-                            <div class="bps-field">
-                                <label class="bps-label">Floor plan image</label>
-                                <input type="file" id="upload" accept="image/png, image/jpeg" class="bps-input">
-                            </div>
-                            <div class="bps-field">
-                                <label class="bps-label">Select existing</label>
-                                <select id="mapSelector" class="bps-input">
-                                    <option value="">-- Please choose an option --</option>
-                                </select>
-                            </div>
-                            <div class="bps-field">
-                                <label class="bps-label">View</label>
-                                <div class="bps-viewrow">
-                                    <label class="bps-switch">
-                                        <input type="checkbox" id="moveToggle">
-                                        <span class="bps-slider"></span>
-                                        <span>Move receivers</span>
-                                    </label>
-                                    <span class="tooltip">❓
-                                        <span class="tooltip-text">When on, drag receivers on the map to move them. When off, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
-                                    </span>
-                                    <button type="button" id="gridToggle" class="bps-btn bps-btn-outline">Grid: off</button>
+                            <div class="bps-field-row">
+                                <div class="bps-field">
+                                    <label class="bps-label">Floor plan image</label>
+                                    <input type="file" id="upload" accept="image/png, image/jpeg" class="bps-input">
+                                </div>
+                                <div class="bps-field">
+                                    <label class="bps-label">View</label>
+                                    <div class="bps-viewrow">
+                                        <label class="bps-switch">
+                                            <input type="checkbox" id="moveToggle">
+                                            <span class="bps-slider"></span>
+                                            <span>Move</span>
+                                        </label>
+                                        <span class="tooltip">❓
+                                            <span class="tooltip-text">When on, drag receivers on the map to move them. When off, dragging pans the map and clicking a receiver focuses it (only that receiver and its circle stay visible).</span>
+                                        </span>
+                                        <button type="button" id="gridToggle" class="bps-btn bps-btn-outline">Grid: off</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -92,8 +92,6 @@
                                 <span class="tooltip">❓
                                     <span class="tooltip-text">Draw each receiver's measured distance as a circle around it — where the circles intersect is where the trilateration places the device.</span>
                                 </span>
-                            </div>
-                            <div class="bps-viewrow">
                                 <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
                                 <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>


### PR DESCRIPTION
Two space optimizations for the Map & Setup tab:

- **Removed the "BLE Positioning System" title** — the tab bar already identifies the panel.
- **Halved the Floor / Tools / Tracking columns** (~400px → ~220px) so the floor plan gets the reclaimed vertical space:
  - Floor: *name + select* on one row, *image + view* on another (two rows instead of four).
  - Tools: the injected tool buttons now lay out two-per-row in a grid.
  - Tracking: the distance-circles toggle and Start/Stop share one row.
  - Control heights, padding, and gaps tightened throughout.

All element ids are preserved. Verified with a static render — three equal ~220px columns, all controls present and readable, tool buttons fitting two-per-row, and the sidebar still scrolling internally.

Panel-only: hard-refresh after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)