### PR TITLE
Split BPS sensors into one device per tracker, nested under the Bermuda device

### DIFF
--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -1,6 +1,7 @@
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 import logging
 
@@ -17,7 +18,24 @@ SENSOR_KINDS = [
 ]
 
 
-def ensure_sensors_for_entity(entity, sensors_cache, new_sensors):
+def find_bermuda_via_device(hass, entity):
+    """Identifier of the Bermuda device that owns this tracker's distance_to
+    sensors, so the BPS device can nest under it (via_device). None when it
+    can't be resolved (e.g. Bermuda not loaded yet) — the BPS device then just
+    stands on its own.
+    """
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    prefix = f"sensor.{entity}_distance_to_"
+    for e in ent_reg.entities.values():
+        if e.device_id and e.entity_id.startswith(prefix):
+            dev = dev_reg.async_get(e.device_id)
+            if dev and dev.identifiers:
+                return next(iter(dev.identifiers))
+    return None
+
+
+def ensure_sensors_for_entity(hass, entity, sensors_cache, new_sensors):
     """Create any missing BPS sensors for a tracked device.
 
     Only the in-memory cache decides whether a sensor exists. A registry
@@ -27,10 +45,11 @@ def ensure_sensors_for_entity(entity, sensors_cache, new_sensors):
     permanently dead (updates are dropped when the cache has no object).
     async_add_entities re-claims the registry entry via unique_id.
     """
+    via_device = find_bermuda_via_device(hass, entity)
     for suffix, label in SENSOR_KINDS:
         entity_id = f"sensor.{entity}_{suffix}"
         if entity_id not in sensors_cache:
-            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id, entity)
+            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id, entity, via_device)
             sensors_cache[entity_id] = sensor
             new_sensors.append(sensor)
 
@@ -66,7 +85,7 @@ def get_filtered_entities(hass):
 
 class CustomDistanceSensor(SensorEntity):
     """A representation of a custom sensor"""
-    def __init__(self, name, unique_id, entity_id, device_key=None):
+    def __init__(self, name, unique_id, entity_id, device_key=None, via_device=None):
         self._name = name
         self._unique_id = unique_id
         self._attr_name = name
@@ -76,14 +95,18 @@ class CustomDistanceSensor(SensorEntity):
         self.entity_id = entity_id
         # Group each tracked device's BPS sensors under their own device rather
         # than one shared "BLE Positioning System" bucket. All four sensors for
-        # a tracked device share the same identifier, so they land together.
+        # a tracked device share the same identifier, so they land together, and
+        # via_device nests that device under its Bermuda tracker device.
         if device_key:
-            self._attr_device_info = DeviceInfo(
+            info = DeviceInfo(
                 identifiers={("bps", device_key)},
                 name=f"{device_key} (BPS)",
                 manufacturer="BPS",
                 model="BLE Positioning System",
             )
+            if via_device:
+                info["via_device"] = via_device
+            self._attr_device_info = info
 
     @property
     def name(self):
@@ -222,7 +245,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     new_sensors = []
     for entity in entities:
-        ensure_sensors_for_entity(entity, hass.data["bps_sensors"], new_sensors)
+        ensure_sensors_for_entity(hass, entity, hass.data["bps_sensors"], new_sensors)
 
     if new_sensors:
         async_add_entities(new_sensors, update_before_add=True)
@@ -240,7 +263,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         new_sensors = []
 
         for entity in new_entities:
-            ensure_sensors_for_entity(entity, sensors_cache, new_sensors)
+            ensure_sensors_for_entity(hass, entity, sensors_cache, new_sensors)
 
         if new_sensors:
             async_add_entities(new_sensors, update_before_add=True)

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -28,10 +28,13 @@ def find_bermuda_via_device(hass, entity):
     dev_reg = dr.async_get(hass)
     prefix = f"sensor.{entity}_distance_to_"
     for e in ent_reg.entities.values():
-        if e.device_id and e.entity_id.startswith(prefix):
+        if e.platform == "bermuda" and e.device_id and e.entity_id.startswith(prefix):
             dev = dev_reg.async_get(e.device_id)
             if dev and dev.identifiers:
-                return next(iter(dev.identifiers))
+                # Prefer a bermuda identifier so the link points at the tracker
+                # device even if it carries identifiers from several integrations.
+                berm = [i for i in dev.identifiers if i[0] == "bermuda"]
+                return berm[0] if berm else next(iter(dev.identifiers))
     return None
 
 
@@ -74,14 +77,24 @@ def is_legacy_bps_entity_id(entity_id):
     return parts[:half] == parts[half:]
 
 def get_filtered_entities(hass):
-    """Fetch and filter sensors based on their entity_id"""
-    sensors = [state for state in hass.states.async_all() if state.entity_id.startswith("sensor.")]
-    filtered = [
-        state.entity_id.replace("sensor.", "").split("_distance_to_")[0]
-        for state in sensors
-        if "_distance_to_" in state.entity_id
-    ]
-    return list(set(filtered))
+    """Tracked-device slugs from Bermuda's per-scanner distance sensors.
+
+    Only entities from the `bermuda` integration count. Other integrations also
+    expose `_distance_to_` sensors (e.g. an ESPHome mmWave presence sensor's
+    `..._distance_to_detection_object`); those aren't trackers and must not get
+    BPS zone/floor sensors or a device.
+    """
+    ent_reg = er.async_get(hass)
+    filtered = set()
+    for state in hass.states.async_all():
+        eid = state.entity_id
+        if not (eid.startswith("sensor.") and "_distance_to_" in eid):
+            continue
+        entry = ent_reg.async_get(eid)
+        if entry is None or entry.platform != "bermuda":
+            continue
+        filtered.add(eid.replace("sensor.", "").split("_distance_to_")[0])
+    return list(filtered)
 
 class CustomDistanceSensor(SensorEntity):
     """A representation of a custom sensor"""

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -1,6 +1,7 @@
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import DeviceInfo
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def ensure_sensors_for_entity(entity, sensors_cache, new_sensors):
     for suffix, label in SENSOR_KINDS:
         entity_id = f"sensor.{entity}_{suffix}"
         if entity_id not in sensors_cache:
-            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id)
+            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id, entity)
             sensors_cache[entity_id] = sensor
             new_sensors.append(sensor)
 
