### PR TITLE
Fill the full viewport width; keep the map within the viewport height

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2469,7 +2469,7 @@ body {
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     margin: 0;
 }
-.bps-app { padding: 12px 22px 40px; max-width: 1600px; }
+.bps-app { padding: 12px 22px 40px; }
 .bps-header h1 {
     font-size: 22px;
     font-weight: 700;
@@ -2526,7 +2526,6 @@ body {
    .bps-content becomes display:contents so its children (setup row, zone bar,
    canvas) join the grid directly. */
 @media (min-width: 1600px) and (min-aspect-ratio: 5/2) {
-    .bps-app { max-width: none; } /* use the full ultrawide width */
     .bps-main {
         display: grid;
         /* Map takes ~80% of the width; the setup column on the left and the
@@ -2693,7 +2692,26 @@ select.bps-input { cursor: pointer; }
     overflow: hidden;
     background: #ffffff;
 }
-.bps-canvas-wrap canvas { display: block; width: 100%; height: auto; }
+.bps-canvas-wrap canvas {
+    display: block;
+    /* Fit the map within the available width AND the viewport height, preserving
+       the plan's aspect ratio (width:auto + max-width caps display at the 2000px
+       drawing buffer and centers with margin:auto). Without the max-height, a
+       square/portrait floor-plan on a wide monitor would grow taller than the
+       viewport and push the map (and Reset-view button) below the fold. */
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: calc(100vh - 320px);
+    margin: 0 auto;
+}
+/* In the ultrawide grid the map fills the 80% column. This must come AFTER the
+   fit-to-box rule above: media queries don't add specificity, so an override
+   placed earlier (inside the ultrawide grid block) would lose the source-order
+   tie to the base rule and the map would cap at the 2000px buffer instead. */
+@media (min-width: 1600px) and (min-aspect-ratio: 5/2) {
+    .bps-canvas-wrap canvas { width: 100%; max-height: none; }
+}
 #viewReset {
     position: absolute;
     left: 10px;


### PR DESCRIPTION
### Dead space
The panel was capped at `max-width: 1600px` with **no** `margin: 0 auto`, so on any viewport wider than 1600px that isn't 32:9 ultrawide, it stayed left-aligned and left a band of dead space on the right (visible e.g. at ~1836px). This drops the cap so the app fills the width at every resolution. The now-redundant ultrawide `max-width: none` override is removed too.

### Guard against the side effect
Filling the width uncapped the map canvas, which is width-driven with its height following the **uploaded plan's** aspect ratio (buffer is fixed at 2000px wide, height from the image). A **square or portrait** floor-plan on a wide monitor would then render taller than the viewport and push the map + Reset-view button below the fold. So the canvas is now **fit-to-box**:

- `max-width: 100%` + `width: auto` cap display at the 2000px drawing buffer and center it (`margin: 0 auto`);
- `max-height: calc(100vh - 320px)` keeps it within the viewport;
- aspect ratio is always preserved (no distortion), and in the **ultrawide grid** the map still fills its 80% column via a later, source-order-correct media query (`width: 100%; max-height: none`).

Click/drag coordinate mapping is unaffected — it reads `getBoundingClientRect` per event, so it adapts to whatever display size the CSS produces (verified in the source).

### Verification
Measured live (via `getBoundingClientRect`) across regimes and plan shapes:

| Viewport | Plan | Result |
|---|---|---|
| 1836×920 (target) | landscape | app fills width, **right dead space 0**, map fills column, no overflow |
| 2560×1440 | landscape | fills width; map crisp at 2000px buffer, centered; no overflow |
| 2560×1440 | square | map letterboxed 1120×1120, **no vertical overflow** (was heading for ~2180×2180 off-screen) |
| 3840×1080 (32:9) | landscape | grid, map fills **80%** (3009px), aspect preserved, no overflow |
| 1000×800 (<1100) | landscape | stacked, sidebar full-width, no overflow |

No horizontal scroll in any case.

Panel-only: hard-refresh after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)