### PR TITLE
Surface scanner naming mismatches + one-click re-link (#64)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -23,6 +23,7 @@ import os
 import json
 import re
 import copy
+import difflib
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from shapely.geometry import Point, Polygon
@@ -202,6 +203,83 @@ def _scanner_slugs_and_readings(hass):
         if st.state not in (None, "", "unknown", "unavailable"):
             with_reading.add(slug)
     return slugs, with_reading
+
+
+_SCANNER_TOKEN_RE = re.compile(r"^[0-9a-f]{5,12}$")
+
+
+def _scanner_token(slug):
+    """The trailing hardware id Bermuda embeds in a scanner slug — the hex group
+    derived from the device's MAC, e.g. 'master_bedroom_esp32c5_f17464' ->
+    'f17464'. This survives renames of the human-readable prefix, so it is a
+    stable identity for a physical scanner. None when the slug has no hex tail.
+    """
+    if not slug:
+        return None
+    last = str(slug).rsplit("_", 1)[-1].lower()
+    return last if _SCANNER_TOKEN_RE.match(last) else None
+
+
+def _suggest_scanner(placement_slug, stored_uid, candidates):
+    """Best live scanner slug to re-link a stale placement to. Prefer a shared
+    hardware token (an explicitly-stored uid, else the placement's own trailing
+    token — the same physical scanner after a rename); otherwise fall back to
+    plain string similarity. Returns a candidate slug or None.
+    """
+    token = stored_uid or _scanner_token(placement_slug)
+    if token:
+        tok_matches = [c for c in candidates if _scanner_token(c) == token]
+        if len(tok_matches) == 1:
+            return tok_matches[0]
+    best, best_score = None, 0.0
+    for c in candidates:
+        score = difflib.SequenceMatcher(None, str(placement_slug), c).ratio()
+        if score > best_score:
+            best, best_score = c, score
+    return best if best_score >= 0.55 else None
+
+
+def _scanner_diagnostics(hass, coordinates_json):
+    """Compare placed receivers against the scanner slugs Bermuda actually
+    exposes, to flag naming mismatches (issue #64):
+      - unmatched_receivers: a placed slug that has NO matching distance sensor
+        (a genuinely wrong/stale name), each with a suggested live scanner.
+      - unplaced_scanners: scanner slugs currently reporting a distance that
+        aren't placed on any floor.
+    """
+    slugs, with_reading = _scanner_slugs_and_readings(hass)
+    placed = []  # (floor_name, entity_id, stored scanner_uid)
+    try:
+        parsed = json.loads(coordinates_json)
+        floors = parsed.get("floor") if isinstance(parsed, dict) else None
+        for fl in floors if isinstance(floors, list) else []:
+            if not isinstance(fl, dict):
+                continue
+            receivers_ = fl.get("receivers")
+            for rec in receivers_ if isinstance(receivers_, list) else []:
+                # entity_id must be a non-empty string: a non-string slug (e.g. a
+                # hand-edited list) would be unhashable and break the set build
+                # below, and isn't a real scanner name anyway.
+                if isinstance(rec, dict) and isinstance(rec.get("entity_id"), str) and rec["entity_id"]:
+                    placed.append((fl.get("name"), rec["entity_id"], rec.get("scanner_uid")))
+    except Exception:
+        # A diagnostics add-on must never break read_text — a malformed or
+        # hand-edited bpsdata.txt just yields no diagnostics.
+        placed = []
+    placed_slugs = {p[1] for p in placed}
+    # Candidates for a re-link: live scanner slugs not already correctly placed.
+    free = [s for s in slugs if s not in placed_slugs]
+    unmatched = []
+    for fname, slug, uid in placed:
+        if slug in slugs:
+            continue  # a real sensor exists (offline is a separate concern)
+        unmatched.append({
+            "entity_id": slug,
+            "floor": fname,
+            "suggested": _suggest_scanner(slug, uid, free),
+        })
+    unplaced = sorted(with_reading - placed_slugs)
+    return {"unmatched_receivers": unmatched, "unplaced_scanners": unplaced}
 
 
 def _refresh_dump_ages(hass, dom, devices):
@@ -1184,7 +1262,11 @@ class BPSReadAPIText(HomeAssistantView):
                 "coordinates": content,
                 "entities": entities,
                 "receivers": receivers,
-                "offline_receivers": offline_receivers
+                "offline_receivers": offline_receivers,
+                # Naming-mismatch diagnostics (issue #64): placed receivers whose
+                # slug has no Bermuda distance sensor, and reporting scanners not
+                # placed anywhere.
+                "scanner_diagnostics": _scanner_diagnostics(hass, content),
             })
         
         except Exception as e:

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2936,6 +2936,21 @@ select.bps-input { cursor: pointer; }
 .bps-subzone-dot { width: 10px; height: 10px; border-radius: 3px; flex: 0 0 auto; display: inline-block; }
 .bps-empty, .bps-hint { color: hsl(var(--muted-foreground)); font-size: 12.5px; }
 .bps-hint { margin-top: 10px; }
