### PR TITLE
Sub-zones + editable zones/sub-zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,31 @@ Zones are no longer limited to rectangles. When drawing a zone:
 - **Drag a corner** to adjust it, or **drag inside the zone** to move the whole
   shape. Dragging is clamped so a corner can never end up off-screen (the old
   trap where an off-canvas handle became ungrabbable).
-- **Right-click** removes the last corner.
+- **Right-click a corner to delete it** (right-clicking empty space removes the
+  last corner you placed). A zone always keeps at least three corners.
 
 Zones drawn with the old rectangle tool keep working unchanged.
+
+**Editing a saved zone:** click the ✎ pencil next to a zone in the **Zones &
+Receivers** sidebar to reopen it in the editor — drag its corners, drag the whole
+shape, add or right-click-delete corners, then **Save Zone**.
+
+## Sub-zones
+
+Sub-zones are smaller polygons drawn **inside** a zone — a couch, a bed, a desk,
+a reading nook — for when "which room" isn't precise enough.
+
+- Click **Draw Sub-Zone**, then click inside the zone you want it in (that becomes
+  its **parent**) and place corners just like a zone. Every corner is **kept inside
+  the parent zone**, and each sub-zone gets its own color. Sub-zones are editable
+  the same way zones are (✎ pencil in the sidebar).
+- Sub-zones are listed under their parent in the sidebar, each with edit and delete
+  buttons; deleting a zone removes its sub-zones with it.
+- Each tracked device gets a **`sensor.<device>_bps_sub_zone`** entity whose state
+  is the sub-zone it is currently in (`unknown` when in none), with a
+  **`parent_zone`** attribute naming the enclosing zone.
+- The Lovelace map card can draw sub-zones too — enable **Show sub-zones**
+  (`show_sub_zones: true`) in the card config.
 
 ## Pre-populated receiver picker
 

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -807,7 +807,14 @@ class BPSFrontendView(HomeAssistantView):
             _LOGGER.error(f"Requested file not found: {frontend_path}")
             return web.Response(status=404, text="File not found")
 
-        return web.FileResponse(path=str(frontend_path))
+        response = web.FileResponse(path=str(frontend_path))
+        # The panel's script.js/CSS change on every integration update. Without
+        # an explicit directive, browsers cache these heuristically and keep
+        # serving the old panel after an update. "no-cache" keeps the cached
+        # copy but forces revalidation (a cheap 304 when unchanged, the new file
+        # when it changed), so updates show up on a normal reload.
+        response.headers["Cache-Control"] = "no-cache"
+        return response
 
 class BPSSaveAPIText(HomeAssistantView):
     """Handle saving of BPS coordinates to a text file."""

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -286,6 +286,10 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
             avg_x, avg_y = float(snapped.x), float(snapped.y)
         zone = find_zone_for_point(new_global_data, entity, lowest_floor_name, test_point)
         nearest_zone = find_nearest_zone(new_global_data, entity, lowest_floor_name, test_point)
