### PR TITLE
Ultrawide: 80% map with equal side columns

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2529,9 +2529,9 @@ body {
     .bps-app { max-width: none; } /* use the full ultrawide width */
     .bps-main {
         display: grid;
-        /* Give the stacked setup sections a generous, growing share of the
-           extra width; the map stays the largest column, the sidebar fixed. */
-        grid-template-columns: minmax(360px, 1fr) minmax(0, 1.5fr) minmax(300px, 340px);
+        /* Map takes ~80% of the width; the setup column on the left and the
+           zones column on the right are equal (~10% each). */
+        grid-template-columns: minmax(240px, 1fr) minmax(0, 8fr) minmax(240px, 1fr);
         grid-template-rows: auto 1fr;
         align-items: start;
     }


### PR DESCRIPTION
Follow-up to the 32:9 ultrawide layout (#25). In that first pass the setup column had grown to roughly a third of the width while the zones sidebar stayed pinned at 340px. This rebalances the three-column grid so the map is the clear focus:

- **Map ≈ 80%** of the row.
- **Setup (left) and Zones (right) columns are equal**, ~10% each, with a `minmax(240px, 1fr)` floor so they stay usable on narrower ultrawide screens.

One-line change to `grid-template-columns` inside the existing `@media (min-width: 1600px) and (min-aspect-ratio: 5/2)` block — the normal (non-ultrawide) layout is untouched.

Verified by rendering at 3840×1080 (32:9): setup 376px, map 3011px, sidebar 376px — left equals right exactly, and the map is 80% of the track space.

Panel-only: hard-refresh after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)