+/* Scanner naming-mismatch warnings (issue #64), amber to read as "attention". */
+.bps-scanner-issues {
+    margin: 8px 0;
+    padding: 8px 10px;
+    border: 1px solid hsl(38 92% 50% / 0.5);
+    border-radius: 8px;
+    background: hsl(38 92% 50% / 0.08);
+    font-size: 12px;
+}
+.bps-issues-title { font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: hsl(38 92% 45%); margin-bottom: 6px; }
+.bps-issue { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 5px; }
+.bps-issue-msg { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bps-issue-hint { color: hsl(var(--muted-foreground)); font-size: 11px; }
+.bps-relink-btn { height: 24px; padding: 0 8px; font-size: 11px; flex: 0 0 auto; }
+.bps-issue-note { color: hsl(var(--muted-foreground)); margin-top: 4px; }
 .bps-scale-status { margin-top: 10px; }
 .bps-scale-line {
     display: flex;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -130,6 +130,9 @@
                     <div id="entitytree">
                         <p class="bps-empty">Select a floor to see its zones and receivers.</p>
                     </div>
+                    <!-- Naming-mismatch warnings (issue #64): placed receivers with no
+                         Bermuda sensor, and scanners reporting a distance but unplaced. -->
+                    <div id="scannerissues"></div>
                     <p class="bps-hint">Enable “Move receivers”, drag one on the map, then Save Floor Plan.</p>
                     <div class="bps-scale-status">
                         <p id="scaleok" class="bps-scale-line" style="display: none">Scale set

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -55,6 +55,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     let receiverName = "";
     let receiverOptions = []; // Receiver names known from Bermuda sensors
     let offlineReceivers = []; // scanners Bermuda hasn't heard recently (backend liveness poll)
+    // Naming-mismatch diagnostics from read_text (issue #64): placed receivers
+    // with no matching Bermuda sensor (each with a suggested live scanner), and
+    // scanners reporting a distance that aren't placed anywhere.
+    let scannerDiagnostics = { unmatched_receivers: [], unplaced_scanners: [] };
     // A placed receiver is "offline" when its scanner's distance sensors are
     // gone (slug no longer in the reported list) OR Bermuda hasn't heard the
     // scanner recently (backend liveness). Guarded on the list being loaded so
@@ -644,6 +648,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             // yet the receiver picker is needed exactly then.
             receiverOptions = Array.isArray(data.receivers) ? [...data.receivers].sort() : [];
             offlineReceivers = Array.isArray(data.offline_receivers) ? data.offline_receivers : [];
+            scannerDiagnostics = (data.scanner_diagnostics && typeof data.scanner_diagnostics === 'object')
+                ? data.scanner_diagnostics : { unmatched_receivers: [], unplaced_scanners: [] };
             console.log("Known receivers:", receiverOptions);
 
             if (data.coordinates) {
@@ -838,6 +844,32 @@ document.addEventListener('DOMContentLoaded', async () => {
             redrawAll();
             return;
         }
+        // Re-link a mismatched placement to a live scanner slug (issue #64):
+        // rename its entity_id + record the scanner's hardware token, then reveal
+        // Save. Only its name changes — position and everything else stay.
+        if (event.target.closest('[data-type="relinkrec"]')) {
+            const el = event.target.closest('[data-type="relinkrec"]');
+            const oldId = el.getAttribute('data-id');
+            const newId = el.getAttribute('data-target');
+            if (!newId || newId === oldId) return;
+            // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
+            if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
+            let changed = false;
+            finalcords.floor.forEach(f => (f.receivers || []).forEach(r => {
+                if (r && r.entity_id === oldId) {
+                    r.entity_id = newId;
+                    r.scanner_uid = scannerTokenJs(newId);
+                    changed = true;
+                }
+            }));
+            if (changed) {
+                savebuttondiv.appendChild(saveButton);
+                clearCanvas();
+                drawElements(); // re-renders the tree + scanner issues
+                bpsToast(`Re-linked "${oldId}" → "${newId}". Save Floor Plan to keep it.`);
+            }
+            return;
+        }
         if (event.target.closest('[data-type="removezone"]')) {
             const idToRemove = event.target.closest('[data-type="removezone"]').getAttribute('data-id');
             // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
@@ -974,6 +1006,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         buttonreset();
         mapSelector.selectedIndex = 0;
         renderEntityTree(null);
+        const issues = document.getElementById("scannerissues");
+        if (issues) issues.innerHTML = ""; // clear stale mismatch warnings + Re-link buttons
     });
 
     function clearCanvas(){
@@ -2253,6 +2287,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         drawAdjustGhost();
         renderEntityTree(floor);
+        renderScannerIssues();
 
         // Keep the map's Save/Cancel actions in sync with tool state. Every
         // activation and every exit path routes through drawElements, so this
@@ -2281,6 +2316,57 @@ document.addEventListener('DOMContentLoaded', async () => {
             ctx.stroke();
         }
         ctx.restore();
+    }
+
+    // The stable hardware token of a scanner slug (trailing hex group Bermuda
+    // derives from the MAC), mirroring the backend's _scanner_token. Stored on a
+    // placement when it's re-linked so future renames stay detectable.
+    function scannerTokenJs(slug) {
+        if (!slug) return null;
+        const last = String(slug).split("_").pop().toLowerCase();
+        return /^[0-9a-f]{5,12}$/.test(last) ? last : null;
+    }
+
+    // Naming-mismatch warnings (issue #64). "Unmatched" is recomputed live from
+    // finalcords + the known scanner slugs so a re-link/remove clears it at once;
+    // the re-link suggestion comes from the backend diagnostics.
+    function renderScannerIssues() {
+        const host = document.getElementById("scannerissues");
+        if (!host) return;
+        const known = new Set(receiverOptions);
+        const placed = new Set();
+        (finalcords.floor || []).forEach(f => (f.receivers || []).forEach(r => { if (r && r.entity_id) placed.add(r.entity_id); }));
+        const suggestOf = {};
+        (scannerDiagnostics.unmatched_receivers || []).forEach(u => { suggestOf[u.entity_id] = u.suggested; });
+
+        const unmatched = [];
+        // Only flag once the scanner list has actually loaded (mirrors isReceiverOffline).
+        if (known.size) {
+            (finalcords.floor || []).forEach(f => (f.receivers || []).forEach(r => {
+                if (r && r.entity_id && !known.has(r.entity_id)) {
+                    unmatched.push({ entity_id: r.entity_id, floor: f.name, suggested: suggestOf[r.entity_id] || null });
+                }
+            }));
+        }
+        const unplaced = (scannerDiagnostics.unplaced_scanners || []).filter(s => !placed.has(s));
+
+        if (!unmatched.length && !unplaced.length) { host.innerHTML = ""; return; }
+        let html = '<div class="bps-scanner-issues"><div class="bps-issues-title">Scanner issues</div>';
+        unmatched.forEach(u => {
+            html += '<div class="bps-issue">'
+                + `<span class="bps-issue-msg" title="${escHtml(u.entity_id)}">No Bermuda sensor for “${escHtml(u.entity_id)}”${u.floor ? " ("+escHtml(u.floor)+")" : ""}</span>`;
+            if (u.suggested) {
+                html += `<button class="bps-btn bps-btn-outline bps-relink-btn" data-type="relinkrec" data-id="${escHtml(u.entity_id)}" data-target="${escHtml(u.suggested)}" title="Rename this placement to the live scanner ${escHtml(u.suggested)}">Re-link → ${escHtml(u.suggested)}</button>`;
+            } else {
+                html += '<span class="bps-issue-hint">no match — remove or re-place</span>';
+            }
+            html += '</div>';
+        });
+        if (unplaced.length) {
+            html += `<div class="bps-issue-note">Reporting a distance but not placed: ${unplaced.map(escHtml).join(", ")}</div>`;
+        }
+        html += '</div>';
+        host.innerHTML = html;
     }
 
     // Sidebar: one section per zone with the receivers placed inside it.


### PR DESCRIPTION
Addresses #64.

## What

When a placed receiver's slug drifts from Bermuda's current scanner slug, the scanner reports a distance in HA but shows no circle in BPS — silently. This surfaces those mismatches and makes them fixable in one click.

- A **"Scanner issues"** section in the sidebar lists:
  - placed receivers with **no matching Bermuda distance sensor** (a wrong/stale name), and
  - scanners **reporting a distance but not placed** on any floor (David's ask #1).
- Each mismatch offers a **"Re-link → `<scanner>`"** button that rewrites the placement's `entity_id` to the live slug and stores its `scanner_uid` (the MAC-derived hardware token embedded in the slug), then reveals Save.

## How

- **Backend** (`read_text`): `scanner_diagnostics` compares placed receivers against the scanner slugs Bermuda actually exposes (`_scanner_slugs_and_readings`). `_suggest_scanner` ranks a re-link target by **shared hardware token** (the trailing hex, which survives renames — David's fuzzy-match ask #2) then string similarity.
- **Frontend**: "unmatched" is recomputed live from `finalcords` + the known scanner list, so a re-link (or remove) clears it immediately; the suggestion comes from the backend.
- **Matching is unchanged** — the tracking loop still does an exact-slug lookup (per the "explicit re-link only" choice); re-linking makes the slug current, so trilateration/floor-election are untouched. The stored `scanner_uid` keeps future drift detectable.

## Robustness

`_scanner_diagnostics` never breaks the read path: a malformed/hand-edited `bpsdata.txt` (non-dict floor, non-list receivers, non-string `entity_id`) yields empty diagnostics instead of a 500. Clear Canvas clears the panel, and the re-link handler carries the same "stale sidebar can't fake a save" guard as the other sidebar actions.

## Testing

- Backend `py_compile`; frontend regex-aware balance check; standalone robustness test over 9 malformed JSON shapes (all no-crash, valid slugs still collected).
- Harness (real CSS): amber "Scanner issues" panel, working "Re-link →" button, long slugs ellipsized, all within the sidebar.
- Adversarial multi-lens review across three rounds (backend correctness / frontend re-link / regressions). It caught a read_text 500 on malformed data, a stale Re-link button after Clear Canvas, and an unhashable-`entity_id` edge — all fixed; final round clean.

Not yet exercised against David's live setup — worth confirming the suggested re-links match his renamed scanners when deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)