### PR TITLE
Zone/sub-zone editor: zoom while drawing, corner delete, cancel, in-window dialogs + delete confirmations

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -65,6 +65,55 @@ canvas {
     z-index: 1000;
 }
 .zone-cancel-btn:hover { background: #b71c1c; }
+
+/* In-window dialogs (replace native alert/confirm) */
+.bps-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.bps-modal {
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    padding: 20px;
+    width: min(380px, calc(100% - 40px));
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+.bps-modal-msg { font-size: 14px; line-height: 1.5; margin-bottom: 18px; }
+.bps-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.bps-btn-danger { background: #d32f2f; color: #ffffff; }
+.bps-btn-danger:hover { background: #b71c1c; }
+.bps-toast-host {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    pointer-events: none;
+}
+.bps-toast {
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    padding: 10px 16px;
+    font-size: 13px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+    max-width: 90vw;
+    opacity: 1;
+    transition: opacity 0.35s ease;
+}
+.bps-toast-out { opacity: 0; }
 .rec-input {
     padding: 2px;
     border-color: #000000;

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -50,6 +50,21 @@ canvas {
     border-width: 2px;
     border-radius: 8px;
 }
+.zone-cancel-btn {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    line-height: 1;
+    border: none;
+    border-radius: 50%;
+    background: #d32f2f;
+    color: #ffffff;
+    font-size: 13px;
+    cursor: pointer;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+    z-index: 1000;
+}
+.zone-cancel-btn:hover { background: #b71c1c; }
 .rec-input {
     padding: 2px;
     border-color: #000000;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1117,15 +1117,21 @@ document.addEventListener('DOMContentLoaded', async () => {
                 break;
             }
         }
-        if (idx >= 0) {
-            // Right-clicked a corner: delete it, but never below a triangle.
-            if (zonePoints.length > 3) zonePoints.splice(idx, 1);
-        } else if (editTarget && !editTarget.id) {
-            // While drawing a NEW shape, right-clicking empty space undoes the
-            // last placed corner. When editing an existing shape we leave the
-            // corners the user didn't click on alone.
-            zonePoints.pop();
+        if (idx < 0) {
+            // Missed every handle: while drawing a NEW shape this undoes the last
+            // placed corner; when editing an existing shape a stray right-click
+            // off a corner does nothing.
+            if (!(editTarget && !editTarget.id)) return;
+            idx = zonePoints.length - 1;
         }
+        // Removing a corner that would drop the shape below a triangle just
+        // discards the whole draw/edit — right-clicking away the last dots
+        // cancels the add/edit instead of getting stuck at three.
+        if (zonePoints.length <= 3) {
+            cancelShapeEdit();
+            return;
+        }
+        zonePoints.splice(idx, 1);
         drawZonePreview();
     }
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -597,6 +597,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         addDeviceButton.innerHTML = addDeviceButton.innerHTML.replace("Save Receiver","Place Receiver");
         addDeviceButton.setAttribute('data-active', 'false');
         if (zoneInputElement) {zoneInputElement.style.display = "none"; zoneInputElement.value = "";}
+        if (zoneCancelBtn) {zoneCancelBtn.style.display = "none";}
         drawAreaButton.innerHTML = drawAreaButton.innerHTML.replace("Save Zone","Draw Zone");
         drawAreaButton.setAttribute('data-active', 'false');
         drawSubZoneButton.innerHTML = drawSubZoneButton.innerHTML.replace("Save Sub-Zone","Draw Sub-Zone");
@@ -745,12 +746,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     let draggingZone = false;
     let dragLast = null;
     let zoneInputElement = null; // För att hantera input-fältet
+    let zoneCancelBtn = null; // floating X that cancels the current draw/edit
     // What the polygon editor is currently building/editing:
     //   {kind:'zone'|'subzone', id:<existing id|null>, parent, parentPoints, color}
     // New zones/sub-zones have id null; sidebar "edit" loads an existing id.
     let editTarget = null;
 
     const handleSize = 15;
+    const MAX_ZONE_POINTS = 12; // corner cap for a zone or sub-zone
 
     // Points in drawable perimeter order for both formats.
     function zonePerimeterPoints(zone) {
@@ -968,6 +971,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         return false;
     }
 
+    // Discard the in-progress draw/edit without writing anything to finalcords
+    // (an edit works on a copy of the points, so the original is untouched).
+    function cancelShapeEdit() {
+        removeListeners();
+        buttonreset();
+        zonePoints = [];
+        selectedVertex = null;
+        draggingZone = false;
+        editTarget = null;
+        clearCanvas();
+        drawElements();
+    }
+
     // Load a saved zone/sub-zone into the polygon editor (reusing the draw
     // machinery); the matching tool button flips to its "Save" state so the
     // next click on it commits the edit in place.
@@ -1016,6 +1032,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function zoneMouseDown(event) {
+        if (event.button !== 0) return; // left button only; right-click deletes via zoneUndoPoint
         const pos = zoneMousePos(event);
 
         // Sub-zone: the first click chooses the parent zone and seeds corner 1.
@@ -1042,6 +1059,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (zonePoints.length >= 3 && pointInPolygon(pos.x, pos.y, zonePoints)) {
             draggingZone = true;
             dragLast = pos;
+            return;
+        }
+        if (zonePoints.length >= MAX_ZONE_POINTS) {
+            alert(`A zone or sub-zone can have at most ${MAX_ZONE_POINTS} corners.`);
             return;
         }
         zonePoints.push(constrainForEdit(pos));
@@ -1099,8 +1120,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (idx >= 0) {
             // Right-clicked a corner: delete it, but never below a triangle.
             if (zonePoints.length > 3) zonePoints.splice(idx, 1);
-        } else {
-            // Right-clicked empty space: undo the last placed corner.
+        } else if (editTarget && !editTarget.id) {
+            // While drawing a NEW shape, right-clicking empty space undoes the
+            // last placed corner. When editing an existing shape we leave the
+            // corners the user didn't click on alone.
             zonePoints.pop();
         }
         drawZonePreview();
@@ -1119,9 +1142,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             zoneInputElement.classList.add("zone-input");
             document.body.appendChild(zoneInputElement);
         }
+        if (!zoneCancelBtn) {
+            zoneCancelBtn = document.createElement("button");
+            zoneCancelBtn.type = "button";
+            zoneCancelBtn.textContent = "✕";
+            zoneCancelBtn.title = "Cancel (discard this zone / sub-zone)";
+            zoneCancelBtn.classList.add("zone-cancel-btn");
+            zoneCancelBtn.addEventListener("click", cancelShapeEdit);
+            document.body.appendChild(zoneCancelBtn);
+        }
 
         if (!zonePoints.length) {
             zoneInputElement.style.display = "none";
+            zoneCancelBtn.style.display = "none";
             return;
         }
 
@@ -1133,6 +1166,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         zoneInputElement.style.top = `${css.top - 40}px`;
         zoneInputElement.style.display = "block";
         zoneInputElement.style.position = "absolute";
+
+        // X button hugging the name field's top-right corner.
+        zoneCancelBtn.style.position = "absolute";
+        zoneCancelBtn.style.display = "block";
+        zoneCancelBtn.style.left = `${css.left - 40 + zoneInputElement.offsetWidth + 4}px`;
+        zoneCancelBtn.style.top = `${css.top - 40}px`;
 
         // Draw the polygon so far
         ctx.beginPath();

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -112,6 +112,70 @@ document.addEventListener('DOMContentLoaded', async () => {
         drawElements();
         drawTrackOverlay();
     }
+
+    // ---- In-window dialogs (replace native alert/confirm) --------------------
+    // A brief, non-blocking notice for informational messages.
+    function bpsToast(message) {
+        let host = document.getElementById("bpsToastHost");
+        if (!host) {
+            host = document.createElement("div");
+            host.id = "bpsToastHost";
+            host.className = "bps-toast-host";
+            document.body.appendChild(host);
+        }
+        const el = document.createElement("div");
+        el.className = "bps-toast";
+        el.textContent = message;
+        host.appendChild(el);
+        setTimeout(() => { el.classList.add("bps-toast-out"); }, 3200);
+        setTimeout(() => { el.remove(); }, 3600);
+    }
+
+    // A modal that resolves to true (confirm) or false (cancel). Replaces the
+    // native confirm() so prompting stays inside the panel window.
+    function bpsConfirm(message, opts = {}) {
+        const { confirmText = "Confirm", cancelText = "Cancel", danger = false } = opts;
+        return new Promise(resolve => {
+            const overlay = document.createElement("div");
+            overlay.className = "bps-modal-overlay";
+            const dialog = document.createElement("div");
+            dialog.className = "bps-modal";
+            const msg = document.createElement("div");
+            msg.className = "bps-modal-msg";
+            msg.textContent = message;
+            const row = document.createElement("div");
+            row.className = "bps-modal-actions";
+            const cancelBtn = document.createElement("button");
+            cancelBtn.type = "button";
+            cancelBtn.className = "bps-btn bps-btn-outline";
+            cancelBtn.textContent = cancelText;
+            const okBtn = document.createElement("button");
+            okBtn.type = "button";
+            okBtn.className = "bps-btn " + (danger ? "bps-btn-danger" : "bps-btn-primary");
+            okBtn.textContent = confirmText;
+            row.appendChild(cancelBtn);
+            row.appendChild(okBtn);
+            dialog.appendChild(msg);
+            dialog.appendChild(row);
+            overlay.appendChild(dialog);
+            document.body.appendChild(overlay);
+            const close = (val) => {
+                overlay.remove();
+                document.removeEventListener("keydown", onKey);
+                resolve(val);
+            };
+            cancelBtn.addEventListener("click", () => close(false));
+            okBtn.addEventListener("click", () => close(true));
+            overlay.addEventListener("click", (e) => { if (e.target === overlay) close(false); });
+            function onKey(e) {
+                if (e.key === "Escape") close(false);
+                else if (e.key === "Enter") close(true);
+            }
+            document.addEventListener("keydown", onKey);
+            okBtn.focus();
+        });
+    }
+
     const createZoneId = () => `zone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let isDrawing = false;
     let SelMapName = "";
@@ -196,7 +260,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const mapsResponse = await fetch('/api/bps/maps');
             if (!mapsResponse.ok) {
                 console.error('Failed to fetch maps:', mapsResponse.statusText);
-                alert('Could not load maps.');
+                bpsToast('Could not load maps.');
                 return false;
             }
         
@@ -261,7 +325,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         starttrackbtn.addEventListener("click", function() {
             if (device == "") {
-                alert("You must choose a device to track!");
+                bpsToast("You must choose a device to track!");
                 return;
             }
             startTrackfunc();
@@ -528,12 +592,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (uploadTrackerIconButton && trackerIconUpload) {
             uploadTrackerIconButton.addEventListener("click", async () => {
                 if (!device) {
-                    alert("Choose tracker first.");
+                    bpsToast("Choose tracker first.");
                     return;
                 }
                 const iconFile = trackerIconUpload.files[0];
                 if (!iconFile) {
-                    alert("Choose an icon file first.");
+                    bpsToast("Choose an icon file first.");
                     return;
                 }
                 const uploadData = new FormData();
@@ -544,12 +608,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                         body: uploadData,
                     });
                     if (!response.ok) {
-                        alert("Could not upload icon.");
+                        bpsToast("Could not upload icon.");
                         return;
                     }
                     const payload = await response.json();
                     if (!payload || !payload.icon_url) {
-                        alert("Could not upload icon.");
+                        bpsToast("Could not upload icon.");
                         return;
                     }
                     ensureIconOption(payload.icon_url, payload.icon_name || payload.icon_url);
@@ -559,10 +623,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                     ensureTrackerIconsStore();
                     finalcords.tracker_icons[getTrackerEntityKey()] = payload.icon_url;
                     savebuttondiv.appendChild(saveButton);
-                    alert("Tracker icon uploaded. Click Save Floor Plan to persist.");
+                    bpsToast("Tracker icon uploaded. Click Save Floor Plan to persist.");
                 } catch (error) {
                     console.error("Icon upload failed:", error);
-                    alert("Could not upload icon.");
+                    bpsToast("Could not upload icon.");
                 }
             });
         }
@@ -571,7 +635,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Check if the image is loaded in the canvas
     function checkCanvasImage() {
         if (canvas.width === 0 || canvas.height === 0) {
-            alert("Please load a floorplan first.");
+            bpsToast("Please load a floorplan first.");
             return false;
         }
         return true;
@@ -609,55 +673,75 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.addEventListener('click', (event) => {
         // Check if the clicked element has the attribute data-type="removerec"
         if (event.target.closest('[data-type="removerec"]')) {
-            const button = event.target.closest('[data-type="removerec"]'); // Get the button that was pressed
-            const idToRemove = button.getAttribute('data-id'); // Get the value from data-id
+            const idToRemove = event.target.closest('[data-type="removerec"]').getAttribute('data-id');
             // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
             if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
-            // Loop through each floor and remove receivers where the entity_id matches
-            finalcords.floor.forEach(floor => {
-                if (sameFloorName(floor.name, SelMapName)) {
-                    floor.receivers = floor.receivers.filter(receiver => receiver.entity_id !== idToRemove);
-                }
+            bpsConfirm(`Remove receiver "${idToRemove}"?`, { confirmText: "Remove", danger: true }).then(ok => {
+                if (!ok) return;
+                finalcords.floor.forEach(floor => {
+                    if (sameFloorName(floor.name, SelMapName)) {
+                        floor.receivers = floor.receivers.filter(receiver => receiver.entity_id !== idToRemove);
+                    }
+                });
+                console.log(`Removed receiver "${idToRemove}"`);
+                savebuttondiv.appendChild(saveButton);
+                clearCanvas();
+                drawElements(); // re-renders the sidebar tree too
             });
-            console.log(`Removed receiver "${idToRemove}"`);
-            savebuttondiv.appendChild(saveButton);
-            clearCanvas();
-            drawElements(); // re-renders the sidebar tree too
+            return;
         }
         if (event.target.closest('[data-type="removezone"]')) {
-            const button = event.target.closest('[data-type="removezone"]'); // Get the button that was pressed
-            const idToRemove = button.getAttribute('data-id'); // Get the value from data-id
+            const idToRemove = event.target.closest('[data-type="removezone"]').getAttribute('data-id');
             // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
             if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
-            // Loop through each floor and remove zones where the internal zone id matches
-            finalcords.floor.forEach(floor => {
-                if (sameFloorName(floor.name, SelMapName)) {
-                    const removed = (floor.zones || []).find(zone => (zone.zone_id || zone.entity_id) === idToRemove);
-                    floor.zones = floor.zones.filter(zone => (zone.zone_id || zone.entity_id) !== idToRemove);
-                    // A sub-zone can't outlive the zone it sits in (matched by
-                    // stable id, so a same-named sibling zone keeps its own).
-                    if (removed && Array.isArray(floor.subzones)) {
-                        floor.subzones = floor.subzones.filter(s => s.parent !== (removed.zone_id || removed.entity_id));
+            const cf = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const zObj = cf && (cf.zones || []).find(z => (z.zone_id || z.entity_id) === idToRemove);
+            const zName = zObj ? zObj.entity_id : "this zone";
+            const subCount = zObj && Array.isArray(cf.subzones)
+                ? cf.subzones.filter(s => s.parent === (zObj.zone_id || zObj.entity_id)).length : 0;
+            const msg = subCount
+                ? `Remove zone "${zName}" and its ${subCount} sub-zone(s)?`
+                : `Remove zone "${zName}"?`;
+            bpsConfirm(msg, { confirmText: "Remove", danger: true }).then(ok => {
+                if (!ok) return;
+                // Loop through each floor and remove zones where the internal zone id matches
+                finalcords.floor.forEach(floor => {
+                    if (sameFloorName(floor.name, SelMapName)) {
+                        const removed = (floor.zones || []).find(zone => (zone.zone_id || zone.entity_id) === idToRemove);
+                        floor.zones = floor.zones.filter(zone => (zone.zone_id || zone.entity_id) !== idToRemove);
+                        // A sub-zone can't outlive the zone it sits in (matched by
+                        // stable id, so a same-named sibling zone keeps its own).
+                        if (removed && Array.isArray(floor.subzones)) {
+                            floor.subzones = floor.subzones.filter(s => s.parent !== (removed.zone_id || removed.entity_id));
+                        }
                     }
-                }
+                });
+                console.log(`Removed zone "${idToRemove}"`);
+                savebuttondiv.appendChild(saveButton);
+                clearCanvas();
+                drawElements(); // re-renders the sidebar tree too
             });
-            console.log(`Removed zone "${idToRemove}"`);
-            savebuttondiv.appendChild(saveButton);
-            clearCanvas();
-            drawElements(); // re-renders the sidebar tree too
+            return;
         }
         if (event.target.closest('[data-type="removesubzone"]')) {
             const idToRemove = event.target.closest('[data-type="removesubzone"]').getAttribute('data-id');
             if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
-            finalcords.floor.forEach(floor => {
-                if (sameFloorName(floor.name, SelMapName) && Array.isArray(floor.subzones)) {
-                    floor.subzones = floor.subzones.filter(s => (s.sub_zone_id || s.entity_id) !== idToRemove);
-                }
+            const cf = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const sObj = cf && (cf.subzones || []).find(s => (s.sub_zone_id || s.entity_id) === idToRemove);
+            const sName = sObj ? sObj.entity_id : "this sub-zone";
+            bpsConfirm(`Remove sub-zone "${sName}"?`, { confirmText: "Remove", danger: true }).then(ok => {
+                if (!ok) return;
+                finalcords.floor.forEach(floor => {
+                    if (sameFloorName(floor.name, SelMapName) && Array.isArray(floor.subzones)) {
+                        floor.subzones = floor.subzones.filter(s => (s.sub_zone_id || s.entity_id) !== idToRemove);
+                    }
+                });
+                console.log(`Removed sub-zone "${idToRemove}"`);
+                savebuttondiv.appendChild(saveButton);
+                clearCanvas();
+                drawElements();
             });
-            console.log(`Removed sub-zone "${idToRemove}"`);
-            savebuttondiv.appendChild(saveButton);
-            clearCanvas();
-            drawElements();
+            return;
         }
         if (event.target.closest('[data-type="editzone"]')) {
             const idToEdit = event.target.closest('[data-type="editzone"]').getAttribute('data-id');
@@ -892,7 +976,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (drawSubZoneButton.dataset.active === 'false') {
             const floor = finalcords.floor.find(f => sameFloorName(f.name, mapname.value));
             if (!floor || !((floor.zones || []).length)) {
-                alert("Draw at least one zone first — a sub-zone is placed inside a zone.");
+                bpsToast("Draw at least one zone first — a sub-zone is placed inside a zone.");
                 return;
             }
             buttonreset();
@@ -919,22 +1003,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Commit the polygon in the editor into finalcords: add a new zone/sub-zone,
     // or update the existing one when editTarget.id is set.
     function finalizeShape() {
-        if (!mapname.value) { alert("Please enter a floor name!"); return false; }
+        if (!mapname.value) { bpsToast("Please enter a floor name!"); return false; }
         SelMapName = mapname.value;
         const isSub = !!(editTarget && editTarget.kind === 'subzone');
         if (zonePoints.length < 3) {
-            alert((isSub ? "A sub-zone" : "A zone") + " needs at least three corners.");
+            bpsToast((isSub ? "A sub-zone" : "A zone") + " needs at least three corners.");
             return false;
         }
         const nameEl = document.getElementById('zoneName');
         const name = (nameEl ? nameEl.value : "").trim();
-        if (!name) { alert("Please provide a name."); return false; }
+        if (!name) { bpsToast("Please provide a name."); return false; }
         const cords = zonePoints.map(p => ({ x: p.x, y: p.y }));
         const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
 
         if (isSub) {
-            if (!editTarget.parent) { alert("Click inside a zone first to choose the sub-zone's parent."); return false; }
-            if (!floor) { alert("Select a floor first."); return false; }
+            if (!editTarget.parent) { bpsToast("Click inside a zone first to choose the sub-zone's parent."); return false; }
+            if (!floor) { bpsToast("Select a floor first."); return false; }
             if (!Array.isArray(floor.subzones)) floor.subzones = [];
             if (editTarget.id) {
                 const sz = floor.subzones.find(s => (s.sub_zone_id || s.entity_id) === editTarget.id);
@@ -950,7 +1034,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 });
             }
             savebuttondiv.appendChild(saveButton);
-            alert(`Sub-zone saved: ${name}`);
+            bpsToast(`Sub-zone saved: ${name}`);
             return true;
         }
 
@@ -959,13 +1043,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             const z = floor && (floor.zones || []).find(zz => (zz.zone_id || zz.entity_id) === editTarget.id);
             if (z) { z.entity_id = name; z.cords = cords; z.poly = true; }
             savebuttondiv.appendChild(saveButton);
-            alert(`Zone saved: ${name}`);
+            bpsToast(`Zone saved: ${name}`);
             return true;
         }
         zoneName = name;
         const newZone = { zone_id: createZoneId(), entity_id: name, poly: true, cords };
         if (addDataToFloor(finalcords, SelMapName, "zones", newZone)) {
-            alert(`Zone saved: ${name}`);
+            bpsToast(`Zone saved: ${name}`);
             return true;
         }
         return false;
@@ -1038,7 +1122,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Sub-zone: the first click chooses the parent zone and seeds corner 1.
         if (editTarget && editTarget.kind === 'subzone' && !editTarget.parent) {
             const parent = hitZoneAt(pos);
-            if (!parent) { alert("Click inside the zone you want to add a sub-zone to."); return; }
+            if (!parent) { bpsToast("Click inside the zone you want to add a sub-zone to."); return; }
             if (!parent.zone_id) parent.zone_id = createZoneId();
             editTarget.parent = parent.zone_id; // stable id, survives renames / same-named zones
             editTarget.parentPoints = zonePerimeterPoints(parent).map(p => ({ x: p.x, y: p.y }));
@@ -1062,7 +1146,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
         if (zonePoints.length >= MAX_ZONE_POINTS) {
-            alert(`A zone or sub-zone can have at most ${MAX_ZONE_POINTS} corners.`);
+            bpsToast(`A zone or sub-zone can have at most ${MAX_ZONE_POINTS} corners.`);
             return;
         }
         zonePoints.push(constrainForEdit(pos));
@@ -1301,18 +1385,18 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function saveScale() {
         if (!startPoint || !endPoint || startPoint.x === endPoint.x || startPoint.y === endPoint.y) {
-            alert("Please draw a line first.");
+            bpsToast("Please draw a line first.");
             return;
         }
 
         const scaleInput = parseFloat(scaleValue.value);
         if (isNaN(scaleInput) || scaleInput <= 0) {
-            alert("Please enter the actual length in meters.");
+            bpsToast("Please enter the actual length in meters.");
             return;
         }
 
         if (!mapname.value) {
-            alert("Floor name must be set.");
+            bpsToast("Floor name must be set.");
             return;
         }
         SelMapName = mapname.value;
@@ -1400,18 +1484,18 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         } else if (addDeviceButton.dataset.active === 'true') {
             if (!mapname.value) {
-                alert("Floor name must be set.");
+                bpsToast("Floor name must be set.");
                 return;
             }
             SelMapName = mapname.value;
             receiverName = getPickedReceiverName();
 
             if (!tmpcords || !Number.isFinite(tmpcords.x) || !Number.isFinite(tmpcords.y)) {
-                alert("Receiver coordinates must be set — click the floorplan first.");
+                bpsToast("Receiver coordinates must be set — click the floorplan first.");
                 return;
             }
             if (!receiverName) {
-                alert("Select a receiver from the list (or pick Custom name… and type one).");
+                bpsToast("Select a receiver from the list (or pick Custom name… and type one).");
                 return;
             }
 
@@ -1674,7 +1758,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return true;
               } else {
                 console.log(`'${dataType}' with the name '${tmpname}' already exists on ${floorName}.`);
-                alert(`'${dataType}' with the name '${tmpname}' already exists on ${floorName}.`);
+                bpsToast(`'${dataType}' with the name '${tmpname}' already exists on ${floorName}.`);
                 buttonreset();
                 clearCanvas();
                 drawElements();
@@ -2141,18 +2225,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         if(saveresult){
             tmpfinalcords = finalcords;
             saveButton.remove();
-            alert('Saved successfully!');
+            bpsToast('Saved successfully!');
             getSavedMaps();
         }
     });
 
     //When clicking the delete button, remove the floor and reset the canvas.
     deleteButton.addEventListener("click", async function () {
-        const userConfirmed = confirm("Are you sure you want to remove the floor named "+SelMapName+"?");
-        if (!userConfirmed) {
-            alert("Action canceled. No changes were made.");
-            return;
-        }
+        const userConfirmed = await bpsConfirm(
+            `Remove the floor "${SelMapName}"? This deletes its map, zones and sub-zones.`,
+            { confirmText: "Delete floor", danger: true }
+        );
+        if (!userConfirmed) return;
 
         // Keep the removed entries so a failed save can restore them.
         const removedFloors = finalcords.floor.filter(floor => sameFloorName(floor.name, SelMapName));
@@ -2182,7 +2266,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             removefile = false;
         }
         if(saveresult){
-            alert("The floor named "+SelMapName+" has been removed!");
+            bpsToast("The floor named "+SelMapName+" has been removed!");
             console.log("Updated data:", finalcords); // Control the updated data
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             mapname.value = "";
@@ -2192,7 +2276,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     async function savedata(skipScaleCheck = false){
         if(!skipScaleCheck && myScaleVal == null){
-            alert("You have not added a scale, it won't work without it!");
+            bpsToast("You have not added a scale, it won't work without it!");
             return;
         }
 
@@ -2208,7 +2292,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if(new_floor){ // Add filedata to variable 'data' if there is a new floor
             const file = upload.files[0];
             if (!file) {
-                alert("No floor image is selected — please choose the floor image again.");
+                bpsToast("No floor image is selected — please choose the floor image again.");
                 return;
             }
             const extension = file.name.substring(file.name.lastIndexOf('.')); // Get the old file ending
@@ -2243,11 +2327,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 new_floor = false;
                 return true;
             } else {
-                alert('Error saving data!');
+                bpsToast('Error saving data!');
             }
         } catch (error) {
             console.error('Error saving data:', error);
-            alert('Error saving data!');
+            bpsToast('Error saving data!');
         }
     }
 
@@ -2396,7 +2480,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             pollCalibration();
         } catch (e) {
             calibAuto.checked = !calibAuto.checked;
-            alert(e.message);
+            bpsToast(e.message);
         }
     });
 
@@ -2409,7 +2493,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     calibStart.addEventListener('click', async () => {
         if (!mapname.value) {
-            alert('Select a floor first.');
+            bpsToast('Select a floor first.');
             return;
         }
         calibResults.innerHTML = '';
@@ -2421,7 +2505,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }));
             if (!calibTimer) calibTimer = setInterval(pollCalibration, 3000);
         } catch (e) {
-            alert(e.message);
+            bpsToast(e.message);
         }
     });
 
@@ -2429,37 +2513,37 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             renderCalibration(await calibRequest({ action: 'cancel' }));
         } catch (e) {
-            alert(e.message);
+            bpsToast(e.message);
         }
     });
 
     calibApply.addEventListener('click', async () => {
         try {
             const data = await calibRequest({ action: 'apply', floor: mapname.value });
-            alert(`Corrections applied to ${data.applied} receiver(s).`);
+            bpsToast(`Corrections applied to ${data.applied} receiver(s).`);
             // The backend edited bpsdata.txt; reload so a later panel save
             // does not overwrite the corrections with stale data.
             await fetchBPSData();
         } catch (e) {
-            alert(e.message);
+            bpsToast(e.message);
         }
     });
 
     calibReset.addEventListener('click', async () => {
         if (!mapname.value) {
-            alert('Select a floor first.');
+            bpsToast('Select a floor first.');
             return;
         }
         const warning = calibAuto.checked
             ? `Remove calibration corrections from floor "${mapname.value}"? Auto calibration is on and will learn and re-apply them again.`
             : `Remove calibration corrections from floor "${mapname.value}"?`;
-        if (!confirm(warning)) return;
+        if (!(await bpsConfirm(warning, { confirmText: "Remove", danger: true }))) return;
         try {
             const data = await calibRequest({ action: 'reset', floor: mapname.value });
-            alert(`Corrections removed from ${data.reset} receiver(s).`);
+            bpsToast(`Corrections removed from ${data.reset} receiver(s).`);
             await fetchBPSData();
         } catch (e) {
-            alert(e.message);
+            bpsToast(e.message);
         }
     });
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1124,14 +1124,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!(editTarget && !editTarget.id)) return;
             idx = zonePoints.length - 1;
         }
-        // Removing a corner that would drop the shape below a triangle just
-        // discards the whole draw/edit — right-clicking away the last dots
-        // cancels the add/edit instead of getting stuck at three.
-        if (zonePoints.length <= 3) {
+        zonePoints.splice(idx, 1);
+        // Deleting the very last corner cancels the whole add/edit; anything
+        // above that just removes the clicked corner (you can go below three
+        // while editing — Save still requires three).
+        if (!zonePoints.length) {
             cancelShapeEdit();
             return;
         }
-        zonePoints.splice(idx, 1);
         drawZonePreview();
     }
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1545,7 +1545,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     canvas.addEventListener("wheel", (event) => {
         if (!mapReady()) return;
         event.preventDefault();
-        if (drawToolActive()) return; // mid-tool zoom would wipe the overlay
+        // Zoom is allowed while drawing/editing a zone or sub-zone — the polygon
+        // overlay is re-rendered below via drawZonePreview so it isn't wiped.
+        // The receiver/scale tools stay blocked: their overlays (pending marker,
+        // scale line) aren't part of drawZonePreview and a redraw would drop them.
+        const zoneDrawActive = drawAreaButton.dataset.active === 'true'
+            || drawSubZoneButton.dataset.active === 'true';
+        if (drawToolActive() && !zoneDrawActive) return;
         const rect = canvas.getBoundingClientRect();
         const px = (event.clientX - rect.left) * (canvas.width / rect.width);
         const py = (event.clientY - rect.top) * (canvas.height / rect.height);
@@ -1556,14 +1562,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         view.y = py - ((py - view.y) / view.zoom) * newZoom;
         view.zoom = newZoom;
         clampView();
-        redrawAll();
+        if (zoneDrawActive) drawZonePreview(); else redrawAll();
     }, { passive: false });
 
     viewReset.addEventListener("click", () => {
         view.zoom = 1;
         view.x = 0;
         view.y = 0;
-        if (mapReady()) redrawAll();
+        if (!mapReady()) return;
+        // Preserve the in-progress polygon overlay when resetting mid-draw.
+        const zoneDrawActive = drawAreaButton.dataset.active === 'true'
+            || drawSubZoneButton.dataset.active === 'true';
+        if (zoneDrawActive) drawZonePreview(); else redrawAll();
     });
 
     // =================================================================


### PR DESCRIPTION
Follow-up polish to the sub-zones feature (the base feature and the panel `Cache-Control: no-cache` fix already merged in #38). Bundles the editor UX work done after that merge:

- **Zoom while drawing/editing** a zone or sub-zone — the wheel no longer freezes mid-tool; it re-renders the in-progress polygon (Reset view too). Receiver/scale tools stay blocked since their overlays aren't part of that redraw.
- **Right-click a corner to delete it** (zones and sub-zones). The mousedown now ignores non-left buttons, so right-click no longer adds a phantom corner or deletes a random one. Deleting corners has **no minimum** — removing the **last** corner cancels the whole draw/edit.
- **X cancel button** on the floating name field to discard the current draw/edit (edits work on a copy, so the saved shape is untouched).
- **12-corner cap** for zones and sub-zones.
- **No native pop-ups**: all `alert()`/`confirm()` replaced with in-window UI — a non-blocking **toast** for informational messages and a themed **modal** for confirmations (Enter/Esc/backdrop). Added **delete confirmations** for receivers, zones (naming how many sub-zones go with it), and sub-zones; delete-floor and reset-corrections use the modal too.

Panel + CSS only. Verified: JS bracket-balance, geometry unit tests still pass, and this branch's tree is identical to the `feature-subzones` branch you've been testing from.

Panel-only: reload the panel after updating (the `no-cache` header from #38 means a normal reload now picks up changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)