### PR TITLE
Fix periodic 'Attribute hass is None' Jinja error

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -668,7 +668,7 @@ async def async_setup(hass, config):
 
         jinja_code = """
         {{
-            expand(states.sensor)
+            states.sensor
             | selectattr("entity_id", "search", "_distance_to_")
             | map(attribute="entity_id")
             | unique
@@ -897,7 +897,7 @@ class BPSReadAPIText(HomeAssistantView):
         bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
         entityjinja = """
         {{
-            expand(states.sensor)
+            states.sensor
             | selectattr("entity_id", "search", "_distance_to_")
             | map(attribute="entity_id")
             | map("replace", "sensor.", "")
@@ -910,7 +910,7 @@ class BPSReadAPIText(HomeAssistantView):
         # the same Bermuda sensors the tracked entities come from.
         receiverjinja = """
         {{
-            expand(states.sensor)
+            states.sensor
             | selectattr("entity_id", "search", "_distance_to_")
             | map(attribute="entity_id")
             | map("regex_replace", "^.*?_distance_to_", "")


### PR DESCRIPTION
Fixes the noisy, intermittent log line:

> `[custom_components.bps] Error executing Jinja code: Attribute hass is None for <entity unknown.unknown=unknown>`

**Cause.** The tracked-entities loop (rendered every second) and the two `read_text` templates enumerate Bermuda's distance sensors with `expand(states.sensor) | selectattr("entity_id","search","_distance_to_")`. `expand()` is for **groups** — it recursively resolves the members of any entity that has an `entity_id` attribute. When one of those members points at a removed/`unknown` entity, HA constructs a placeholder `<entity unknown.unknown=unknown>` that has no `hass`, which raises "Attribute hass is None" during rendering. It's intermittent (depends on those entities' transient state) and caught at INFO, so it's harmless — the affected 1‑second cycle is just skipped — but it spams the log.

**Fix.** BPS doesn't need `expand()`: Bermuda's `*_distance_to_*` sensors are plain sensors already present in `states.sensor`. Iterate `states.sensor` directly (no group expansion, no member resolution) in all three templates. Same filtering/result, without the fragile group-member lookup.

Backend-only; reload the integration or restart HA after updating.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)