### PR TITLE
Add a "Scanner linking" debug view (#64)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -239,6 +239,35 @@ def _suggest_scanner(placement_slug, stored_uid, candidates):
     return best if best_score >= 0.55 else None
 
 
+def _placed_receivers(coordinates_json):
+    """Placed receivers as (floor_name, entity_id slug, stored scanner_uid).
+
+    Parsed defensively: a malformed or hand-edited bpsdata.txt yields [] rather
+    than raising into a caller (diagnostics must never break read_text). Each
+    entity_id must be a non-empty string — a non-string slug isn't a real
+    scanner name and would be unhashable when callers build a set of slugs.
+    """
+    placed = []
+    try:
+        parsed = json.loads(coordinates_json)
+        floors = parsed.get("floor") if isinstance(parsed, dict) else None
+        for fl in floors if isinstance(floors, list) else []:
+            if not isinstance(fl, dict):
+                continue
+            receivers_ = fl.get("receivers")
+            for rec in receivers_ if isinstance(receivers_, list) else []:
+                if isinstance(rec, dict) and isinstance(rec.get("entity_id"), str) and rec["entity_id"]:
+                    placed.append((fl.get("name"), rec["entity_id"], rec.get("scanner_uid")))
+    except Exception:
+        return []
+    return placed
+
+
+# Distance-sensor states that mean "no distance right now" (as opposed to a
+# real numeric reading). Shared by the diagnostics and the linking debug view.
+_NO_DISTANCE_STATES = (None, "", "unknown", "unavailable")
+
+
 def _scanner_diagnostics(hass, coordinates_json):
     """Compare placed receivers against the scanner slugs Bermuda actually
     exposes, to flag naming mismatches (issue #64):
@@ -248,24 +277,7 @@ def _scanner_diagnostics(hass, coordinates_json):
         aren't placed on any floor.
     """
     slugs, with_reading = _scanner_slugs_and_readings(hass)
-    placed = []  # (floor_name, entity_id, stored scanner_uid)
-    try:
-        parsed = json.loads(coordinates_json)
-        floors = parsed.get("floor") if isinstance(parsed, dict) else None
-        for fl in floors if isinstance(floors, list) else []:
-            if not isinstance(fl, dict):
-                continue
-            receivers_ = fl.get("receivers")
-            for rec in receivers_ if isinstance(receivers_, list) else []:
-                # entity_id must be a non-empty string: a non-string slug (e.g. a
-                # hand-edited list) would be unhashable and break the set build
-                # below, and isn't a real scanner name anyway.
-                if isinstance(rec, dict) and isinstance(rec.get("entity_id"), str) and rec["entity_id"]:
-                    placed.append((fl.get("name"), rec["entity_id"], rec.get("scanner_uid")))
-    except Exception:
-        # A diagnostics add-on must never break read_text — a malformed or
-        # hand-edited bpsdata.txt just yields no diagnostics.
-        placed = []
+    placed = _placed_receivers(coordinates_json)
     placed_slugs = {p[1] for p in placed}
     # Candidates for a re-link: live scanner slugs not already correctly placed.
     free = [s for s in slugs if s not in placed_slugs]
@@ -280,6 +292,71 @@ def _scanner_diagnostics(hass, coordinates_json):
         })
     unplaced = sorted(with_reading - placed_slugs)
     return {"unmatched_receivers": unmatched, "unplaced_scanners": unplaced}
