### PR TITLE
Receiver picker: search bar + cancel X

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -65,6 +65,8 @@ canvas {
     z-index: 1000;
 }
 .zone-cancel-btn:hover { background: #b71c1c; }
+/* Receiver-picker cancel X: pinned to the picker box's top-right corner. */
+.rec-cancel-btn { position: absolute; top: -8px; right: -8px; }
 
 /* In-window dialogs (replace native alert/confirm) */
 .bps-modal-overlay {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1420,9 +1420,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Place receiver functionality
     // =================================================================
 
-    let entityInput = null; // Floating receiver picker (select + custom input)
+    let entityInput = null; // Floating receiver picker (search + select + custom input)
     let receiverSelect = null;
     let receiverCustomInput = null;
+    let receiverSearchInput = null;
+    let availableReceiverNames = []; // unplaced receiver names, for the search filter
     const CUSTOM_RECEIVER_OPTION = "__custom__";
 
     function getPickedReceiverName() {
@@ -1431,6 +1433,38 @@ document.addEventListener('DOMContentLoaded', async () => {
             return receiverCustomInput.value.trim();
         }
         return receiverSelect.value.trim();
+    }
+
+    // Render the receiver <option>s, filtered by the search query. Keeps the
+    // placeholder and "Custom name…" entries, and preserves the current pick
+    // when it still matches the filter.
+    function renderReceiverOptions(query = "") {
+        if (!receiverSelect) return;
+        const q = query.trim().toLowerCase();
+        const prev = receiverSelect.value;
+        receiverSelect.innerHTML = "";
+        const placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.textContent = "-- Select receiver --";
+        receiverSelect.appendChild(placeholder);
+        availableReceiverNames
+            .filter(name => !q || name.toLowerCase().includes(q))
+            .forEach(name => {
+                const option = document.createElement("option");
+                option.value = name;
+                option.textContent = name;
+                receiverSelect.appendChild(option);
+            });
+        const custom = document.createElement("option");
+        custom.value = CUSTOM_RECEIVER_OPTION;
+        custom.textContent = "Custom name…";
+        receiverSelect.appendChild(custom);
+        if ([...receiverSelect.options].some(o => o.value === prev)) {
+            receiverSelect.value = prev;
+        } else {
+            receiverSelect.value = "";
+            if (receiverCustomInput) receiverCustomInput.style.display = "none";
+        }
     }
 
     function populateReceiverSelect() {
@@ -1443,26 +1477,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                 (floor.receivers || []).forEach(r => placedAnywhere.add(r.entity_id));
             });
         }
-        receiverSelect.innerHTML = "";
-        const placeholder = document.createElement("option");
-        placeholder.value = "";
-        placeholder.textContent = "-- Select receiver --";
-        receiverSelect.appendChild(placeholder);
-        receiverOptions
-            .filter(name => !placedAnywhere.has(name))
-            .forEach(name => {
-                const option = document.createElement("option");
-                option.value = name;
-                option.textContent = name;
-                receiverSelect.appendChild(option);
-            });
-        const custom = document.createElement("option");
-        custom.value = CUSTOM_RECEIVER_OPTION;
-        custom.textContent = "Custom name…";
-        receiverSelect.appendChild(custom);
-        receiverSelect.value = "";
-        receiverCustomInput.value = "";
-        receiverCustomInput.style.display = "none";
+        availableReceiverNames = receiverOptions.filter(name => !placedAnywhere.has(name));
+        if (receiverSearchInput) receiverSearchInput.value = "";
+        renderReceiverOptions("");
+        if (receiverCustomInput) {
+            receiverCustomInput.value = "";
+            receiverCustomInput.style.display = "none";
+        }
     }
 
     addDeviceButton.addEventListener('click', () => {
@@ -1530,6 +1551,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             entityInput = document.createElement("div");
             entityInput.classList.add("rec-input-wrap");
 
+            receiverSearchInput = document.createElement("input");
+            receiverSearchInput.type = "text";
+            receiverSearchInput.id = "receiverSearch";
+            receiverSearchInput.placeholder = "Search receivers…";
+            receiverSearchInput.classList.add("rec-input");
+            receiverSearchInput.addEventListener("input", () => renderReceiverOptions(receiverSearchInput.value));
+
             receiverSelect = document.createElement("select");
             receiverSelect.id = "receiverName";
             receiverSelect.classList.add("rec-input");
@@ -1546,6 +1574,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.classList.add("rec-input");
             receiverCustomInput.style.display = "none";
 
+            entityInput.appendChild(receiverSearchInput);
             entityInput.appendChild(receiverSelect);
             entityInput.appendChild(receiverCustomInput);
             document.body.appendChild(entityInput);

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1424,6 +1424,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let receiverSelect = null;
     let receiverCustomInput = null;
     let receiverSearchInput = null;
+    let receiverCancelBtn = null; // X that cancels receiver placement
     let availableReceiverNames = []; // unplaced receiver names, for the search filter
     const CUSTOM_RECEIVER_OPTION = "__custom__";
 
@@ -1433,6 +1434,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             return receiverCustomInput.value.trim();
         }
         return receiverSelect.value.trim();
+    }
+
+    // Abort the Place Receiver flow and discard the pending marker.
+    function cancelReceiverPlacement() {
+        removeListeners();
+        buttonreset(); // resets the Place Receiver button and hides the picker
+        tmpcords = null;
+        receiverName = "";
+        clearCanvas();
+        drawElements();
     }
 
     // Render the receiver <option>s, filtered by the search query. Keeps the
@@ -1574,9 +1585,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.classList.add("rec-input");
             receiverCustomInput.style.display = "none";
 
+            receiverCancelBtn = document.createElement("button");
+            receiverCancelBtn.type = "button";
+            receiverCancelBtn.textContent = "✕";
+            receiverCancelBtn.title = "Cancel receiver placement";
+            receiverCancelBtn.classList.add("zone-cancel-btn", "rec-cancel-btn");
+            receiverCancelBtn.addEventListener("click", cancelReceiverPlacement);
+
             entityInput.appendChild(receiverSearchInput);
             entityInput.appendChild(receiverSelect);
             entityInput.appendChild(receiverCustomInput);
+            entityInput.appendChild(receiverCancelBtn);
             document.body.appendChild(entityInput);
             // Populate only on creation; the session-start populate happens
             // in the Place Receiver activation. Repopulating on every canvas


### PR DESCRIPTION
Two additions to the receiver picker (the floating box shown after you click the map with **Place Receiver** active):

**Search bar** — a field above the dropdown that live-filters the receiver options as you type (case-insensitive substring). The `-- Select receiver --` placeholder and `Custom name…` entries always stay, a still-matching pick is preserved, and it resets each time you start a placement. Handy on installs with many proxies.

**Cancel X** — a red ✕ pinned to the box's top-right corner cancels the placement: removes the placement click handler, resets the Place Receiver button, discards the pending coordinates, and clears the pending marker from the canvas.

Panel-only (`script.js` + a one-line CSS rule; reuses the existing `rec-input` and `zone-cancel-btn` styling). Verified with the JS bracket-balance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)