### PR TITLE
Fix #51: performance regression that stalled all of Home Assistant

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -138,9 +138,9 @@ async def update_tracked_entities(hass, jinja_code):
     """Update tracked_entities with the result of the Jinja code once per second."""
     global tracked_entities, tracked_listeners, global_data, new_global_data
     global secToUpdate
+    template = Template(jinja_code, hass)  # compile once; async_render re-evaluates each tick
     while True:
         try:
-            template = Template(jinja_code, hass)
             tracked_entities = template.async_render()
 
             await prune_stale_positions(hass)

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -48,13 +48,21 @@ def ensure_sensors_for_entity(hass, entity, sensors_cache, new_sensors):
     permanently dead (updates are dropped when the cache has no object).
     async_add_entities re-claims the registry entry via unique_id.
     """
+    # Resolve the Bermuda parent (a full entity-registry scan) ONLY when a
+    # sensor actually needs creating. In steady state every sensor is already
+    # cached, so this returns before touching the registry — the old
+    # unconditional scan here ran on every state_changed event and stalled HA
+    # (issue #51).
+    missing = [(suffix, label) for suffix, label in SENSOR_KINDS
+               if f"sensor.{entity}_{suffix}" not in sensors_cache]
+    if not missing:
+        return
     via_device = find_bermuda_via_device(hass, entity)
-    for suffix, label in SENSOR_KINDS:
+    for suffix, label in missing:
         entity_id = f"sensor.{entity}_{suffix}"
-        if entity_id not in sensors_cache:
-            sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id, entity, via_device)
-            sensors_cache[entity_id] = sensor
-            new_sensors.append(sensor)
+        sensor = CustomDistanceSensor(f"{entity} {label}", f"{suffix}_{entity}", entity_id, entity, via_device)
+        sensors_cache[entity_id] = sensor
+        new_sensors.append(sensor)
 
 
 def is_legacy_bps_entity_id(entity_id):
@@ -266,10 +274,24 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     @callback
     def state_changed_listener(event):
-        """Listen for state changes to update dynamic sensors"""
+        """Create BPS sensors when a NEW distance sensor appears.
+
+        This is bound to the GLOBAL state bus, so it fires for every entity's
+        every state change in all of HA (the busiest event there is). It must be
+        O(1) for the overwhelming majority of those events. Only a newly-ADDED
+        ``sensor.*_distance_to_*`` entity (``old_state`` is None) can introduce a
+        new tracker; the constant value-updates of existing distance sensors and
+        every unrelated entity are skipped cheaply. Without this filter the
+        handler ran a full states + entity-registry scan on every state change
+        and stalled the event loop (issue #51).
+        """
         sensors_cache = hass.data.get("bps_sensors")
         if sensors_cache is None:
             # Integration is unloading/reloading; ignore late state events.
+            return
+
+        entity_id = event.data.get("entity_id") or ""
+        if "_distance_to_" not in entity_id or event.data.get("old_state") is not None:
             return
 
         new_entities = get_filtered_entities(hass)


### PR DESCRIPTION
Fixes #51.

## Cause
`custom_components/bps/sensor.py` subscribes to the **global `state_changed` bus** (`hass.bus.async_listen("state_changed", …)`), so its `@callback` runs synchronously on the event loop for **every entity's every state change in all of HA** — the busiest event there is. PR #44 (split-devices) loaded that per-event path with heavy work:

- `find_bermuda_via_device()` — a scan of the **entire entity registry** — was called **unconditionally** at the top of `ensure_sensors_for_entity`, before the cache check, for every tracked device;
- `get_filtered_entities()` scans **all** states + a registry lookup per `_distance_to_` sensor.

So each state change cost ≈ `O(all_states + tracked_devices × registry_entries)`, hundreds of times a second → the event loop saturates and **all of HA** crawls. In 1.0.1 the same listener existed but only did cheap cache checks. This matches every symptom in #51: appeared with a *morning* commit after sub-zones, whole-HA slow, no error logs (pure CPU), worse once trackers exist, invisible on a fast server.

## Fix
- **Filter the listener**: return immediately unless a `sensor.*_distance_to_*` entity was **newly added** (`old_state is None`) — the only case that can mean a new tracker. Unrelated events and distance-sensor value-updates become an O(1) skip.
- **No unconditional registry scan**: `ensure_sensors_for_entity` resolves the Bermuda parent only when a sensor actually needs creating.
- **Compile the tracking Jinja `Template` once** instead of rebuilding it every 1 s tick.

Per-event cost goes from `O(all_states + tracked×registry)` to O(1) for essentially all events. New trackers still get their BPS sensors (a newly-added distance sensor triggers the rescan), and the boot-time creation pass in `async_setup_entry` is unchanged.

## Verification
`py_compile`; the diagnosis and the fix were each checked by an adversarial review (the fix review found no correctness regressions — new-tracker creation and boot pass preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)