### PR TITLE
Normalize Bermuda distance_to units (feet/meters) to meters

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -10,6 +10,8 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.template import Template
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.const import UnitOfLength
+from homeassistant.util.unit_conversion import DistanceConverter
 import numpy as np
 from scipy.optimize import least_squares
 import voluptuous as vol
@@ -167,6 +169,15 @@ async def update_receiver_radii(hass, eids):
             if rec_value is not None:
                 try:
                     distance = float(rec_value.state)
+                    # Bermuda's distance_to sensors can report in feet or
+                    # meters, chosen per entity. The floor scale and the
+                    # calibration corrections are both in meters, so normalize
+                    # to meters first — otherwise a feet sensor reads ~3.28x too
+                    # far (treated as metres), inflating its circle and pulling
+                    # the trilateration toward it.
+                    unit = rec_value.attributes.get("unit_of_measurement")
+                    if unit in DistanceConverter.VALID_UNITS and unit != UnitOfLength.METERS:
+                        distance = DistanceConverter.convert(distance, unit, UnitOfLength.METERS)
                     # Per-receiver correction factor learned by the
                     # calibration (calibration.py); equivalent to a
                     # per-scanner RSSI offset in Bermuda's exponential model.


### PR DESCRIPTION
### Problem
Bermuda's `<device>_distance_to_<receiver>` sensors can report in **feet or meters**, chosen per entity. `update_receiver_radii` read `float(rec_value.state)` and treated the number as **meters unconditionally** — so a feet-configured receiver was read as ~3.28× too far. Its distance circle was inflated and it pulled the trilateration toward itself; the panel pill showed the wrong number, mislabeled "m".

Reported on the Bermuda tracker ([issue #21](https://github.com/agittins/bermuda/issues/21#issuecomment-4896062150)): a scanner reading **7.1 ft** with a ~1.25 correction rendered as **8.8 m** instead of ~2.7 m.

### Fix
Read the sensor's `unit_of_measurement` and convert to meters with `DistanceConverter` before applying the per-receiver correction and the floor's pixel scale:

```python
unit = rec_value.attributes.get("unit_of_measurement")
if unit in DistanceConverter.VALID_UNITS and unit != UnitOfLength.METERS:
    distance = DistanceConverter.convert(distance, unit, UnitOfLength.METERS)
```

- **Feet** → converted (7.1 ft × 1.25 → **2.71 m**, was 8.88 "m").
- **Meters / unknown / absent unit** → unchanged, so correctly-configured meter sensors are unaffected (10.80 m × 0.5571 → **6.02 m**, same as before).

### Why calibration didn't need changing
Calibration samples `bermuda.dump_devices` `rssi_distance_raw`, which is always meters, so the learned corrections were already unit-consistent — only *live tracking* misread the per-entity display unit. As a bonus, the cross-floor "closest receiver" election now compares distances in a consistent unit too.

Verified: `py_compile` clean; a standalone replication of normalize→correct→scale confirms the feet case is fixed and the meters case is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)