@@ -65,7 +66,7 @@ def get_filtered_entities(hass):
 
 class CustomDistanceSensor(SensorEntity):
     """A representation of a custom sensor"""
-    def __init__(self, name, unique_id, entity_id):
+    def __init__(self, name, unique_id, entity_id, device_key=None):
         self._name = name
         self._unique_id = unique_id
         self._attr_name = name
@@ -73,6 +74,16 @@ class CustomDistanceSensor(SensorEntity):
         self._state = "unknown"
         self._attrs = {}
         self.entity_id = entity_id
+        # Group each tracked device's BPS sensors under their own device rather
+        # than one shared "BLE Positioning System" bucket. All four sensors for
+        # a tracked device share the same identifier, so they land together.
+        if device_key:
+            self._attr_device_info = DeviceInfo(
+                identifiers={("bps", device_key)},
+                name=f"{device_key} (BPS)",
+                manufacturer="BPS",
+                model="BLE Positioning System",
+            )
 
     @property
     def name(self):


### PR DESCRIPTION
The per-tracked-device sensors carried no `device_info`, so Home Assistant listed them flat under the integration.

- **Per-tracker devices**: each `CustomDistanceSensor` gets `device_info` keyed by the tracked-device name (`identifiers={("bps", <device>)}`, `name="<device> (BPS)"`), so a tracker's four sensors — **BPS Zone / Floor / Nearest Zone / Sub-Zone** — group under one device.
- **Nested under Bermuda**: the BPS device sets `via_device` to the Bermuda tracker device that owns the tracker's `distance_to` sensors (resolved via the entity registry → `device_id` → the device's `bermuda` identifier), so `<device> (BPS)` shows as connected via its Bermuda device. Falls back to standalone if Bermuda can't be resolved.
- **Bermuda-only trackers**: `get_filtered_entities` now only treats entities from the `bermuda` integration as trackers. Previously any `sensor.*_distance_to_*` matched, so a non-Bermuda source (e.g. an ESPHome mmWave sensor's `_distance_to_detection_object`) got picked up and produced junk BPS sensors + a device. Stale entities for now-excluded sources are pruned by the existing setup cleanup.
- Parent resolution also requires the matched distance entity to be `bermuda`-platform and prefers a `bermuda` identifier, so the nesting points at the right tracker.

**Entity IDs are unchanged.** Reload the integration (or restart HA) after updating.

### Fixed issues
Fixed in this PR:
- Closes #37 — Device per tracked beacon.
- Closes #39 — Ignore `sensor.*_distance_to_*` entities from integrations other than Bermuda.

Also now resolved by work already shipped to the fork (closed here so the tracker is up to date):
- Closes #33 — FR: micro locations (sub-zones).
- Closes #34 — Delete zone (delete with confirmation, plus editable zones).
- Closes #36 — 8 points/edges per zone (zones/sub-zones now support up to 12 corners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)