### PR TITLE
Make off-floor tracking clear on the map (#70)

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2737,6 +2737,11 @@ select.bps-input { cursor: pointer; }
     font-size: 13px;
 }
 .bps-zonevalue { font-weight: 600; color: hsl(var(--foreground)); }
+/* Tracked device's floor in the zone bar: muted when it's the floor you're
+   viewing, red/bold when the device is actually on a different floor. */
+.bps-zonefloor { color: hsl(var(--muted-foreground)); }
+.bps-zonefloor.bps-offfloor { color: hsl(0 84% 55%); font-weight: 600; }
+#switchFloorBtn.bps-switch-floor { height: 26px; padding: 0 10px; font-size: 12px; }
 
 /* Toggle switch */
 .bps-switch {

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -106,6 +106,10 @@
                     <div id="zonediv" class="bps-zonebar" style="display: none">
                         <span class="bps-label">Current zone:</span>
                         <span id="zonevalue" class="bps-zonevalue">xxx</span>
+                        <!-- The tracked device's floor; turns into an off-floor warning
+                             (+ Switch button) when it isn't the floor being viewed. -->
+                        <span id="zonefloor" class="bps-zonefloor"></span>
+                        <button type="button" id="switchFloorBtn" class="bps-btn bps-btn-outline bps-switch-floor" style="display: none"></button>
                     </div>
 
                     <div class="bps-canvas-wrap">

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -363,10 +363,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return;
                 }
                 let dt = {x: result.cords[0], y:result.cords[1]};
-                const circles = sameFloorName(result.floor, SelMapName) ? result.radii : null;
-                drawTracker(dt, circles);
+                // A missing floor can't be judged off-floor, so treat it as the
+                // current one (no dim/badge/switch) rather than a false warning.
+                const sameFloor = !result.floor || sameFloorName(result.floor, SelMapName);
+                const circles = sameFloor ? result.radii : null;
+                drawTracker(dt, circles, { offFloor: !sameFloor, floor: result.floor });
                 zonediv.style.display = "";
                 document.getElementById("zonevalue").textContent = result.zone || "unknown";
+                updateFloorReadout(result.floor, sameFloor);
             }, 500); // Run every half second
         }
 
@@ -383,6 +387,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
         stoptrackbtn.addEventListener("click", stoptrackfunc);
 
+        // "Switch to <floor>" (shown in the zone bar when the tracked device is
+        // on another floor): load that floor's map so its fix renders correctly.
+        // Tracking keeps running; the next poll tick sees the new SelMapName and
+        // draws the icon + circles on-floor and clears the off-floor readout.
+        const switchFloorBtn = document.getElementById("switchFloorBtn");
+        if (switchFloorBtn) {
+            switchFloorBtn.addEventListener("click", async () => {
+                const target = switchFloorBtn.dataset.target;
+                if (!target) return;
+                mapSelector.value = target;
+                await selectExistingMap(target);
+            });
+        }
+
 
     // =================================================================
     // Triliterate functionality
@@ -391,11 +409,20 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function drawTrackOverlay() {
         if (!lastTrack || !pollTrackActive) return;
-        drawDistanceCircles(lastTrack.circles);
+        drawDistanceCircles(lastTrack.circles); // already null when off-floor
         const iconSize = canvas.width * 0.04;
         const icon = getCachedImage(getSelectedTrackerIcon());
         if (icon) {
+            ctx.save();
+            // Fade the icon when the device is on another floor: its position on
+            // this plan is not real, so it shouldn't read as a confident fix.
+            if (lastTrack.offFloor) ctx.globalAlpha = 0.35;
             ctx.drawImage(icon, lastTrack.x - iconSize / 2, lastTrack.y - iconSize / 2, iconSize, iconSize);
+            ctx.restore();
+        }
+        if (lastTrack.offFloor && lastTrack.floor) {
+            // Red pill under the icon spelling out which floor it's really on.
+            drawLabelPill(`on ${lastTrack.floor}`, lastTrack.x, lastTrack.y + iconSize / 2 + 16, 0);
         }
     }
 
