### PR TITLE
Calibration UI: diagonal matrix headers + tooltips below the pointer

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -15,7 +15,7 @@
     
     /* Positionering */
     position: absolute;
-    bottom: 125%; /* Placera ovanför */
+    top: 125%; /* below the icon, so it isn't clipped at the top of the page */
     left: 50%;
     transform: translateX(-50%);
     opacity: 0;
@@ -2883,6 +2883,25 @@ select.bps-input { cursor: pointer; }
 }
 .bps-calib-status { font-size: 13px; color: hsl(var(--muted-foreground)); margin: 6px 0 12px; }
 .bps-calib-matrix { overflow-x: auto; }
+/* Diagonal (45°) column headers so long scanner names aren't cut off. */
+.bps-calib-matrix th.bps-calib-colhead {
+    height: 130px;
+    padding: 0;
+    vertical-align: bottom;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 11px;
+}
+.bps-calib-matrix th.bps-calib-colhead > div {
+    width: 22px;
+    transform: translate(11px, 0) rotate(-45deg);
+    transform-origin: left bottom;
+}
+.bps-calib-matrix th.bps-calib-colhead > div > span {
+    display: inline-block;
+    padding: 0 4px;
+    white-space: nowrap;
+}
 
 /* Dark remaps for utility classes baked into generated HTML */
 .text-gray-500 { color: hsl(var(--muted-foreground)); }

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -15,6 +15,7 @@
     
     /* Positionering */
     position: absolute;
+    z-index: 1000; /* above the matrix's transformed diagonal headers */
     top: 125%; /* below the icon, so it isn't clipped at the top of the page */
     left: 50%;
     transform: translateX(-50%);

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2446,7 +2446,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         slugs.forEach(s => {
             html += `<th class="bps-calib-colhead"><div><span>${escHtml(s)}</span></div></th>`;
         });
-        html += '<th style="padding:2px 6px">correction</th></tr>';
+        html += '<th class="bps-calib-colhead"><div><span>correction</span></div></th></tr>';
         slugs.forEach(tx => {
             html += `<tr><td style="padding:2px 6px; white-space:nowrap">${escHtml(tx)}${lowConfidence.includes(tx) ? ' ⚠' : ''}</td>`;
             slugs.forEach(rx => {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2444,7 +2444,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         let html = '<table style="border-collapse:collapse; font-size:11px; margin-top:8px">'
             + '<tr><th style="text-align:left; padding:2px 6px">tx \\ rx</th>';
         slugs.forEach(s => {
-            html += `<th style="padding:2px 3px"><div style="writing-mode:vertical-rl; transform:rotate(180deg); max-height:140px; overflow:hidden">${escHtml(s)}</div></th>`;
+            html += `<th class="bps-calib-colhead"><div><span>${escHtml(s)}</span></div></th>`;
         });
         html += '<th style="padding:2px 6px">correction</th></tr>';
         slugs.forEach(tx => {


### PR DESCRIPTION
Two calibration-page UI fixes.

**#43 — long scanner names cut off in the matrix header.** The column headers rendered with `writing-mode: vertical-rl` and `max-height: 140px; overflow: hidden`, so long names (e.g. `name_device_last-6-of-mac`) were clipped at the top. They're now **45° diagonal labels** (a `.bps-calib-colhead` class) with no height clip, so the full name is readable and takes less vertical space than upright text — as suggested in the issue.

**#35 — help tooltips clipped off the top.** `.tooltip .tooltip-text` was positioned `bottom: 125%` (above the ❓), so the calibration page's tooltips (near the top of the panel) were cut off. Moved to `top: 125%` so they appear **below** the icon. (Applies to the ❓ tooltips app-wide — below is safer than above for these top-of-panel icons.)

Verified in a preview harness with a mock matrix (long names render diagonally, unclipped) and by confirming the tooltip computes to `top: 30px` (below) rather than bottom-anchored.

Panel-only (`script.js` header markup + `bpsstyle.css`). Reload the panel after updating.

Closes #43.
Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)