### PR TITLE
Focus a receiver from the Zones & Receivers list

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2837,6 +2837,14 @@ select.bps-input { cursor: pointer; }
 .bps-zone-group li span,
 .bps-zone-head span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .bps-zone-group li:hover { background: hsl(var(--sidebar-accent)); }
+.bps-zone-group li.bps-rec-row { cursor: pointer; }
+/* The receiver currently focused on the map: accent bar + tint, held on hover
+   so the active row stays distinguishable from a plain hover. */
+.bps-zone-group li.bps-rec-focused,
+.bps-zone-group li.bps-rec-focused:hover {
+    background: hsl(var(--sidebar-accent));
+    box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
 .bps-icon-btn {
     flex: 0 0 auto;
     display: inline-flex;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -747,6 +747,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
             return;
         }
+        // Clicking a receiver row focuses it on the map (only that receiver and
+        // its circle stay visible); clicking it again clears the focus. Mirrors
+        // clicking the receiver's icon on the map. Checked after removerec so
+        // the trash button deletes rather than focuses.
+        if (event.target.closest('[data-type="focusrec"]')) {
+            const recId = event.target.closest('[data-type="focusrec"]').getAttribute('data-id');
+            focusedReceiver = recId === focusedReceiver ? null : recId;
+            redrawAll();
+            return;
+        }
         if (event.target.closest('[data-type="removezone"]')) {
             const idToRemove = event.target.closest('[data-type="removezone"]').getAttribute('data-id');
             // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
@@ -2059,7 +2069,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const receiverRow = r => {
             const off = isReceiverOffline(r.entity_id);
             const label = (off ? "(Offline) " : "") + r.entity_id;
-            return `<li><span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
+            // The whole row focuses that receiver on the map (only it and its
+            // circle stay visible), mirroring a click on its icon. The trash
+            // button's handler runs first, so removing never focuses.
+            const cls = "bps-rec-row" + (r.entity_id === focusedReceiver ? " bps-rec-focused" : "");
+            return `<li class="${cls}" data-type="focusrec" data-id="${escHtml(r.entity_id)}">`
+                + `<span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
                 + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
         };
 


### PR DESCRIPTION
Clicking a receiver row in the **Zones & Receivers** sidebar now **focuses that receiver on the map** — only that receiver (and its distance circle, if shown) stays visible — exactly like clicking the receiver's icon on the map. Clicking the same row again, or clicking the map / empty space, clears the focus.

The currently focused receiver's row is marked in the sidebar with a left accent bar and a subtle tint, so it's clear which one is active.

**Implementation**
- The receiver row is a `data-type="focusrec"` target, handled in the existing delegated sidebar click listener **after** the `removerec` branch — so the row's trash button still deletes (never focuses).
- Toggles the existing `focusedReceiver` state and calls `redrawAll()` (which repaints the map *and* re-renders the sidebar), reusing the same mechanism the map-click focus already uses. No new state or backend change.
- CSS: `.bps-rec-row` (pointer cursor) and `.bps-rec-focused` (accent bar + tint, theme-aware via `--sidebar-accent` / `--primary`).

Frontend-only. Verified: JS balance, and a browser test of the delegation/toggle (click focuses, click again clears, switching rows switches focus, trash deletes without focusing, focused row gets the highlight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)