### PR TITLE
UX: stop the Grid toggle from jumping to a new row

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2669,6 +2669,9 @@ body {
     color: hsl(var(--muted-foreground));
 }
 .bps-viewrow { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; min-height: 30px; }
+/* Pin the grid toggle to one width so cycling off -> m -> ft never resizes it
+   or bumps it onto a second row (its label was the only variable-width item). */
+#gridToggle { min-width: 74px; }
 
 /* Inputs */
 .bps-input {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2181,8 +2181,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     const gridToggle = document.getElementById("gridToggle");
 
     function updateGridButton() {
+        // Short units ("m"/"ft") keep every label narrow enough to sit on one
+        // line; a fixed button width (CSS) stops it hopping to a new row as the
+        // label changes.
         gridToggle.textContent = gridUnit === "off" ? "Grid: off"
-            : gridUnit === "m" ? "Grid: meters" : "Grid: feet";
+            : gridUnit === "m" ? "Grid: m" : "Grid: ft";
     }
     updateGridButton();
 


### PR DESCRIPTION
## What

In the FLOOR card's **View** row, the Grid toggle used to jump onto a second line when switched from *off* to *meters*/*feet* — the longer label widened the button past the wrap point of the flex row, shifting its position.

Now the button keeps one stable size on a single row in every state:

| Before | After |
|---|---|
| `Grid: off` (line 1) → `Grid: meters` / `Grid: feet` (wrap to line 2) | `Grid: off` / `Grid: m` / `Grid: ft` — same spot, same width |

## How

- Shortened the unit labels to `Grid: m` / `Grid: ft` — narrower than `Grid: off`, and consistent with the on-map grid labels (`1m`, `2m`, `1ft`).
- Pinned `#gridToggle` to `min-width: 74px` so the button is one fixed width regardless of label.

Because the widest state is now `Grid: off` (its current width, which already sits on line 1), no state can push past the wrap point — verified in a harness that the button stays on a single row across all three states at the panel width, and wraps *consistently* (no per-state jump) only if the card is made much narrower.

## Testing

- Measured the VIEW row in a script-free harness with the real CSS: all three states render at an identical 74px width on line 1 at the panel width; no state-dependent reflow.
- JS bracket/quote balance unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)