@@ -527,9 +554,43 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
-    function drawTracker(tricords, circles){
-        lastTrack = { x: tricords.x, y: tricords.y, circles: circles };
+    function drawTracker(tricords, circles, opts){
+        lastTrack = {
+            x: tricords.x, y: tricords.y, circles: circles,
+            // The fix belongs to another floor than the one on screen, so its
+            // position here isn't meaningful — the overlay fades it + labels it.
+            offFloor: !!(opts && opts.offFloor),
+            floor: opts && opts.floor,
+        };
         redrawAll();
+    }
+
+    // Zone-bar floor readout for the tracked device. Muted "· <floor>" when it's
+    // the floor on screen; a red "· on <floor> — not this floor" plus a
+    // "Switch to <floor>" button (if that floor has a map) when it isn't.
+    function updateFloorReadout(floorName, sameFloor) {
+        const zf = document.getElementById("zonefloor");
+        const btn = document.getElementById("switchFloorBtn");
+        if (!zf) return;
+        if (sameFloor || !floorName) {
+            zf.textContent = floorName ? `· ${floorName}` : "";
+            zf.classList.remove("bps-offfloor");
+            if (btn) { btn.style.display = "none"; btn.dataset.target = ""; }
+            return;
+        }
+        zf.textContent = `· on ${floorName} — not this floor`;
+        zf.classList.add("bps-offfloor");
+        // Offer to jump there, but only if a saved map matches that floor name.
+        const opt = mapSelector && [...mapSelector.options]
+            .find(o => o.value && sameFloorName(removeExtension(o.value), floorName));
+        if (btn && opt) {
+            btn.textContent = `Switch to ${floorName}`;
+            btn.dataset.target = opt.value;
+            btn.style.display = "";
+        } else if (btn) {
+            btn.style.display = "none";
+            btn.dataset.target = "";
+        }
     }
 
     // =================================================================


### PR DESCRIPTION
Fixes #70.

## What

When you view one floor but track a device that's on another, it's now obvious the device isn't on the floor you're looking at.

- **Zone bar** shows the tracked device's floor. When it's the floor you're viewing, it's a muted "· Ground Floor"; when it isn't, it turns red: "· on Ground Floor — not this floor".
- **The person icon** is faded (35% opacity) and gets a red "on Ground Floor" pill when the device is off-floor — its position on this plan isn't real, so it no longer reads as a confident fix. (On-floor tracking is unchanged: full opacity + distance circles.)
- **A "Switch to Ground Floor" button** appears in the zone bar; clicking it loads that floor's map. Tracking keeps running, and the next poll tick renders the icon + circles correctly on-floor and clears the warning.

## Why

Per @davidcoulson's report: the icon was drawn at a meaningless coordinate on the wrong floor, and the only signal something was off was the missing circles.

## How

- The device's floor is already in the cords API (`result.floor`), so this is **frontend-only** — a single `sameFloor` check drives the readout, the icon fade/pill, and the switch button. Sub-zone in the readout was intentionally left out since it would require a backend change; can add later if wanted.
- The switch button resolves the floor name to its saved map via the existing name↔filename convention (`sameFloorName`/`removeExtension`) and reuses `selectExistingMap`; it's hidden if no map matches that floor. It's a manual button (not auto-switch) so it doesn't fight you when you're deliberately viewing another floor.

## Testing

- Bracket/quote balance verified with a regex-aware checker.
- Zone-bar states measured in a harness: on-floor = muted floor label, no button; off-floor = red bold warning + visible "Switch to …" button, single row.
- Adversarial multi-lens review (off-floor logic / switch-button / regressions): **0 findings** — including that switching floors mid-tracking doesn't break the poll loop, the icon alpha doesn't leak to later draws, and on-floor behavior is unchanged.

Not yet exercised against a live multi-floor setup — worth a quick check when deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)