### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.0.1"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
Bump `manifest.json` version 1.0.1 → 1.1.0 for the release covering the sub-zones feature, the zone/sub-zone editor improvements, in-window dialogs, and per-tracker devices nested under Bermuda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)