### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.1.0"
+    "version": "1.2.0"
 }


### PR DESCRIPTION
Bumps `manifest.json` to **1.2.0**, marking the release with the feature set merged since 1.1.0:

- Per-device grouping (each tracker's BPS sensors under their own device)
- Offline receiver markers in the panel
- Focus a receiver from the Zones & Receivers list
- Card zone / sub-zone labels
- **Adjust Zones / Adjust Sub-zones** floor-plan clean-up

Manifest-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)