### PR TITLE
Only let visible receivers be clicked on the map

### DIFF
--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1824,11 +1824,32 @@ document.addEventListener('DOMContentLoaded', async () => {
             || SetScaleButton.dataset.active === 'true';
     }
 
+    // Receivers are not drawn while laying out geometry (adjust preview, or
+    // drawing/editing a zone/sub-zone, or setting the scale). This is the single
+    // source of truth for BOTH rendering and hit-testing, so a receiver is
+    // clickable exactly when it is visible. (Place Receiver is excluded: there
+    // the receivers stay visible.)
+    function receiversHidden() {
+        return !!adjustPreview
+            || drawAreaButton.dataset.active === 'true'
+            || drawSubZoneButton.dataset.active === 'true'
+            || SetScaleButton.dataset.active === 'true';
+    }
+
     function hitReceiverAt(pos) {
+        // Hidden receivers must not be clickable/draggable — only what's on
+        // screen can be hit (mirrors the render guard exactly).
+        if (receiversHidden()) return null;
         const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
         if (!floor) return null;
         const hitRadius = canvas.width * 0.02 + 10; // icon radius plus slack
-        return (floor.receivers || []).find(r =>
+        // When one receiver is focused, only it is drawn, so only it is hittable;
+        // a click over a hidden sibling then clears the focus instead of selecting
+        // an invisible receiver.
+        const candidates = focusedReceiver
+            ? (floor.receivers || []).filter(r => r.entity_id === focusedReceiver)
+            : (floor.receivers || []);
+        return candidates.find(r =>
             r.cords && Math.hypot(r.cords.x - pos.x, r.cords.y - pos.y) <= hitRadius) || null;
     }
 
@@ -2114,15 +2135,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         tmpdrawcords.forEach((item, index) => {
 
             if (item.type == "receiver"){
-                // Hide receivers whenever the map is being used to lay out
-                // geometry — previewing a zone/sub-zone adjustment, drawing or
-                // editing a zone/sub-zone, or setting the scale — so the outlines
-                // being worked on stay uncluttered. Placing a receiver is excluded
-                // (addDeviceButton): you need to see the others to position it.
-                if (adjustPreview
-                    || drawAreaButton.dataset.active === 'true'
-                    || drawSubZoneButton.dataset.active === 'true'
-                    || SetScaleButton.dataset.active === 'true') return;
+                // Skip receivers while laying out geometry so the outlines being
+                // worked on stay uncluttered. Same predicate as hit-testing, so a
+                // receiver is clickable exactly when it is drawn.
+                if (receiversHidden()) return;
                 if (focusedReceiver && item.entity_id !== focusedReceiver) return;
                 const x = item.cords.x;
                 const y = item.cords.y;


### PR DESCRIPTION
## What

Fixes a bug where clicking the map where a **hidden** receiver sits still selected it (and, in move mode, could drag it). Now a receiver is clickable/draggable **exactly when it's drawn**.

## Why

Receiver hit-testing (`hitReceiverAt`) didn't account for whether a receiver was actually visible. Two things hide receivers:
1. **Laying out geometry** — an Adjust Zones/Sub-zones preview, or Draw Zone / Draw Sub-Zone / Set Scale. (The draw tools already blocked map clicks, but the *adjust preview* doesn't set a tool active, so hidden receivers stayed clickable during it — the reported bug.)
2. **Focusing a single receiver** — the others aren't drawn, but a click over one of them still selected the invisible receiver (a pre-existing instance of the same problem, surfaced during review).

## How

- Added a single `receiversHidden()` predicate (adjust preview / draw / set-scale; Place Receiver excluded) used by **both** the render guard and `hitReceiverAt`, so render and hit-test can't drift.
- `hitReceiverAt` returns `null` when receivers are hidden, and — when one receiver is focused — only considers that receiver. So during a hiding mode nothing is hit; while focused, only the focused receiver is hit, and a click elsewhere clears the focus instead of selecting an invisible one.

`hitReceiverAt` has a single caller (the canvas mousedown handler), so this covers both focus-click and move-drag.

## Testing

- Bracket/quote balance verified with a regex-aware checker.
- Adversarial review (two rounds): the first confirmed the adjust-preview fix and surfaced the focus-filter instance of the same bug; after extending the fix, the re-review returned **0 findings** (invariant "drawn ⇔ hittable" holds across normal / adjust / draw / scale / place-receiver / focused, in both normal and move mode; no regressions to clicking, dragging, panning, or focus-toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)