### PR TITLE
Mark offline receivers in red with an (Offline) prefix (live, Bermuda-liveness)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -934,6 +934,26 @@ class BPSReadAPIText(HomeAssistantView):
         except Exception as e:
             _LOGGER.info(f"Error during the execution of the receiver Jinja code: {e}")
 
+        # A scanner is "online" only if at least one distance-to sensor is
+        # currently a valid number. When every reading is unavailable/unknown
+        # the scanner isn't being heard (powered off) or its entities are gone,
+        # so the panel marks it offline.
+        offline_receivers = []
+        try:
+            online = set()
+            for st in hass.states.async_all("sensor"):
+                eid = st.entity_id
+                if "_distance_to_" not in eid:
+                    continue
+                try:
+                    float(st.state)
+                except (ValueError, TypeError):
+                    continue  # unavailable / unknown / non-numeric
+                online.add(eid.split("_distance_to_", 1)[1])
+            offline_receivers = [r for r in receivers if r not in online]
+        except Exception as e:
+            _LOGGER.info(f"Error computing offline receivers: {e}")
+
         try:
             if not bpsdata_file_path.is_file(): # Check if the file exists
                 return web.Response(status=404, text="bpsdata.txt not found")
@@ -945,7 +965,8 @@ class BPSReadAPIText(HomeAssistantView):
             return web.json_response({
                 "coordinates": content,
                 "entities": entities,
-                "receivers": receivers
+                "receivers": receivers,
+                "offline_receivers": offline_receivers
             })
         
         except Exception as e:

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.const import UnitOfLength
 from homeassistant.util.unit_conversion import DistanceConverter
+from homeassistant.util import slugify
 import numpy as np
 from scipy.optimize import least_squares
 import voluptuous as vol
@@ -55,6 +56,10 @@ tracked_listeners = {}
 tracked_entities = []
 new_global_data = {}
 secToUpdate = 1
+# A scanner Bermuda hasn't heard for this long is treated as offline; the
+# liveness is polled from dump_devices every RECEIVER_DUMP_INTERVAL seconds.
+RECEIVER_OFFLINE_SECS = 30
+RECEIVER_DUMP_INTERVAL = 15
 apitricords = []
 # A tracker not detected by any receiver for this long disappears from the
 # map and its zone/floor sensors go to unknown. Override with a top-level
@@ -158,7 +163,68 @@ async def update_tracked_entities(hass, jinja_code):
         except Exception as e:
             _LOGGER.info(f"Error executing Jinja code: {e}")
 
+        # Refresh receiver liveness on its own slower cadence.
+        now_ts = time.time()
+        if now_ts - getattr(update_tracked_entities, "last_liveness", 0.0) >= RECEIVER_DUMP_INTERVAL:
+            update_tracked_entities.last_liveness = now_ts
+            await update_receiver_liveness(hass)
+
         await asyncio.sleep(secToUpdate)  # Run every X seconds, set timer in global variables