+
+
+def _scanner_linking(hass, coordinates_json):
+    """Debug view for issue #64: for every placed receiver, the Bermuda distance
+    sensors that feed it and each one's current state.
+
+    This distinguishes the two failure modes David couldn't tell apart from the
+    map alone: a receiver correctly linked but simply not reporting a distance
+    right now ("silent" — usually just no recent BLE contact), versus one whose
+    name matches no distance sensor at all ("unmatched" — a real naming
+    mismatch). Reads live HA state directly, so it does not depend on a device
+    being actively tracked. Returns:
+      - placed:   one row per placed receiver with its status and per-device
+                  readings (the exact `<device>_distance_to_<slug>` sensors
+                  update_receiver_radii looks up).
+      - unplaced: scanner slugs that have distance sensors but no placement,
+                  for context (a superset of the diagnostics' "reporting" list).
+    """
+    by_slug = {}
+    for st in hass.states.async_all("sensor"):
+        eid = st.entity_id
+        if "_distance_to_" not in eid:
+            continue
+        device_part, slug = eid.split("_distance_to_", 1)
+        device = device_part[len("sensor."):] if device_part.startswith("sensor.") else device_part
+        state = None if st.state is None else str(st.state)
+        by_slug.setdefault(slug, []).append({"device": device, "entity_id": eid, "state": state})
+
+    def _reporting(sensors):
+        return [s for s in sensors if s["state"] not in _NO_DISTANCE_STATES]
+
+    placed = _placed_receivers(coordinates_json)
+    placed_slugs = {p[1] for p in placed}
+    rows = []
+    for fname, slug, uid in placed:
+        sensors = sorted(by_slug.get(slug, []), key=lambda s: s["device"])
+        reporting = _reporting(sensors)
+        if not sensors:
+            status = "unmatched"
+        elif reporting:
+            status = "live"
+        else:
+            status = "silent"
+        rows.append({
+            "entity_id": slug,
+            "floor": fname,
+            "scanner_uid": uid,
+            "token": _scanner_token(slug),
+            "status": status,
+            "sensor_count": len(sensors),
+            "reporting_count": len(reporting),
+            "sensors": sensors,
+        })
+    unplaced = []
+    for slug, sensors in by_slug.items():
+        if slug in placed_slugs:
+            continue
+        unplaced.append({
+            "entity_id": slug,
+            "token": _scanner_token(slug),
+            "sensor_count": len(sensors),
+            "reporting_count": len(_reporting(sensors)),
+        })
+    unplaced.sort(key=lambda u: u["entity_id"])
+    return {"placed": rows, "unplaced": unplaced}
 
 
 def _refresh_dump_ages(hass, dom, devices):
@@ -855,6 +932,7 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSReadAPIText())
             hass.http.register_view(BPSAdjustZonesAPI())
             hass.http.register_view(BPSReceiverStatusAPI())
+            hass.http.register_view(BPSScannerLinkingAPI())
             hass.http.register_view(BPSCordsAPI(hass))
             hass.http.register_view(BPSCalibrationAPI())
             hass.data["bps_views_registered"] = True
@@ -1283,6 +1361,35 @@ class BPSReceiverStatusAPI(HomeAssistantView):
         hass = request.app["hass"]
         offline = hass.data.get(DOMAIN, {}).get("rl_offline", [])
         return web.json_response({"offline": list(offline)})
+
+
+class BPSScannerLinkingAPI(HomeAssistantView):
+    """On-demand debug view (issue #64): how each placed receiver links to its
+    Bermuda distance sensors and whether each is reporting right now. Fetched
+    live only when the panel's 'Scanner linking' section is expanded, so it
+    never adds cost to a normal panel load or the tracking loop."""
+    url = "/api/bps/scanner_linking"
+    name = "api:bps:scanner_linking"
+    requires_auth = False
+
+    async def get(self, request):
+        hass = request.app["hass"]
+        maps_path = hass.config.path("www/bps_maps")
+        bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
+        content = ""
+        try:
+            if bpsdata_file_path.is_file():
+                async with aiofiles.open(bpsdata_file_path, "r") as f:
+                    content = await f.read()
+        except Exception as e:
+            # No placements to compare against is fine; still report the sensors.
+            _LOGGER.info(f"scanner_linking: could not read bpsdata: {e}")
+            content = ""
+        try:
+            return web.json_response(_scanner_linking(hass, content))
+        except Exception as e:
+            _LOGGER.error(f"scanner_linking failed: {e}")
+            return web.json_response({"placed": [], "unplaced": []})
 
 
 class BPSMapsListAPI(HomeAssistantView):

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2951,6 +2951,69 @@ select.bps-input { cursor: pointer; }
 .bps-issue-hint { color: hsl(var(--muted-foreground)); font-size: 11px; }
 .bps-relink-btn { height: 24px; padding: 0 8px; font-size: 11px; flex: 0 0 auto; }
 .bps-issue-note { color: hsl(var(--muted-foreground)); margin-top: 4px; }