+        sub_zone, sub_parent = find_sub_zone_for_point(new_global_data, entity, lowest_floor_name, test_point)
+        # parent_zone always names the enclosing main zone: the sub-zone's
+        # declared parent when inside one, otherwise the current main zone.
+        parent_zone = sub_parent if sub_parent else zone
         apitricords = update_or_add_entry(
             apitricords,
             {
@@ -303,6 +307,7 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", nearest_zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_floor", lowest_floor_name)
+        update_bps_sensor_state(hass, f"sensor.{entity}_bps_sub_zone", sub_zone, {"parent_zone": parent_zone})
 
 def update_or_add_entry(data, new_entry):
     for item in data:
@@ -343,6 +348,7 @@ async def prune_stale_positions(hass):
         update_bps_sensor_state(hass, f"sensor.{ent}_bps_zone", "unknown")
         update_bps_sensor_state(hass, f"sensor.{ent}_bps_floor", "unknown")
         update_bps_sensor_state(hass, f"sensor.{ent}_bps_nearest_zone", "unknown")
+        update_bps_sensor_state(hass, f"sensor.{ent}_bps_sub_zone", "unknown", {"parent_zone": "unknown"})
 
 async def update_apitricords(hass, new_data):
     """Update apitricords in hass.data"""
@@ -350,8 +356,8 @@ async def update_apitricords(hass, new_data):
     hass.data[DOMAIN]["apitricords"] = new_data
 
 
-def update_bps_sensor_state(hass, entity_id, state):
-    """Update state on registered BPS SensorEntity instead of raw hass state."""
+def update_bps_sensor_state(hass, entity_id, state, attributes=None):
+    """Update state (and optional extra attributes) on a registered BPS SensorEntity."""
     sensors_cache = hass.data.get("bps_sensors")
     if not sensors_cache:
         return
@@ -359,6 +365,8 @@ def update_bps_sensor_state(hass, entity_id, state):
     if sensor is None:
         return
     sensor._state = state
+    if attributes is not None:
+        sensor._attrs = attributes
     sensor.async_write_ha_state()
 
 async def process_single_entity(hass, new_global_data, eids):
@@ -510,6 +518,55 @@ def find_nearest_zone(data, entity, floor_name, point):
         if nearest_distance is None or distance < nearest_distance:
             nearest_id, nearest_distance = zone_id, distance
     return nearest_id
+
+
+def _floor_sub_zone_polygons(data, entity, floor_name):
+    """Yield (sub-zone name, parent zone name, polygon) for the entity's floor.
+
+    Sub-zones are small precise areas drawn inside a zone (a couch, a desk), so
+    they are matched strictly (no soft buffer). They live in a separate
+    "subzones" list, so the main-zone election/snap/nearest logic is untouched.
+    """
+    for entity_data in data:
+        if entity_data["entity"] != entity:
+            continue
+        for floor in entity_data["data"]["floor"]:
+            if floor["name"] != floor_name:
+                continue
+            # Sub-zones link to their parent by the zone's stable id; resolve it
+            # to the zone's display name for the parent_zone attribute.
+            zone_name_by_id = {}
+            for z in floor.get("zones") or []:
+                zone_name_by_id[z.get("zone_id") or z.get("entity_id")] = z.get("entity_id")
+            for sub in floor.get("subzones") or []:
+                coords = sub.get("cords") or []
+                if len(coords) < 3:
+                    continue
+                polygon = Polygon([(c["x"], c["y"]) for c in coords])
+                if not polygon.is_valid:
+                    repaired = (
+                        shapely_make_valid(polygon)
+                        if shapely_make_valid
+                        else polygon.buffer(0)
+                    )
+                    if repaired is None or repaired.is_empty:
+                        continue
+                    polygon = repaired
+                parent_ref = sub.get("parent")
+                yield sub.get("entity_id"), zone_name_by_id.get(parent_ref, parent_ref), polygon
+
+
+def find_sub_zone_for_point(data, entity, floor_name, point):
+    """The sub-zone containing the point and its parent zone name.
+
+    Returns (sub_zone_name, parent_zone_name); ("unknown", None) when the point
+    is in no sub-zone.
+    """
+    for sub_id, parent_id, polygon in _floor_sub_zone_polygons(data, entity, floor_name):
+        if polygon.covers(point):
+            return sub_id, parent_id
+    return "unknown", None
+
 
 async def async_setup(hass, config):
     """Set up the BPS integration."""
@@ -706,7 +763,7 @@ async def async_unload_entry(hass: HomeAssistant, entry):
         state.entity_id
         for state in hass.states.async_all()
         if state.entity_id.startswith("sensor.")
-        and state.entity_id.endswith(("_bps_zone", "_bps_floor", "_bps_nearest_zone"))
+        and state.entity_id.endswith(("_bps_zone", "_bps_floor", "_bps_nearest_zone", "_bps_sub_zone"))
     ]
     for entity_id in bps_state_ids:
         hass.states.async_remove(entity_id)

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -88,6 +88,7 @@ class BpsMapCard extends HTMLElement {
     this._iconCache = new Map();
     this._tintedIconCache = new Map();
     this._receivers = [];
+    this._subzones = [];
     this._receiverStatuses = new Map();
     this._bermudaScanners = null;
     this._bermudaDumpAt = 0;
@@ -126,6 +127,7 @@ class BpsMapCard extends HTMLElement {
       map_file: config.map_file || "",
       show_receivers: Boolean(config.show_receivers),
       show_receiver_labels: Boolean(config.show_receiver_labels),
+      show_sub_zones: Boolean(config.show_sub_zones),
       scale_receiver_icon: BpsMapCard.inheritPercent(config.scale_receiver_icon, config.scale_icon),
       scale_receiver_labels: BpsMapCard.inheritPercent(config.scale_receiver_labels, config.scale_labels),
       receiver_timeout:
@@ -144,6 +146,7 @@ class BpsMapCard extends HTMLElement {
     this._bootstrapPromise = null;
     this._positions.clear();
     this._receivers = [];
+    this._subzones = [];
     this._receiverStatuses = new Map();
     // A reconfigure gets an immediate dump attempt; the previous scanner map
     // is kept to bridge the gap until it lands.
@@ -177,6 +180,7 @@ class BpsMapCard extends HTMLElement {
       poll_interval: 3,
       show_receivers: false,
       show_receiver_labels: false,
+      show_sub_zones: false,
     };
   }
 
@@ -613,6 +617,9 @@ class BpsMapCard extends HTMLElement {
     this._receivers = Array.isArray(floor.receivers)
       ? floor.receivers.filter((r) => r && r.entity_id && r.cords && r.cords.x != null && r.cords.y != null)
       : [];
+    this._subzones = Array.isArray(floor.subzones)
+      ? floor.subzones.filter((s) => s && Array.isArray(s.cords) && s.cords.length >= 3)
+      : [];
     await this._refreshBermudaScanners();
     this._receiverStatuses = this._computeReceiverStatuses();
     if (expectedGen !== this._runGeneration) {
@@ -752,6 +759,31 @@ class BpsMapCard extends HTMLElement {
     ctx.restore();
   }
 
+  _drawSubZones() {
+    if (!this._config?.show_sub_zones || !this._imgNaturalW) return;
+    const subs = this._subzones || [];
+    if (!subs.length) return;
+    const ctx = this._canvas.getContext("2d");
+    ctx.save();
+    for (const sub of subs) {
+      const pts = sub.cords || [];
+      if (pts.length < 3) continue;
+      const color = sub.color || "#3f51b5";
+      ctx.beginPath();
+      ctx.moveTo(Number(pts[0].x), Number(pts[0].y));
+      for (let i = 1; i < pts.length; i++) ctx.lineTo(Number(pts[i].x), Number(pts[i].y));
+      ctx.closePath();
+      ctx.globalAlpha = 0.18;
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
   _drawReceivers() {
     if (!this._config?.show_receivers || !this._imgNaturalW || this._receivers.length === 0) return;
     const ctx = this._canvas.getContext("2d");
@@ -798,6 +830,7 @@ class BpsMapCard extends HTMLElement {
 
   _redraw() {
     this._drawBase();
+    this._drawSubZones();
     this._drawReceivers();
     this._drawMarkers();
   }
@@ -1013,6 +1046,23 @@ class BpsMapCardEditor extends HTMLElement {
     recLabelsRow.appendChild(recLabelsLabel);
     recLabelsRow.appendChild(recLabelsCb);
     root.appendChild(recLabelsRow);
+
+    const subZoneRow = document.createElement("div");
+    subZoneRow.style.marginBottom = "8px";
+    const subZoneLabel = document.createElement("label");
+    subZoneLabel.textContent = "Show sub-zones";
+    subZoneLabel.style.display = "block";
+    subZoneLabel.style.fontSize = "12px";
+    const subZoneCb = document.createElement("input");
+    subZoneCb.type = "checkbox";
+    subZoneCb.checked = Boolean(this._config.show_sub_zones);
+    subZoneCb.addEventListener("change", () => {
+      this._config.show_sub_zones = subZoneCb.checked;
+      this._fire();
+    });
+    subZoneRow.appendChild(subZoneLabel);
+    subZoneRow.appendChild(subZoneCb);
+    root.appendChild(subZoneRow);
 
     this.appendChild(root);
   }

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2781,6 +2781,11 @@ select.bps-input { cursor: pointer; }
     border-radius: 6px;
 }
 .bps-icon-btn:hover { color: hsl(0 84% 60%); background: hsl(var(--sidebar-accent)); }
+.bps-zone-actions { display: inline-flex; gap: 2px; flex: 0 0 auto; }
+.bps-subzone-list { padding-left: 16px !important; }
+.bps-subzone-row { justify-content: flex-start; }
+.bps-subzone-row > span:not(.bps-subzone-dot) { flex: 1 1 auto; }
+.bps-subzone-dot { width: 10px; height: 10px; border-radius: 3px; flex: 0 0 auto; display: inline-block; }
 .bps-empty, .bps-hint { color: hsl(var(--muted-foreground)); font-size: 12.5px; }
 .bps-hint { margin-top: 10px; }
 .bps-scale-status { margin-top: 10px; }

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const starttrackbtn = document.getElementById('starttrack');
     const stoptrackbtn = document.getElementById('stoptrack');
     const drawAreaButton = document.createElement('button');
+    const drawSubZoneButton = document.createElement('button');
     const addDeviceButton = document.createElement('button');
     const clearCanvasButton = document.createElement('button');
     const saveReceiverButton = document.createElement('button');
@@ -424,6 +425,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     }
                 });
                 existing.zones = (existing.zones || []).concat(floor.zones || []);
+                existing.subzones = (existing.subzones || []).concat(floor.subzones || []);
                 if (existing.scale == null) {
                     existing.scale = floor.scale;
                 }
@@ -594,9 +596,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (entityInput) {entityInput.style.display = "none";}
         addDeviceButton.innerHTML = addDeviceButton.innerHTML.replace("Save Receiver","Place Receiver");
         addDeviceButton.setAttribute('data-active', 'false');
-        if (zoneInputElement) {zoneInputElement.style.display = "none";}
+        if (zoneInputElement) {zoneInputElement.style.display = "none"; zoneInputElement.value = "";}
         drawAreaButton.innerHTML = drawAreaButton.innerHTML.replace("Save Zone","Draw Zone");
         drawAreaButton.setAttribute('data-active', 'false');
+        drawSubZoneButton.innerHTML = drawSubZoneButton.innerHTML.replace("Save Sub-Zone","Draw Sub-Zone");
+        drawSubZoneButton.setAttribute('data-active', 'false');
         focusedReceiver = null;
         messdiv.innerHTML = "";
     }
@@ -627,13 +631,44 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Loop through each floor and remove zones where the internal zone id matches
             finalcords.floor.forEach(floor => {
                 if (sameFloorName(floor.name, SelMapName)) {
+                    const removed = (floor.zones || []).find(zone => (zone.zone_id || zone.entity_id) === idToRemove);
                     floor.zones = floor.zones.filter(zone => (zone.zone_id || zone.entity_id) !== idToRemove);
+                    // A sub-zone can't outlive the zone it sits in (matched by
+                    // stable id, so a same-named sibling zone keeps its own).
+                    if (removed && Array.isArray(floor.subzones)) {
+                        floor.subzones = floor.subzones.filter(s => s.parent !== (removed.zone_id || removed.entity_id));
+                    }
                 }
             });
             console.log(`Removed zone "${idToRemove}"`);
             savebuttondiv.appendChild(saveButton);
             clearCanvas();
             drawElements(); // re-renders the sidebar tree too
+        }
+        if (event.target.closest('[data-type="removesubzone"]')) {
+            const idToRemove = event.target.closest('[data-type="removesubzone"]').getAttribute('data-id');
+            if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
+            finalcords.floor.forEach(floor => {
+                if (sameFloorName(floor.name, SelMapName) && Array.isArray(floor.subzones)) {
+                    floor.subzones = floor.subzones.filter(s => (s.sub_zone_id || s.entity_id) !== idToRemove);
+                }
+            });
+            console.log(`Removed sub-zone "${idToRemove}"`);
+            savebuttondiv.appendChild(saveButton);
+            clearCanvas();
+            drawElements();
+        }
+        if (event.target.closest('[data-type="editzone"]')) {
+            const idToEdit = event.target.closest('[data-type="editzone"]').getAttribute('data-id');
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const zone = floor && (floor.zones || []).find(z => (z.zone_id || z.entity_id) === idToEdit);
+            if (zone) beginEditZone(zone);
+        }
+        if (event.target.closest('[data-type="editsubzone"]')) {
+            const idToEdit = event.target.closest('[data-type="editsubzone"]').getAttribute('data-id');
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const sub = floor && (floor.subzones || []).find(s => (s.sub_zone_id || s.entity_id) === idToEdit);
+            if (sub) beginEditSubZone(sub);
         }
         if (event.target.closest('[data-type="collapse"]')) {
             const collapseDiv = event.target.closest('[data-type="collapse"]');
@@ -669,6 +704,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!checkCanvasImage()) return;
         removeListeners();
         drawAreaButton.remove();
+        drawSubZoneButton.remove();
         addDeviceButton.remove();
         clearCanvasButton.remove();
         SetScaleButton.remove();
@@ -709,6 +745,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     let draggingZone = false;
     let dragLast = null;
     let zoneInputElement = null; // För att hantera input-fältet
+    // What the polygon editor is currently building/editing:
+    //   {kind:'zone'|'subzone', id:<existing id|null>, parent, parentPoints, color}
+    // New zones/sub-zones have id null; sidebar "edit" loads an existing id.
+    let editTarget = null;
 
     const handleSize = 15;
 
@@ -739,6 +779,76 @@ document.addEventListener('DOMContentLoaded', async () => {
         };
     }
 
+    const createSubZoneId = () => `subzone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    // Each sub-zone gets its own hue so overlapping ones stay distinguishable.
+    function randomZoneColor() {
+        return `hsl(${Math.floor(Math.random() * 360)}, 70%, 45%)`;
+    }
+
+    // Nearest point on segment ab to p.
+    function projectPointToSegment(p, a, b) {
+        const dx = b.x - a.x, dy = b.y - a.y;
+        const len2 = dx * dx + dy * dy;
+        if (len2 === 0) return { x: a.x, y: a.y };
+        let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+        t = Math.max(0, Math.min(1, t));
+        return { x: a.x + t * dx, y: a.y + t * dy };
+    }
+
+    // Keep a point inside a polygon: unchanged when inside, else projected onto
+    // the nearest edge. This is how a sub-zone corner is stopped from leaving
+    // its parent zone (the client-side mirror of the backend's snap-into-zone).
+    function clampPointToPolygon(pt, polyPts) {
+        if (!polyPts || polyPts.length < 3) return pt;
+        if (pointInPolygon(pt.x, pt.y, polyPts)) return pt;
+        let best = null, bestD = Infinity;
+        for (let i = 0, j = polyPts.length - 1; i < polyPts.length; j = i++) {
+            const proj = projectPointToSegment(pt, polyPts[j], polyPts[i]);
+            const d = Math.hypot(proj.x - pt.x, proj.y - pt.y);
+            if (d < bestD) { bestD = d; best = proj; }
+        }
+        return best || pt;
+    }
+
+    // A sub-zone's points are constrained to its parent zone; a main zone's are
+    // only clamped to the canvas (already done by zoneMousePos).
+    function constrainForEdit(pos) {
+        if (editTarget && editTarget.kind === 'subzone' && editTarget.parentPoints) {
+            return clampPointToPolygon(pos, editTarget.parentPoints);
+        }
+        return pos;
+    }
+
+    // True when p is inside the polygon or essentially on its edge. Used for
+    // whole-shape sub-zone drags: a strict inside test would reject the move as
+    // soon as any corner sits on the parent boundary (which clamping puts there),
+    // so a sub-zone traced along a wall could never be moved.
+    function insideOrOnParent(p, poly) {
+        if (!poly) return true;
+        const c = clampPointToPolygon(p, poly);
+        return Math.hypot(c.x - p.x, c.y - p.y) <= 0.75;
+    }
+
+    // Topmost saved zone (last drawn) whose polygon contains pos.
+    function hitZoneAt(pos) {
+        const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+        if (!floor) return null;
+        const zones = floor.zones || [];
+        for (let i = zones.length - 1; i >= 0; i--) {
+            const pts = zonePerimeterPoints(zones[i]);
+            if (pts.length >= 3 && pointInPolygon(pos.x, pos.y, pts)) return zones[i];
+        }
+        return null;
+    }
+
+    function attachZoneHandlers() {
+        canvas.addEventListener("mousedown", zoneMouseDown);
+        canvas.addEventListener("mousemove", zoneMouseMove);
+        canvas.addEventListener("mouseup", zoneMouseUp);
+        canvas.addEventListener("contextmenu", zoneUndoPoint);
+    }
+
     drawAreaButton.addEventListener("click", () => {
         if (!checkCanvasImage()) return;
         removeListeners();
@@ -750,50 +860,176 @@ document.addEventListener('DOMContentLoaded', async () => {
             zonePoints = [];
             selectedVertex = null;
             draggingZone = false;
-            canvas.addEventListener("mousedown", zoneMouseDown);
-            canvas.addEventListener("mousemove", zoneMouseMove);
-            canvas.addEventListener("mouseup", zoneMouseUp);
-            canvas.addEventListener("contextmenu", zoneUndoPoint);
+            editTarget = { kind: 'zone', id: null };
+            attachZoneHandlers();
             drawAreaButton.innerHTML = drawAreaButton.innerHTML.replace("Draw Zone","Save Zone");
             drawAreaButton.setAttribute('data-active', 'true');
-            messdiv.innerHTML = '<h4 class="font-medium mb-2">Instructions</h4><p class="text-sm text-gray-500">Click the floor image to place the zone\'s corners, one by one — any shape with three or more corners works. Drag a corner to adjust it, or drag the inside of the zone to move the whole zone. Right-click removes the last corner. Enter the zone name (matching your Home Assistant areas is a good idea) and press Save Zone.</p>';
+            messdiv.innerHTML = '<h4 class="font-medium mb-2">Instructions</h4><p class="text-sm text-gray-500">Click the floor image to place the zone\'s corners, one by one — any shape with three or more corners works. Drag a corner to adjust it, or drag the inside of the zone to move the whole zone. Right-click a corner to delete it. Enter the zone name (matching your Home Assistant areas is a good idea) and press Save Zone.</p>';
         } else if (drawAreaButton.dataset.active === 'true') {
-            if (!mapname.value) {
-                alert("Please enter a floor name!");
-                return;
-            }
-            SelMapName = mapname.value;
-            if (zonePoints.length < 3) {
-                alert("A zone needs at least three corners.");
-                return;
-            }
-            zoneName = document.getElementById('zoneName').value.trim();
-            if (!zoneName) {
-                alert("Please provide a name for the zone.");
-                return;
-            }
-
-            let newZone = {
-                zone_id: createZoneId(),
-                entity_id: zoneName,
-                poly: true,
-                cords: zonePoints.map(p => ({ x: p.x, y: p.y }))
-              };
-            if(addDataToFloor(finalcords, SelMapName, "zones", newZone)){
-                alert(`Zone saved: ${zoneName}`);
-                console.log("Saved coordinates:", newZone.cords);
+            if (finalizeShape()) {
                 buttonreset();
-                zoneInputElement.value = "";
+                if (zoneInputElement) zoneInputElement.value = "";
                 zonePoints = [];
+                editTarget = null;
                 clearCanvas();
                 drawElements();
             }
-
         }
     });
 
+    // Sub-zone tool: draw a polygon inside a chosen parent zone (a couch, a
+    // desk). Shares the polygon editor with Draw Zone; the difference is a
+    // parent that every corner is clamped inside, and a random color.
+    drawSubZoneButton.addEventListener("click", () => {
+        if (!checkCanvasImage()) return;
+        removeListeners();
+        clearCanvas();
+        drawElements();
+
+        if (drawSubZoneButton.dataset.active === 'false') {
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, mapname.value));
+            if (!floor || !((floor.zones || []).length)) {
+                alert("Draw at least one zone first — a sub-zone is placed inside a zone.");
+                return;
+            }
+            buttonreset();
+            zonePoints = [];
+            selectedVertex = null;
+            draggingZone = false;
+            editTarget = { kind: 'subzone', id: null, parent: null, parentPoints: null, color: randomZoneColor() };
+            attachZoneHandlers();
+            drawSubZoneButton.innerHTML = drawSubZoneButton.innerHTML.replace("Draw Sub-Zone","Save Sub-Zone");
+            drawSubZoneButton.setAttribute('data-active', 'true');
+            messdiv.innerHTML = '<h4 class="font-medium mb-2">Instructions</h4><p class="text-sm text-gray-500">Click inside the zone you want to add a sub-zone to — that becomes its parent — then keep clicking to place corners (they stay inside the parent). Drag a corner to adjust it, drag the inside to move it, right-click a corner to delete it. Name it (e.g. Couch) and press Save Sub-Zone.</p>';
+        } else if (drawSubZoneButton.dataset.active === 'true') {
+            if (finalizeShape()) {
+                buttonreset();
+                if (zoneInputElement) zoneInputElement.value = "";
+                zonePoints = [];
+                editTarget = null;
+                clearCanvas();
+                drawElements();
+            }
+        }
+    });
+
+    // Commit the polygon in the editor into finalcords: add a new zone/sub-zone,
+    // or update the existing one when editTarget.id is set.
+    function finalizeShape() {
+        if (!mapname.value) { alert("Please enter a floor name!"); return false; }
+        SelMapName = mapname.value;
+        const isSub = !!(editTarget && editTarget.kind === 'subzone');
+        if (zonePoints.length < 3) {
+            alert((isSub ? "A sub-zone" : "A zone") + " needs at least three corners.");
+            return false;
+        }
+        const nameEl = document.getElementById('zoneName');
+        const name = (nameEl ? nameEl.value : "").trim();
+        if (!name) { alert("Please provide a name."); return false; }
+        const cords = zonePoints.map(p => ({ x: p.x, y: p.y }));
+        const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+
+        if (isSub) {
+            if (!editTarget.parent) { alert("Click inside a zone first to choose the sub-zone's parent."); return false; }
+            if (!floor) { alert("Select a floor first."); return false; }
+            if (!Array.isArray(floor.subzones)) floor.subzones = [];
+            if (editTarget.id) {
+                const sz = floor.subzones.find(s => (s.sub_zone_id || s.entity_id) === editTarget.id);
+                if (sz) { sz.entity_id = name; sz.cords = cords; sz.parent = editTarget.parent; sz.poly = true; }
+            } else {
+                floor.subzones.push({
+                    sub_zone_id: createSubZoneId(),
+                    entity_id: name,
+                    parent: editTarget.parent,
+                    poly: true,
+                    color: editTarget.color || randomZoneColor(),
+                    cords,
+                });
+            }
+            savebuttondiv.appendChild(saveButton);
+            alert(`Sub-zone saved: ${name}`);
+            return true;
+        }
+
+        // Main zone: update in place when editing, else add a new one.
+        if (editTarget && editTarget.id) {
+            const z = floor && (floor.zones || []).find(zz => (zz.zone_id || zz.entity_id) === editTarget.id);
+            if (z) { z.entity_id = name; z.cords = cords; z.poly = true; }
+            savebuttondiv.appendChild(saveButton);
+            alert(`Zone saved: ${name}`);
+            return true;
+        }
+        zoneName = name;
+        const newZone = { zone_id: createZoneId(), entity_id: name, poly: true, cords };
+        if (addDataToFloor(finalcords, SelMapName, "zones", newZone)) {
+            alert(`Zone saved: ${name}`);
+            return true;
+        }
+        return false;
+    }
+
+    // Load a saved zone/sub-zone into the polygon editor (reusing the draw
+    // machinery); the matching tool button flips to its "Save" state so the
+    // next click on it commits the edit in place.
+    function beginEditZone(zone) {
+        if (!checkCanvasImage()) return;
+        removeListeners();
+        buttonreset();
+        SelMapName = mapname.value || SelMapName;
+        zonePoints = zonePerimeterPoints(zone).map(p => ({ x: p.x, y: p.y }));
+        selectedVertex = null;
+        draggingZone = false;
+        editTarget = { kind: 'zone', id: zone.zone_id || zone.entity_id };
+        attachZoneHandlers();
+        drawAreaButton.setAttribute('data-active', 'true');
+        drawAreaButton.innerHTML = drawAreaButton.innerHTML.replace("Draw Zone","Save Zone");
+        drawZonePreview();
+        const zn = document.getElementById('zoneName');
+        if (zn) zn.value = zone.entity_id || "";
+        messdiv.innerHTML = '<h4 class="font-medium mb-2">Editing zone</h4><p class="text-sm text-gray-500">Drag a corner to move it, drag the inside to move the whole zone, right-click a corner to delete it, or click empty space to add one. Press Save Zone to keep the changes.</p>';
+    }
+
+    function beginEditSubZone(sub) {
+        if (!checkCanvasImage()) return;
+        removeListeners();
+        buttonreset();
+        SelMapName = mapname.value || SelMapName;
+        const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+        const parentZone = floor && (floor.zones || []).find(z => (z.zone_id || z.entity_id) === sub.parent);
+        zonePoints = (sub.cords || []).map(p => ({ x: p.x, y: p.y }));
+        selectedVertex = null;
+        draggingZone = false;
+        editTarget = {
+            kind: 'subzone',
+            id: sub.sub_zone_id || sub.entity_id,
+            parent: sub.parent,
+            parentPoints: parentZone ? zonePerimeterPoints(parentZone).map(p => ({ x: p.x, y: p.y })) : null,
+            color: sub.color || randomZoneColor(),
+        };
+        attachZoneHandlers();
+        drawSubZoneButton.setAttribute('data-active', 'true');
+        drawSubZoneButton.innerHTML = drawSubZoneButton.innerHTML.replace("Draw Sub-Zone","Save Sub-Zone");
+        drawZonePreview();
+        const zn = document.getElementById('zoneName');
+        if (zn) zn.value = sub.entity_id || "";
+        messdiv.innerHTML = '<h4 class="font-medium mb-2">Editing sub-zone</h4><p class="text-sm text-gray-500">Corners stay inside the parent zone. Drag a corner, drag the inside to move it, right-click a corner to delete it. Press Save Sub-Zone to keep the changes.</p>';
+    }
+
     function zoneMouseDown(event) {
         const pos = zoneMousePos(event);
+
+        // Sub-zone: the first click chooses the parent zone and seeds corner 1.
+        if (editTarget && editTarget.kind === 'subzone' && !editTarget.parent) {
+            const parent = hitZoneAt(pos);
+            if (!parent) { alert("Click inside the zone you want to add a sub-zone to."); return; }
+            if (!parent.zone_id) parent.zone_id = createZoneId();
+            editTarget.parent = parent.zone_id; // stable id, survives renames / same-named zones
+            editTarget.parentPoints = zonePerimeterPoints(parent).map(p => ({ x: p.x, y: p.y }));
+            zonePoints = [clampPointToPolygon(pos, editTarget.parentPoints)];
+            drawZonePreview();
+            return;
+        }
+
         selectedVertex = null;
         draggingZone = false;
 
@@ -808,7 +1044,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             dragLast = pos;
             return;
         }
-        zonePoints.push(pos);
+        zonePoints.push(constrainForEdit(pos));
         drawZonePreview();
     }
 
@@ -817,18 +1053,28 @@ document.addEventListener('DOMContentLoaded', async () => {
         const pos = zoneMousePos(event);
 
         if (selectedVertex !== null) {
-            zonePoints[selectedVertex] = pos;
+            zonePoints[selectedVertex] = constrainForEdit(pos);
         } else if (draggingZone) {
-            // Clamp the translation so no corner can leave the canvas — a
-            // corner outside the visible area cannot be grabbed anymore.
             let dx = pos.x - dragLast.x;
             let dy = pos.y - dragLast.y;
-            const xs = zonePoints.map(p => p.x);
-            const ys = zonePoints.map(p => p.y);
-            dx = Math.max(-Math.min(...xs), Math.min(canvas.width - Math.max(...xs), dx));
-            dy = Math.max(-Math.min(...ys), Math.min(canvas.height - Math.max(...ys), dy));
-            zonePoints = zonePoints.map(p => ({ x: p.x + dx, y: p.y + dy }));
-            dragLast = pos;
+            if (editTarget && editTarget.kind === 'subzone' && editTarget.parentPoints) {
+                // Move only if every corner stays inside the parent zone, so the
+                // sub-zone keeps its shape and never leaks out of its parent.
+                const moved = zonePoints.map(p => ({ x: p.x + dx, y: p.y + dy }));
+                if (moved.every(p => insideOrOnParent(p, editTarget.parentPoints))) {
+                    zonePoints = moved;
+                    dragLast = pos;
+                }
+            } else {
+                // Main zone: clamp the translation so no corner can leave the
+                // canvas — a corner outside the visible area can't be grabbed.
+                const xs = zonePoints.map(p => p.x);
+                const ys = zonePoints.map(p => p.y);
+                dx = Math.max(-Math.min(...xs), Math.min(canvas.width - Math.max(...xs), dx));
+                dy = Math.max(-Math.min(...ys), Math.min(canvas.height - Math.max(...ys), dy));
+                zonePoints = zonePoints.map(p => ({ x: p.x + dx, y: p.y + dy }));
+                dragLast = pos;
+            }
         }
         drawZonePreview();
     }
@@ -841,10 +1087,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function zoneUndoPoint(event) {
         event.preventDefault();
-        if (zonePoints.length) {
-            zonePoints.pop();
-            drawZonePreview();
+        if (!zonePoints.length) return;
+        const pos = zoneMousePos(event);
+        let idx = -1;
+        for (let i = 0; i < zonePoints.length; i++) {
+            if (Math.hypot(zonePoints[i].x - pos.x, zonePoints[i].y - pos.y) <= handleSize * 2) {
+                idx = i;
+                break;
+            }
         }
+        if (idx >= 0) {
+            // Right-clicked a corner: delete it, but never below a triangle.
+            if (zonePoints.length > 3) zonePoints.splice(idx, 1);
+        } else {
+            // Right-clicked empty space: undo the last placed corner.
+            zonePoints.pop();
+        }
+        drawZonePreview();
     }
 
     function drawZonePreview() {
@@ -881,12 +1140,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         for (let i = 1; i < zonePoints.length; i++) {
             ctx.lineTo(zonePoints[i].x, zonePoints[i].y);
         }
+        const shapeColor = (editTarget && editTarget.kind === 'subzone') ? (editTarget.color || "#3f51b5") : "red";
         if (zonePoints.length >= 3) {
             ctx.closePath();
-            ctx.fillStyle = "rgba(255, 1, 0, 0.08)"; // shows where the zone can be dragged
+            ctx.save();
+            ctx.globalAlpha = 0.12; // shows where the shape can be dragged
+            ctx.fillStyle = shapeColor;
             ctx.fill();
+            ctx.restore();
         }
-        ctx.strokeStyle = "red";
+        ctx.strokeStyle = shapeColor;
         ctx.lineWidth = 2;
         ctx.stroke();
 
@@ -894,7 +1157,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         zonePoints.forEach(point => {
             ctx.beginPath();
             ctx.arc(point.x, point.y, handleSize, 0, Math.PI * 2);
-            ctx.fillStyle = "red";
+            ctx.fillStyle = shapeColor;
             ctx.fill();
         });
     }
@@ -1185,6 +1448,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function drawToolActive() {
         return drawAreaButton.dataset.active === 'true'
+            || drawSubZoneButton.dataset.active === 'true'
             || addDeviceButton.dataset.active === 'true'
             || SetScaleButton.dataset.active === 'true';
     }
@@ -1451,6 +1715,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 zone.type = "zone";
                 tmpdrawcords.push(zone);
             });
+            // Sub-zones are pushed after zones so they paint on top of them.
+            (floor.subzones || []).forEach(sub => {
+                if (!sub.sub_zone_id) {
+                    sub.sub_zone_id = createSubZoneId();
+                }
+                sub.type = "subzone";
+                tmpdrawcords.push(sub);
+            });
         } else {
             // No saved floor matches the selection: tracking has nothing to
             // iterate, so do not offer it.
@@ -1493,6 +1765,29 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const cy = pts.reduce((s, p) => s + p.y, 0) / pts.length;
                 drawCenteredLabel(item.entity_id, cx, cy + 8, "600 24px system-ui, sans-serif", "#d32f2f");
             }
+            if (item.type == "subzone"){
+                const pts = item.cords || [];
+                if (pts.length < 3) return;
+                const color = item.color || "#3f51b5";
+                ctx.beginPath();
+                ctx.moveTo(pts[0].x, pts[0].y);
+                for (let p = 1; p < pts.length; p++) {
+                    ctx.lineTo(pts[p].x, pts[p].y);
+                }
+                ctx.closePath();
+                ctx.save();
+                ctx.globalAlpha = 0.18;
+                ctx.fillStyle = color;
+                ctx.fill();
+                ctx.restore();
+                ctx.strokeStyle = color;
+                ctx.lineWidth = 2;
+                ctx.stroke();
+
+                const cx = pts.reduce((s, p) => s + p.x, 0) / pts.length;
+                const cy = pts.reduce((s, p) => s + p.y, 0) / pts.length;
+                drawCenteredLabel(item.entity_id, cx, cy + 6, "600 18px system-ui, sans-serif", color);
+            }
         });
 
         renderEntityTree(floor);
@@ -1506,6 +1801,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
         const trashSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>';
+        const pencilSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>';
+        const subzones = (floor.subzones || []);
+        const subRow = s => {
+            const sid = s.sub_zone_id || s.entity_id;
+            return `<li class="bps-subzone-row"><span class="bps-subzone-dot" style="background:${escHtml(s.color || '#3f51b5')}"></span>`
+                + `<span title="${escHtml(s.entity_id)}">${escHtml(s.entity_id)}</span>`
+                + `<button class="bps-icon-btn" title="Edit sub-zone" data-type="editsubzone" data-id="${escHtml(sid)}">${pencilSvg}</button>`
+                + `<button class="bps-icon-btn" title="Remove sub-zone" data-type="removesubzone" data-id="${escHtml(sid)}">${trashSvg}</button></li>`;
+        };
         const receiverRow = r =>
             `<li><span title="${escHtml(r.entity_id)}">${escHtml(r.entity_id)}</span>`
             + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
@@ -1520,14 +1824,30 @@ document.addEventListener('DOMContentLoaded', async () => {
                 : [];
             inside.forEach(r => claimed.add(r.entity_id));
             const zoneDomId = zone.zone_id || zone.entity_id;
+            const subs = subzones.filter(s => s.parent === zoneDomId);
             html += '<div class="bps-zone-group">'
                 + `<div class="bps-zone-head"><span title="${escHtml(zone.entity_id)}">${escHtml(zone.entity_id)}<span class="bps-count"> · ${inside.length}</span></span>`
-                + `<button class="bps-icon-btn" title="Remove zone" data-type="removezone" data-id="${escHtml(zoneDomId)}">${trashSvg}</button></div>`;
+                + '<span class="bps-zone-actions">'
+                + `<button class="bps-icon-btn" title="Edit zone" data-type="editzone" data-id="${escHtml(zoneDomId)}">${pencilSvg}</button>`
+                + `<button class="bps-icon-btn" title="Remove zone" data-type="removezone" data-id="${escHtml(zoneDomId)}">${trashSvg}</button>`
+                + '</span></div>';
             if (inside.length) {
                 html += "<ul>" + inside.map(receiverRow).join("") + "</ul>";
             }
+            if (subs.length) {
+                html += '<ul class="bps-subzone-list">' + subs.map(subRow).join("") + "</ul>";
+            }
             html += "</div>";
         });
+        // Sub-zones whose parent zone no longer exists — still listed so they
+        // can be edited or deleted.
+        const zoneIds = new Set((floor.zones || []).map(z => z.zone_id || z.entity_id));
+        const orphanSubs = subzones.filter(s => !zoneIds.has(s.parent));
+        if (orphanSubs.length) {
+            html += '<div class="bps-zone-group">'
+                + `<div class="bps-zone-head"><span>Unlinked sub-zones<span class="bps-count"> · ${orphanSubs.length}</span></span></div>`
+                + '<ul class="bps-subzone-list">' + orphanSubs.map(subRow).join("") + "</ul></div>";
+        }
         const unzoned = receivers.filter(r => !claimed.has(r.entity_id));
         if (unzoned.length) {
             html += '<div class="bps-zone-group">'
@@ -1618,6 +1938,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Display selected map
     async function selectExistingMap(value) {
+        // Abandon any in-progress draw/edit so its handlers and half-built
+        // polygon can't bleed onto the newly-selected floor.
+        removeListeners();
+        buttonreset();
+        zonePoints = [];
+        selectedVertex = null;
+        draggingZone = false;
+        editTarget = null;
         img.src = `/local/bps_maps/${value}`;
         imgfilename = value;
         mapname.value = removeExtension(value);
@@ -1681,6 +2009,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                 `;
             drawAreaButton.setAttribute('data-active', 'false');
 
+            drawSubZoneButton.className = drawAreaButton.className;
+            drawSubZoneButton.innerHTML = `
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-box-select w-4 h-4 mr-2" data-component-name="SubZone"><rect x="3" y="3" width="18" height="18" rx="2"></rect><rect x="8" y="8" width="8" height="8" rx="1"></rect></svg>
+                    Draw Sub-Zone
+                `;
+            drawSubZoneButton.setAttribute('data-active', 'false');
+
             addDeviceButton.className = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2';
             addDeviceButton.innerHTML = `
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-radio w-4 h-4 mr-2" data-component-name="Radio"><path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"></path><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"></path><circle cx="12" cy="12" r="2"></circle><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"></path><path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"></path></svg>
@@ -1709,6 +2044,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             
             mapbuttondiv.appendChild(addDeviceButton);
             mapbuttondiv.appendChild(drawAreaButton);
+            mapbuttondiv.appendChild(drawSubZoneButton);
             mapbuttondiv.appendChild(SetScaleButton);
             mapbuttondiv.appendChild(clearCanvasButton);
         });

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -12,6 +12,7 @@ SENSOR_KINDS = [
     ("bps_zone", "BPS Zone"),
     ("bps_floor", "BPS Floor"),
     ("bps_nearest_zone", "BPS Nearest Zone"),
+    ("bps_sub_zone", "BPS Sub-Zone"),
 ]
 
 
@@ -70,19 +71,25 @@ class CustomDistanceSensor(SensorEntity):
         self._attr_name = name
         self._attr_unique_id = unique_id
         self._state = "unknown"
+        self._attrs = {}
         self.entity_id = entity_id
-    
+
     @property
     def name(self):
         return self._name
-    
+
     @property
     def unique_id(self):
         return self._unique_id
-    
+
     @property
     def state(self):
         return self._state
+
+    @property
+    def extra_state_attributes(self):
+        # Used by the sub-zone sensor to carry "parent_zone"; empty for the rest.
+        return self._attrs
 
 def cleanup_legacy_bps_entities(hass):
     """Remove old duplicated-name BPS entities from entity registry."""


### PR DESCRIPTION
Adds **sub-zones** — polygons drawn *inside* a zone (a couch, a bed, a desk) for when "which room" isn't precise enough — and makes existing zones and sub-zones fully editable.

### Sub-zones
- New tool **Draw Sub-Zone**: click inside a zone to pick the parent, then place corners. Every corner is **kept inside the parent zone** (projected onto the parent's edge if you click outside), and each sub-zone gets its **own random color**.
- New per-device entity **`sensor.<device>_bps_sub_zone`** — state is the sub-zone the tracker is in (`unknown` when in none), with a **`parent_zone`** attribute naming the enclosing zone.
- Data lives in a **separate `subzones` list per floor**, so the existing zone election / snap / nearest-zone logic is untouched. Sub-zones link to their parent by the zone's **stable id** (survives renames and same-named zones), resolved to the zone name for the attribute.
- The Lovelace map card can draw them too: **`show_sub_zones: true`** (config option + visual-editor toggle).

### Editable zones & sub-zones
- A **✎ pencil** next to each zone/sub-zone in the sidebar reopens it in the polygon editor: drag a corner, drag the whole shape, **right-click a corner to delete it** (min 3 corners). This works on *saved* shapes now, not just while drawing.
- Sub-zones nest under their parent in the sidebar; **deleting a zone cascades to its sub-zones** (by stable id, so a same-named sibling keeps its own). Whole-shape sub-zone drag stays inside the parent (slides along walls).

### Safety / back-compat
Additive: floors with no `subzones` behave exactly as before; legacy rectangle zones still work. Domain unchanged.

### Verification
Backend `py_compile`; both JS files bracket-balanced; unit-tested the geometry (point-in-polygon, clamp-to-polygon incl. concave L-shape, and the drag-acceptance "slide along wall / reject through wall"). A 5-dimension adversarial review (backend, editor state, geometry, sidebar/persistence, card) surfaced 10 issues — **all fixed** (parent-by-stable-id, boundary-drag, floor-switch reset, unload cleanup, name-input clear, `mergeDuplicateFloors` folding sub-zones). Interactive editing wasn't runnable headlessly here — worth a click-through on live HA.

Panel + card only. Hard-refresh the panel; bump the dashboard resource URL for `bps-map-card.js` so the card reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)