+
+
+async def update_receiver_liveness(hass):
+    """Refresh the set of offline receivers (scanners) from bermuda.dump_devices.
+
+    Proximity-independent: the probes advertise iBeacons that the scanners hear
+    from each other, so a live scanner's last_seen advances even when no tracked
+    device is home (a device being far away must NOT mark every receiver
+    offline). Mirrors the Lovelace card's liveness tier, including the
+    monotonic-stamp re-anchoring for a fleet-wide outage.
+    """
+    dom = hass.data.setdefault(DOMAIN, {})
+    try:
+        devices = await hass.services.async_call(
+            "bermuda", "dump_devices", {"configured_devices": True},
+            blocking=True, return_response=True,
+        ) or {}
+    except Exception as e:
+        _LOGGER.info(f"Receiver liveness: dump_devices unavailable: {e}")
+        return
+    if not isinstance(devices, dict):
+        return
+
+    # last_seen is monotonic (seconds since HA boot), not epoch; the freshest
+    # stamp in the payload is "now" on that clock.
+    newest = 0.0
+    for dev in devices.values():
+        ls = dev.get("last_seen") if isinstance(dev, dict) else None
+        if isinstance(ls, (int, float)) and ls > newest:
+            newest = ls
+
+    prev_newest = dom.get("rl_newest")
+    now = time.time()
+    # Re-anchor only when the payload aged forward. If newest didn't advance
+    # (every scanner stopped hearing adverts — a real fleet-wide outage) keep
+    # the previous ages so they grow with wall time and cross the timeout; a
+    # large backward jump is a monotonic-clock reset (HA reboot), so accept it.
+    if not (prev_newest is not None and prev_newest - 60 < newest <= prev_newest):
+        ages = {}
+        for dev in devices.values():
+            if not isinstance(dev, dict) or dev.get("_is_scanner") is not True:
+                continue
+            slug = slugify(str(dev.get("name") or ""))
+            if not slug:
+                continue
+            ls = dev.get("last_seen")
+            ages[slug] = (newest - ls) if isinstance(ls, (int, float)) else float("inf")
+        dom["rl_newest"] = newest
+        dom["rl_anchor_wall"] = now
+        dom["rl_ages"] = ages
+
+    ages = dom.get("rl_ages", {})
+    elapsed = max(0.0, now - dom.get("rl_anchor_wall", now))
+    dom["rl_offline"] = [s for s, age in ages.items() if age + elapsed > RECEIVER_OFFLINE_SECS]
+
 
 async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
@@ -589,6 +655,7 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSTrackerIconsListAPI())
             hass.http.register_view(BPSUploadTrackerIconAPI())
             hass.http.register_view(BPSReadAPIText())
+            hass.http.register_view(BPSReceiverStatusAPI())
             hass.http.register_view(BPSCordsAPI(hass))
             hass.http.register_view(BPSCalibrationAPI())
             hass.data["bps_views_registered"] = True
@@ -934,25 +1001,9 @@ class BPSReadAPIText(HomeAssistantView):
         except Exception as e:
             _LOGGER.info(f"Error during the execution of the receiver Jinja code: {e}")
 
-        # A scanner is "online" only if at least one distance-to sensor is
-        # currently a valid number. When every reading is unavailable/unknown
-        # the scanner isn't being heard (powered off) or its entities are gone,
-        # so the panel marks it offline.
-        offline_receivers = []
-        try:
-            online = set()
-            for st in hass.states.async_all("sensor"):
-                eid = st.entity_id
-                if "_distance_to_" not in eid:
-                    continue
-                try:
-                    float(st.state)
-                except (ValueError, TypeError):
-                    continue  # unavailable / unknown / non-numeric
-                online.add(eid.split("_distance_to_", 1)[1])
-            offline_receivers = [r for r in receivers if r not in online]
-        except Exception as e:
-            _LOGGER.info(f"Error computing offline receivers: {e}")
+        # Offline scanners come from the Bermuda-liveness poller (proximity-
+        # independent), refreshed on a slower cadence by the background loop.
+        offline_receivers = list(hass.data.get(DOMAIN, {}).get("rl_offline", []))
 
         try:
             if not bpsdata_file_path.is_file(): # Check if the file exists
@@ -972,6 +1023,18 @@ class BPSReadAPIText(HomeAssistantView):
         except Exception as e:
             _LOGGER.error(f"Failed to read coordinates: {e}")
             return web.Response(status=500, text="Failed to read coordinates")
+
+class BPSReceiverStatusAPI(HomeAssistantView):
+    """Current offline receivers (Bermuda liveness), polled live by the panel."""
+    url = "/api/bps/receiver_status"
+    name = "api:bps:receiver_status"
+    requires_auth = False
+
+    async def get(self, request):
+        hass = request.app["hass"]
+        offline = hass.data.get(DOMAIN, {}).get("rl_offline", [])
+        return web.json_response({"offline": list(offline)})
+
 
 class BPSMapsListAPI(HomeAssistantView):
     """API to list map files in /www/bps_maps."""

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.template import Template
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.const import UnitOfLength
 from homeassistant.util.unit_conversion import DistanceConverter
 from homeassistant.util import slugify
