### PR TITLE
Rebrand to BPS-improved (manifest, README, card) and bump to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Lovelace card
 Install this fork through HACS as a custom repository:
 
 1. HACS → **Integrations** → ⋮ → **Custom repositories**.
-2. Repository: `maxi1134/BPS`, Category: `Integration`. Click **Add**.
+2. Repository: `maxi1134/BPS-improved`, Category: `Integration`. Click **Add**.
 3. Install **BLE Positioning System**, restart Home Assistant, then add the
    integration under **Settings → Devices & Services → Add Integration → BPS**.
 
@@ -338,7 +338,7 @@ troubleshooting) is in the [upstream wiki](https://github.com/Hogster/BPS/wiki/L
 ## Feedback & contributions
 
 Issues and pull requests for these additions are welcome on
-[maxi1134/BPS](https://github.com/maxi1134/BPS). For the core integration and
+[maxi1134/BPS-improved](https://github.com/maxi1134/BPS-improved). For the core integration and
 general BPS discussion, see [Hogster/BPS](https://github.com/Hogster/BPS) and
 the [Home Assistant Community thread](https://community.home-assistant.io/t/bps-the-indoor-precise-tracking-system/843429).
 

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -1038,5 +1038,5 @@ window.customCards.push({
   name: "BPS Map",
   description: "Show one or more BPS trackers on a floor plan.",
   preview: true,
-  documentationURL: "https://github.com/Hogster/BPS",
+  documentationURL: "https://github.com/maxi1134/BPS-improved",
 });

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -1,13 +1,13 @@
 {
     "domain": "bps",
     "name": "BLE Positioning System",
-    "codeowners": ["@Hogster"],
+    "codeowners": ["@maxi1134"],
     "config_flow": true,
     "dependencies": ["http"],
-    "documentation": "https://github.com/Hogster/BPS",
+    "documentation": "https://github.com/maxi1134/BPS-improved",
     "integration_type": "device",
     "iot_class": "calculated",
-    "issue_tracker": "https://github.com/Hogster/BPS/issues",
+    "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "0.1.5"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
Reflects the repo rename to **maxi1134/BPS-improved** and cuts a release version.

**manifest.json**
- `documentation` → `https://github.com/maxi1134/BPS-improved`
- `issue_tracker` → `https://github.com/maxi1134/BPS-improved/issues`
- `codeowners` → `@maxi1134`
- `version` → **1.0.1** (was 0.1.5)

**README.md**
- HACS custom-repository install instruction → `maxi1134/BPS-improved`
- "Feedback & contributions" link (this fork's issues/PRs) → `maxi1134/BPS-improved`

**bps-map-card.js**
- Lovelace card `documentationURL` → `maxi1134/BPS-improved`

**Deliberately left as-is:** `domain: "bps"` (renaming it breaks existing entity IDs and stored config), the upstream references that describe the fork source / credits / upstream README & wiki (`Hogster/BPS`), and the `LICENSE` copyright (stays with the original author under MIT). Only metadata/links changed — no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)