+
+/* Scanner linking debug section (issue #64) — a neutral collapsible panel that
+   shows how each placed receiver maps to Bermuda distance sensors. */
+.bps-linking { margin: 8px 0; font-size: 12px; }
+.bps-linking-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+    padding: 6px 8px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    color: hsl(var(--muted-foreground));
+    font-weight: 600;
+}
+.bps-linking-head:hover { background: hsl(var(--accent)); }
+.bps-linking-caret { width: 12px; display: inline-block; text-align: center; }
+.bps-linking-title { text-transform: uppercase; font-size: 11px; letter-spacing: 0.04em; }
+.bps-linking-body {
+    margin-top: 6px;
+    padding: 8px 10px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+}
+.bps-linking-actions { display: flex; justify-content: flex-end; margin-bottom: 6px; }
+.bps-linking-refresh { height: 24px; padding: 0 10px; font-size: 11px; }
+.bps-linking-msg { color: hsl(var(--muted-foreground)); margin: 4px 0; }
+.bps-linking-list { list-style: none; margin: 0; padding: 0; }
+.bps-linking-row {
+    padding: 6px 0;
+    border-top: 1px solid hsl(var(--border) / 0.6);
+}
+.bps-linking-row:first-child { border-top: 0; }
+.bps-linking-row-head { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.bps-linking-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; }
+.bps-linking-floor { color: hsl(var(--muted-foreground)); font-size: 11px; flex: 0 0 auto; }
+.bps-linking-chip {
+    flex: 0 0 auto;
+    padding: 1px 7px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.bps-chip-live { background: hsl(142 71% 45% / 0.18); color: hsl(142 61% 38%); }
+.bps-chip-silent { background: hsl(38 92% 50% / 0.18); color: hsl(38 92% 42%); }
+.bps-chip-unmatched { background: hsl(0 84% 60% / 0.18); color: hsl(0 74% 52%); }
+.bps-linking-readings { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+.bps-linking-reading {
+    padding: 1px 6px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-family: monospace;
+    background: hsl(var(--muted) / 0.5);
+}
+.bps-linking-reading.is-live { background: hsl(142 71% 45% / 0.14); }
+.bps-linking-reading.is-silent { background: hsl(38 92% 50% / 0.14); color: hsl(var(--muted-foreground)); }
+.bps-linking-detail { color: hsl(var(--muted-foreground)); margin-top: 4px; }
+.bps-linking-note { margin-top: 8px; color: hsl(var(--muted-foreground)); }
+.bps-linking-help { margin-top: 8px; color: hsl(var(--muted-foreground)); font-size: 11px; line-height: 1.4; }
+
 .bps-scale-status { margin-top: 10px; }
 .bps-scale-line {
     display: flex;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -133,6 +133,10 @@
                     <!-- Naming-mismatch warnings (issue #64): placed receivers with no
                          Bermuda sensor, and scanners reporting a distance but unplaced. -->
                     <div id="scannerissues"></div>
+                    <!-- On-demand debug view (issue #64): how each placed receiver links
+                         to Bermuda distance sensors and whether each is reporting right
+                         now. Collapsed by default; fetched live when expanded. -->
+                    <div id="scannerlinking" class="bps-linking"></div>
                     <p class="bps-hint">Enable “Move receivers”, drag one on the map, then Save Floor Plan.</p>
                     <div class="bps-scale-status">
                         <p id="scaleok" class="bps-scale-line" style="display: none">Scale set

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -59,6 +59,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     // with no matching Bermuda sensor (each with a suggested live scanner), and
     // scanners reporting a distance that aren't placed anywhere.
     let scannerDiagnostics = { unmatched_receivers: [], unplaced_scanners: [] };
+    // On-demand "Scanner linking" debug section (issue #64). Collapsed by
+    // default; each time it opens it fetches a fresh live snapshot from
+    // /api/bps/scanner_linking so a scanner renamed in Bermuda re-checks without
+    // a page reload. Kept independent of the map redraw so it never refetches
+    // on every canvas repaint.
+    let scannerLinkingOpen = false;
+    let scannerLinkingLoading = false;
+    let scannerLinkingData = null;
     // A placed receiver is "offline" when its scanner's distance sensors are
     // gone (slug no longer in the reported list) OR Bermuda hasn't heard the
     // scanner recently (backend liveness). Guarded on the list being loaded so
@@ -337,6 +345,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (tmpsaved){
             await fetchBPSData();
         }
+        // Show the collapsed "Scanner linking (debug)" header; its body loads on
+        // demand when expanded.
+        renderScannerLinking();
 
 
         let stoptrackstat = false;
@@ -868,6 +879,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                 drawElements(); // re-renders the tree + scanner issues
                 bpsToast(`Re-linked "${oldId}" → "${newId}". Save Floor Plan to keep it.`);
             }
+            return;
+        }
+        // Scanner-linking debug section (issue #64). Refresh is checked first so
+        // a click on its button (which lives in the body) doesn't also toggle.
+        if (event.target.closest('[data-type="refreshlinking"]')) {
+            if (!scannerLinkingLoading) loadScannerLinking();
+            return;
+        }
+        if (event.target.closest('[data-type="togglelinking"]')) {
+            scannerLinkingOpen = !scannerLinkingOpen;
+            renderScannerLinking();
+            if (scannerLinkingOpen && !scannerLinkingLoading) loadScannerLinking();
             return;
         }
         if (event.target.closest('[data-type="removezone"]')) {
@@ -2366,6 +2389,100 @@ document.addEventListener('DOMContentLoaded', async () => {
             html += `<div class="bps-issue-note">Reporting a distance but not placed: ${unplaced.map(escHtml).join(", ")}</div>`;
         }
         html += '</div>';
+        host.innerHTML = html;
+    }
+
+    // Distance-sensor states that mean "no reading right now" (mirrors the
+    // backend's _NO_DISTANCE_STATES).
+    function linkingHasReading(state) {
+        return state !== null && state !== "" && state !== "unknown" && state !== "unavailable";
+    }
+
+    // Fetch a fresh linking snapshot each time the section opens or Refresh is
+    // pressed. Live HA state changes constantly, so there's no useful cache to
+    // keep across opens; a stale/failed fetch just shows an empty snapshot.
+    async function loadScannerLinking() {
+        scannerLinkingLoading = true;
+        renderScannerLinking();
+        let data = { placed: [], unplaced: [] };
+        try {
+            const res = await fetch('/api/bps/scanner_linking');
+            if (res.ok) {
+                const parsed = await res.json();
+                if (parsed && typeof parsed === 'object') {
+                    data = {
+                        placed: Array.isArray(parsed.placed) ? parsed.placed : [],
+                        unplaced: Array.isArray(parsed.unplaced) ? parsed.unplaced : [],
+                    };
+                }
+            }
+        } catch (e) { /* transient; show an empty snapshot */ }
+        scannerLinkingData = data;
+        scannerLinkingLoading = false;
+        renderScannerLinking();
+    }
+
+    const LINKING_STATUS_LABEL = { live: "Live", silent: "No reading", unmatched: "Unmatched" };
+    const LINKING_STATUS_RANK = { unmatched: 0, silent: 1, live: 2 };
+
+    function renderLinkingBody() {
+        if (scannerLinkingLoading) return '<p class="bps-linking-msg">Loading…</p>';
+        const data = scannerLinkingData;
+        if (!data) return '<p class="bps-linking-msg">No data.</p>';
+        let html = '<div class="bps-linking-actions"><button type="button" class="bps-btn bps-btn-outline bps-linking-refresh" data-type="refreshlinking">Refresh</button></div>';
+        const rows = (data.placed || []).slice().sort((a, b) =>
+            (LINKING_STATUS_RANK[a.status] - LINKING_STATUS_RANK[b.status])
+            || String(a.floor || "").localeCompare(String(b.floor || ""))
+            || String(a.entity_id).localeCompare(String(b.entity_id)));
+        if (!rows.length) {
+            html += '<p class="bps-linking-msg">No receivers placed yet.</p>';
+        } else {
+            html += '<ul class="bps-linking-list">';
+            rows.forEach(r => {
+                const status = LINKING_STATUS_RANK.hasOwnProperty(r.status) ? r.status : "unmatched";
+                let detail;
+                if (status === "unmatched") {
+                    detail = '<div class="bps-linking-detail">No distance sensor named “' + escHtml(r.entity_id) + '”'
+                        + (r.token ? ' (hardware ' + escHtml(r.token) + ')' : '') + '</div>';
+                } else {
+                    const readings = (r.sensors || []).map(s => {
+                        const live = linkingHasReading(s.state);
+                        const val = (s.state === null || s.state === "") ? "—" : s.state;
+                        return '<span class="bps-linking-reading ' + (live ? 'is-live' : 'is-silent') + '" title="' + escHtml(s.entity_id) + '">'
+                            + escHtml(s.device) + ': ' + escHtml(val) + '</span>';
+                    }).join("");
+                    detail = '<div class="bps-linking-readings">' + (readings || '<span class="bps-linking-detail">no sensors</span>') + '</div>';
+                }
+                html += '<li class="bps-linking-row bps-status-' + status + '">'
+                    + '<div class="bps-linking-row-head">'
+                    + '<span class="bps-linking-name" title="' + escHtml(r.entity_id) + '">' + escHtml(r.entity_id) + '</span>'
+                    + (r.floor ? '<span class="bps-linking-floor">' + escHtml(r.floor) + '</span>' : '')
+                    + '<span class="bps-linking-chip bps-chip-' + status + '">' + LINKING_STATUS_LABEL[status] + '</span>'
+                    + '</div>'
+                    + detail
+                    + '</li>';
+            });
+            html += '</ul>';
+        }
+        const unplaced = (data.unplaced || []);
+        if (unplaced.length) {
+            html += '<div class="bps-linking-note"><strong>Sensors not placed on any floor:</strong> '
+                + unplaced.map(u => escHtml(u.entity_id) + (u.reporting_count ? "" : " (silent)")).join(", ") + '</div>';
+        }
+        html += '<p class="bps-linking-help">“No reading” means the name matches a Bermuda sensor but it has no distance right now — usually just no recent BLE contact, not a naming problem. “Unmatched” means no sensor carries that name at all.</p>';
+        return html;
+    }
+
+    // Collapsible "Scanner linking (debug)" section (issue #64). Header is
+    // always shown so the tool is discoverable; the body renders only when open.
+    function renderScannerLinking() {
+        const host = document.getElementById("scannerlinking");
+        if (!host) return;
+        let html = '<div class="bps-linking-head' + (scannerLinkingOpen ? ' bps-open' : '') + '" data-type="togglelinking">'
+            + '<span class="bps-linking-caret">' + (scannerLinkingOpen ? "▾" : "▸") + '</span>'
+            + '<span class="bps-linking-title">Scanner linking (debug)</span>'
+            + '</div>';
+        if (scannerLinkingOpen) html += '<div class="bps-linking-body">' + renderLinkingBody() + '</div>';
         host.innerHTML = html;
     }
 


### PR DESCRIPTION
Follow-up to #74, addressing David's request on #64:

> Can you add some debug output to show how it is matching up the scanners using the new logic — I don't think it got it wrong, they just were not reporting anything.

## Why

The amber **Scanner issues** panel from #74 only surfaces two states: a placed slug with *no* Bermuda sensor at all (unmatched), and scanners *reporting but unplaced*. The case David is hitting — a scanner that **is** linked correctly but whose distance sensor is `unavailable`/`unknown` right now — shows up in neither list. So he gets no circle **and** no explanation.

## What this adds

A collapsible, on-demand **"Scanner linking (debug)"** section in the panel sidebar. For every placed receiver it shows the Bermuda distance sensors feeding it and each one's current state, classified as:

| Status | Meaning |
|---|---|
| **Live** | some tracked device is reading a distance through it |
| **No reading** | a matching sensor exists but is `unavailable`/empty right now — usually just no recent BLE contact, **not** a naming problem |
| **Unmatched** | no distance sensor carries that slug at all (a real mismatch → use #74's Re-link) |

Rows sort problems-first (unmatched → no reading → live), each showing the per-device readings (the exact `sensor.<device>_distance_to_<slug>` entities `update_receiver_radii` looks up). It also lists scanners that have sensors but aren't placed anywhere. A **Refresh** button re-checks live, so after renaming an entity in Bermuda you can confirm the fix without reloading.

## Design notes

- **On-demand**: a new `GET /api/bps/scanner_linking` is fetched only when the section is expanded (or Refresh is pressed), so it adds nothing to a normal panel load or the tracking loop.
- **Device-agnostic**: reads live HA state directly, so it works whether or not a device is actively tracked.
- The tracking loop and the exact-slug lookup in `update_receiver_radii` are **unchanged**. The defensive placement parse from #74 is extracted into a shared `_placed_receivers()` (behavior identical).

## Stacking

Based on the `solidify-scanner-detection` branch (#74) since it builds on that diagnostics code — so this diff is just the debug-view delta, and it retargets to `main` automatically once #74 merges. Merge #74 first.

## Verification

- `py_compile`; regex-aware JS balance check.
- Standalone backend test (19 assertions): live/silent/unmatched classification incl. David's matched-but-silent case, per-device grouping, sorting, and 9 malformed/hostile `bpsdata` shapes (never raises).
- Browser harness against the real render code + CSS: collapsed header, expand-loads, correct chips/readings, Refresh re-fetch, failed-fetch degrades to an empty snapshot, collapse keeps the header.
- 4-lens adversarial review (correctness / robustness / frontend-behavior / integration) with per-finding adversarial verify — **0 confirmed findings**.

Not yet exercised against David's live setup — worth confirming the three bedroom scanners show as **No reading** (linked but silent) rather than **Unmatched** when deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