@@ -172,41 +173,53 @@ async def update_tracked_entities(hass, jinja_code):
         await asyncio.sleep(secToUpdate)  # Run every X seconds, set timer in global variables
 
 
-async def update_receiver_liveness(hass):
-    """Refresh the set of offline receivers (scanners) from bermuda.dump_devices.
+# State strings that mean "not working" when a status/availability entity is read.
+_OFFLINE_STATES = {
+    "", "unavailable", "unknown", "none", "off", "false",
+    "not_home", "offline", "disconnected", "no",
+}
 
-    Proximity-independent: the probes advertise iBeacons that the scanners hear
-    from each other, so a live scanner's last_seen advances even when no tracked
-    device is home (a device being far away must NOT mark every receiver
-    offline). Mirrors the Lovelace card's liveness tier, including the
-    monotonic-stamp re-anchoring for a fleet-wide outage.
+
+def _state_looks_online(state):
+    """Whether a status/availability entity's state reads as online."""
+    if state is None:
+        return False
+    return str(state).strip().lower() not in _OFFLINE_STATES
+
+
+def _scanner_slugs_and_readings(hass):
+    """Single pass over distance sensors: every scanner slug Bermuda exposes,
+    and the subset that currently has a live reading (for the heuristic tier)."""
+    slugs = set()
+    with_reading = set()
+    for st in hass.states.async_all("sensor"):
+        eid = st.entity_id
+        if "_distance_to_" not in eid:
+            continue
+        slug = eid.split("_distance_to_", 1)[1]
+        slugs.add(slug)
+        if st.state not in (None, "", "unknown", "unavailable"):
+            with_reading.add(slug)
+    return slugs, with_reading
+
+
+def _refresh_dump_ages(hass, dom, devices):
+    """Update the cached per-scanner Bermuda-liveness ages from a dump payload.
+
+    last_seen is monotonic (seconds since HA boot), not epoch; the freshest
+    stamp in the payload is "now" on that clock. Re-anchor only when the payload
+    aged forward — if newest didn't advance (every scanner stopped hearing
+    adverts, a real fleet-wide outage) keep the previous ages so they grow with
+    wall time and cross the timeout; a large backward jump is a monotonic clock
+    reset (HA reboot), so accept it.
     """
-    dom = hass.data.setdefault(DOMAIN, {})
-    try:
-        devices = await hass.services.async_call(
-            "bermuda", "dump_devices", {"configured_devices": True},
-            blocking=True, return_response=True,
-        ) or {}
-    except Exception as e:
-        _LOGGER.info(f"Receiver liveness: dump_devices unavailable: {e}")
-        return
-    if not isinstance(devices, dict):
-        return
-
-    # last_seen is monotonic (seconds since HA boot), not epoch; the freshest
-    # stamp in the payload is "now" on that clock.
     newest = 0.0
     for dev in devices.values():
         ls = dev.get("last_seen") if isinstance(dev, dict) else None
         if isinstance(ls, (int, float)) and ls > newest:
             newest = ls
-
     prev_newest = dom.get("rl_newest")
     now = time.time()
-    # Re-anchor only when the payload aged forward. If newest didn't advance
-    # (every scanner stopped hearing adverts — a real fleet-wide outage) keep
-    # the previous ages so they grow with wall time and cross the timeout; a
-    # large backward jump is a monotonic-clock reset (HA reboot), so accept it.
     if not (prev_newest is not None and prev_newest - 60 < newest <= prev_newest):
         ages = {}
         for dev in devices.values():
@@ -221,9 +234,115 @@ async def update_receiver_liveness(hass):
         dom["rl_anchor_wall"] = now
         dom["rl_ages"] = ages
 
+
+def _build_device_availability(hass):
+    """Maps for the device-availability tier: slug -> device, device -> entities.
+
+    A device slug that isn't unique is dropped (ambiguous) so a stale/duplicate
+    device can't decide a receiver's status.
+    """
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    slug_to_device = {}
+    ambiguous = set()
+    for d in dev_reg.devices.values():
+        name = d.name_by_user or d.name
+        if not name:
+            continue
+        slug = slugify(name)
+        if not slug:
+            continue
+        if slug in slug_to_device and slug_to_device[slug] != d.id:
+            ambiguous.add(slug)
+        else:
+            slug_to_device[slug] = d.id
+    for slug in ambiguous:
+        slug_to_device.pop(slug, None)
+    device_entities = {}
+    for ent in ent_reg.entities.values():
+        if ent.device_id:
+            device_entities.setdefault(ent.device_id, []).append(ent.entity_id)
+    return slug_to_device, device_entities
+
+
+async def update_receiver_liveness(hass):
+    """Recompute the set of offline receivers, mirroring the Lovelace card's
+    tiered status so the panel and the card agree.
+
+    For each receiver slug Bermuda exposes, the first tier that resolves wins:
+      1. Bermuda scanner liveness — last advert heard within RECEIVER_OFFLINE_SECS.
+         Proximity-independent: the probes advertise iBeacons the scanners hear
+         from each other, so a live scanner ages fresh even with no tracked
+         device home. But Bermuda drops a downed proxy from the scanner list, so
+         this tier can't see it at all — hence the fallbacks below.
+      2. A `binary_sensor.<slug>_status` connectivity sensor.
+      3. The receiver's HA device: online while any of its entities is not
+         `unavailable`; a connectivity entity on the device is authoritative.
+      4. Distance heuristic (last resort): working if some tracker got a reading
+         through it recently. Only reached for a scanner with no liveness and no
+         mapped device (6 of this install's receivers, whose device name doesn't
+         slugify to the receiver id). An *up* scanner is caught by tier 1, so
+         this can't misfire when every tracked device leaves home — it only
+         decides a scanner that is both absent from the dump and deviceless.
+    A receiver no tier can resolve at all is left ONLINE (never flagged).
+    """
+    dom = hass.data.setdefault(DOMAIN, {})
+    try:
+        devices = await hass.services.async_call(
+            "bermuda", "dump_devices", {"configured_devices": True},
+            blocking=True, return_response=True,
+        ) or {}
+    except Exception as e:
+        _LOGGER.info(f"Receiver liveness: dump_devices unavailable: {e}")
+        devices = None
+
+    if isinstance(devices, dict):
+        _refresh_dump_ages(hass, dom, devices)
     ages = dom.get("rl_ages", {})
-    elapsed = max(0.0, now - dom.get("rl_anchor_wall", now))
-    dom["rl_offline"] = [s for s, age in ages.items() if age + elapsed > RECEIVER_OFFLINE_SECS]
+    elapsed = max(0.0, time.time() - dom["rl_anchor_wall"]) if dom.get("rl_anchor_wall") else 0.0
+
+    receivers, with_reading = _scanner_slugs_and_readings(hass)
+    slug_to_device, device_entities = _build_device_availability(hass)
+
+    def device_online(slug):
+        device_id = slug_to_device.get(slug)
+        if not device_id:
+            return None
+        eids = device_entities.get(device_id)
+        if not eids:
+            return None
+        # A connectivity entity reports link state directly and is authoritative:
+        # ESPHome keeps its status sensor available with state "off" when the
+        # proxy disconnects, so "any entity not unavailable" would miss it.
+        for eid in eids:
+            st = hass.states.get(eid)
+            if st and st.attributes.get("device_class") == "connectivity" and st.state is not None:
+                return _state_looks_online(st.state)
+        saw_state = False
+        for eid in eids:
+            st = hass.states.get(eid)
+            if st is None or st.state is None:
+                continue
+            saw_state = True
+            if st.state != "unavailable":
+                return True
+        return False if saw_state else None
+
+    def is_online(slug):
+        age = ages.get(slug)
+        if age is not None:
+            return (age + elapsed) <= RECEIVER_OFFLINE_SECS
+        st = hass.states.get(f"binary_sensor.{slug}_status")
+        if st and st.attributes.get("device_class") == "connectivity":
+            return _state_looks_online(st.state)
+        resolved = device_online(slug)
+        if resolved is not None:
+            return resolved
+        # tier 4: distance heuristic (last resort). Matches the card: a receiver
+        # here is online only while some tracker reads a distance through it.
+        return slug in with_reading
+
+    dom["rl_offline"] = sorted(s for s in receivers if not is_online(s))
 
 
 async def update_receiver_radii(hass, eids):

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -42,15 +42,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     const circles = [];
     let receiverName = "";
     let receiverOptions = []; // Receiver names known from Bermuda sensors
-    let offlineReceivers = []; // scanners with no valid current distance reading (from the backend)
+    let offlineReceivers = []; // scanners Bermuda hasn't heard recently (backend liveness poll)
     // A placed receiver is "offline" when its scanner's distance sensors are
-    // gone (slug no longer in the reported list) OR none of them currently read
-    // a valid number (backend-computed). Guarded on the list being loaded so
+    // gone (slug no longer in the reported list) OR Bermuda hasn't heard the
+    // scanner recently (backend liveness). Guarded on the list being loaded so
     // nothing is flagged before the receiver data arrives.
     function isReceiverOffline(slug) {
         if (receiverOptions.length === 0) return false;
         return !receiverOptions.includes(slug) || offlineReceivers.includes(slug);
     }
+
+    // Live-refresh the offline set from the backend so (Offline) markers update
+    // without a reload. Repaints only when the set changed and we're not mid
+    // draw/edit (would wipe the overlay) or mid-tracking (that loop repaints and
+    // picks up the new set on its own).
+    async function fetchReceiverStatus() {
+        try {
+            const res = await fetch('/api/bps/receiver_status');
+            if (!res.ok) return;
+            const data = await res.json();
+            const next = Array.isArray(data.offline) ? data.offline : [];
+            const changed = next.length !== offlineReceivers.length
+                || next.some(s => !offlineReceivers.includes(s));
+            offlineReceivers = next;
+            if (changed && mapReady() && !drawToolActive() && !editTarget && !pollTrackActive) {
+                clearCanvas();
+                drawElements();
+            }
+        } catch (e) { /* transient; keep the last known set */ }
+    }
+    setInterval(fetchReceiverStatus, 10000);
     let zoneName = "";
     // Floor names come from two places that can disagree in case/whitespace:
     // the typed floor-name field and the map file basename. Always compare

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -42,6 +42,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const circles = [];
     let receiverName = "";
     let receiverOptions = []; // Receiver names known from Bermuda sensors
+    // A placed receiver whose slug is no longer among the scanners Bermuda
+    // reports (its distance sensors were renamed/removed) counts as "offline".
+    // Guarded on receiverOptions being loaded so nothing is flagged before then.
+    function isReceiverOffline(slug) {
+        return receiverOptions.length > 0 && !receiverOptions.includes(slug);
+    }
     let zoneName = "";
     // Floor names come from two places that can disagree in case/whitespace:
     // the typed floor-name field and the map file basename. Always compare
@@ -1944,7 +1950,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (labelY < 24) {
                     labelY = y + iconSize / 2 + 24;
                 }
-                drawCenteredLabel(item.entity_id, x, labelY, "600 22px system-ui, sans-serif", "#111111");
+                const recOffline = isReceiverOffline(item.entity_id);
+                drawCenteredLabel((recOffline ? "(Offline) " : "") + item.entity_id, x, labelY,
+                    "600 22px system-ui, sans-serif", recOffline ? "#d32f2f" : "#111111");
             }
             if (item.type == "zone"){
                 const pts = zonePerimeterPoints(item);
@@ -2011,9 +2019,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 + `<button class="bps-icon-btn" title="Edit sub-zone" data-type="editsubzone" data-id="${escHtml(sid)}">${pencilSvg}</button>`
                 + `<button class="bps-icon-btn" title="Remove sub-zone" data-type="removesubzone" data-id="${escHtml(sid)}">${trashSvg}</button></li>`;
         };
-        const receiverRow = r =>
-            `<li><span title="${escHtml(r.entity_id)}">${escHtml(r.entity_id)}</span>`
-            + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
+        const receiverRow = r => {
+            const off = isReceiverOffline(r.entity_id);
+            const label = (off ? "(Offline) " : "") + r.entity_id;
+            return `<li><span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
+                + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
+        };
 
         const receivers = (floor.receivers || []).filter(r => r && r.entity_id && r.cords);
         const claimed = new Set();

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -406,10 +406,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     beaconBase.src = "beacon.svg";
     const beaconTintCache = new Map();
 
-    function tintedBeacon(hue, size) {
+    // Recolor the beacon glyph to `fill` (any CSS color) via source-in, cached
+    // per (color, size). Returns null until the SVG has loaded.
+    function tintedBeacon(fill, size) {
         if (!beaconBase.complete || beaconBase.naturalWidth === 0) return null;
         const px = Math.max(8, Math.round(size));
-        const key = `${hue}|${px}`;
+        const key = `${fill}|${px}`;
         let tile = beaconTintCache.get(key);
         if (!tile) {
             tile = document.createElement("canvas");
@@ -418,18 +420,28 @@ document.addEventListener('DOMContentLoaded', async () => {
             const tctx = tile.getContext("2d");
             tctx.drawImage(beaconBase, 0, 0, px, px);
             tctx.globalCompositeOperation = "source-in";
-            tctx.fillStyle = `hsl(${hue}, 90%, 42%)`;
+            tctx.fillStyle = fill;
             tctx.fillRect(0, 0, px, px);
             beaconTintCache.set(key, tile);
         }
         return tile;
     }
 
-    // With circles enabled the icon takes the circle's color, so each circle
-    // can be traced back to its receiver at a glance.
-    function drawReceiverIcon(x, y, iconSize) {
+    const OFFLINE_RED = "#d32f2f";
+
+    // Icon color: with circles enabled it takes the circle's color so each
+    // circle traces back to its receiver; with circles off, an offline receiver
+    // is tinted red (matching its "(Offline)" label) so a dead node stands out
+    // without a circle color. Otherwise the plain black glyph.
+    function drawReceiverIcon(x, y, iconSize, offline) {
+        let fill = null;
         if (circleToggle.checked) {
-            const tinted = tintedBeacon(floorReceiverHue(x, y), iconSize);
+            fill = `hsl(${floorReceiverHue(x, y)}, 90%, 42%)`;
+        } else if (offline) {
+            fill = OFFLINE_RED;
+        }
+        if (fill) {
+            const tinted = tintedBeacon(fill, iconSize);
             if (tinted) {
                 ctx.drawImage(tinted, x - iconSize / 2, y - iconSize / 2, iconSize, iconSize);
                 return;
@@ -1967,7 +1979,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (focusedReceiver && item.entity_id !== focusedReceiver) return;
                 const x = item.cords.x;
                 const y = item.cords.y;
-                drawReceiverIcon(x, y, iconSize);
+                const recOffline = isReceiverOffline(item.entity_id);
+                drawReceiverIcon(x, y, iconSize, recOffline);
 
                 // Name centered above the icon; below it when too close to
                 // the top edge.
@@ -1975,9 +1988,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (labelY < 24) {
                     labelY = y + iconSize / 2 + 24;
                 }
-                const recOffline = isReceiverOffline(item.entity_id);
                 drawCenteredLabel((recOffline ? "(Offline) " : "") + item.entity_id, x, labelY,
-                    "600 22px system-ui, sans-serif", recOffline ? "#d32f2f" : "#111111");
+                    "600 22px system-ui, sans-serif", recOffline ? OFFLINE_RED : "#111111");
             }
             if (item.type == "zone"){
                 const pts = zonePerimeterPoints(item);

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -42,11 +42,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const circles = [];
     let receiverName = "";
     let receiverOptions = []; // Receiver names known from Bermuda sensors
-    // A placed receiver whose slug is no longer among the scanners Bermuda
-    // reports (its distance sensors were renamed/removed) counts as "offline".
-    // Guarded on receiverOptions being loaded so nothing is flagged before then.
+    let offlineReceivers = []; // scanners with no valid current distance reading (from the backend)
+    // A placed receiver is "offline" when its scanner's distance sensors are
+    // gone (slug no longer in the reported list) OR none of them currently read
+    // a valid number (backend-computed). Guarded on the list being loaded so
+    // nothing is flagged before the receiver data arrives.
     function isReceiverOffline(slug) {
-        return receiverOptions.length > 0 && !receiverOptions.includes(slug);
+        if (receiverOptions.length === 0) return false;
+        return !receiverOptions.includes(slug) || offlineReceivers.includes(slug);
     }
     let zoneName = "";
     // Floor names come from two places that can disagree in case/whitespace:
@@ -530,6 +533,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             // fresh install bpsdata.txt is empty and JSON.parse would throw,
             // yet the receiver picker is needed exactly then.
             receiverOptions = Array.isArray(data.receivers) ? [...data.receivers].sort() : [];
+            offlineReceivers = Array.isArray(data.offline_receivers) ? data.offline_receivers : [];
             console.log("Known receivers:", receiverOptions);
 
             if (data.coordinates) {


### PR DESCRIPTION
A placed receiver that isn't currently usable is surfaced in the panel: the **map label** and the **Zones & Receivers sidebar row** show it in **red** with an **`(Offline)`** prefix — e.g. `(Offline) bermuda_patio_tv_probe`. When distance circles are **off**, the **beacon icon itself also renders red** (matching the label) so a dead node stands out at a glance; with circles **on** the icon keeps its per-receiver circle color so the circle-to-icon mapping is preserved. Everything updates **live** (no reload), matching what the Lovelace map card shows.

**Status is decided by the same tiered cascade the card uses** (first tier that resolves per receiver wins), computed by a backend poller that runs in the 1 s loop throttled to 15 s:

1. **Bermuda scanner liveness** — last advert heard within `RECEIVER_OFFLINE_SECS` (30 s), from `bermuda.dump_devices`, with monotonic re-anchoring so a genuine fleet-wide outage still ages out. Proximity-independent: probes advertise iBeacons the scanners hear from each other, so a live scanner ages fresh even with no tracked device home.
2. **`binary_sensor.<slug>_status`** connectivity sensor.
3. **The receiver's HA device** — online while any of its entities isn't `unavailable`; a `connectivity` entity on the device is authoritative (catches an ESPHome/ESPresense proxy whose status sensor reads `off` while still available). This is what resolves most receivers here and is proximity-independent.
4. **Distance heuristic** (last resort) — only for a receiver with no liveness entry and no mapped device.

Why the cascade (not liveness alone): when a proxy goes down, Bermuda drops it from the dump's scanner list, so tier 1 can no longer see it — the lower tiers catch it. And because an *up* scanner is always caught by tier 1/3 first, the "all tracked devices left home" case can't false-flag receivers (the earlier distance-only version did).

**Live updates.** New `/api/bps/receiver_status` endpoint serves the cached offline set; the panel polls it every 10 s and repaints the markers (skipping the repaint while mid draw/edit or during tracking). `read_text` seeds the initial set on load.

Display-only — identity, distance lookups, and calibration are untouched.

Verified: backend `py_compile`; a logic test of the full cascade (liveness fresh/stale, connectivity sensor, device availability, heuristic, all-beacons-away, fleet outage); a check against the live registry (25/31 receivers map to a proxy device for tier 3); a rendered pixel check that the tinted beacon glyph is exactly `#d32f2f`; and an adversarial review of the icon-tint change (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)