### PR TITLE
Debugging tab for receiver linking; slim the map-sidebar heads-up (#64)

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2952,43 +2952,10 @@ select.bps-input { cursor: pointer; }
 .bps-relink-btn { height: 24px; padding: 0 8px; font-size: 11px; flex: 0 0 auto; }
 .bps-issue-note { color: hsl(var(--muted-foreground)); margin-top: 4px; }
 
-/* Scanner linking debug section (issue #64) — a neutral collapsible panel that
-   shows how each placed receiver maps to Bermuda distance sensors. */
-.bps-linking { margin: 8px 0; font-size: 12px; }
-.bps-linking-head {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    user-select: none;
-    padding: 6px 8px;
-    border: 1px solid hsl(var(--border));
-    border-radius: 8px;
-    color: hsl(var(--muted-foreground));
-    font-weight: 600;
-}
-.bps-linking-head:hover { background: hsl(var(--accent)); }
-.bps-linking-caret { width: 12px; display: inline-block; text-align: center; }
-.bps-linking-title { text-transform: uppercase; font-size: 11px; letter-spacing: 0.04em; }
-.bps-linking-body {
-    margin-top: 6px;
-    padding: 8px 10px;
-    border: 1px solid hsl(var(--border));
-    border-radius: 8px;
-}
-.bps-linking-actions { display: flex; justify-content: flex-end; margin-bottom: 6px; }
-.bps-linking-refresh { height: 24px; padding: 0 10px; font-size: 11px; }
-.bps-linking-msg { color: hsl(var(--muted-foreground)); margin: 4px 0; }
-.bps-linking-list { list-style: none; margin: 0; padding: 0; }
-.bps-linking-row {
-    padding: 6px 0;
-    border-top: 1px solid hsl(var(--border) / 0.6);
-}
-.bps-linking-row:first-child { border-top: 0; }
-.bps-linking-row-head { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-.bps-linking-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; }
-.bps-linking-floor { color: hsl(var(--muted-foreground)); font-size: 11px; flex: 0 0 auto; }
+/* Receiver-linking status chips (issue #64) — shared by the map-sidebar
+   heads-up and the Debugging tab table. */
 .bps-linking-chip {
+    display: inline-block;
     flex: 0 0 auto;
     padding: 1px 7px;
     border-radius: 999px;
@@ -2996,23 +2963,58 @@ select.bps-input { cursor: pointer; }
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.03em;
+    white-space: nowrap;
 }
 .bps-chip-live { background: hsl(142 71% 45% / 0.18); color: hsl(142 61% 38%); }
 .bps-chip-silent { background: hsl(38 92% 50% / 0.18); color: hsl(38 92% 42%); }
 .bps-chip-unmatched { background: hsl(0 84% 60% / 0.18); color: hsl(0 74% 52%); }
-.bps-linking-readings { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-.bps-linking-reading {
-    padding: 1px 6px;
+
+/* Map sidebar: compact "not reporting right now" heads-up (names only). */
+.bps-linking { margin: 8px 0; font-size: 12px; }
+.bps-linking-mini {
+    padding: 8px 10px;
+    border: 1px solid hsl(38 92% 50% / 0.5);
+    border-radius: 8px;
+    background: hsl(38 92% 50% / 0.08);
+}
+.bps-linking-mini-title { font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: hsl(38 92% 45%); margin-bottom: 6px; }
+.bps-linking-mini-list { list-style: none; margin: 0 0 6px; padding: 0; }
+.bps-linking-mini-list li { font-family: monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 1px 0; }
+.bps-linking-mini-hint { color: hsl(var(--muted-foreground)); font-size: 11px; line-height: 1.4; }
+
+/* Debugging tab: full receiver-linking table. */
+.bps-debug { font-size: 13px; }
+.bps-debug-msg { color: hsl(var(--muted-foreground)); margin: 8px 0; }
+.bps-debug-toolbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.bps-debug-summary { display: flex; gap: 6px; flex-wrap: wrap; }
+.bps-debug-tablewrap { overflow-x: auto; border: 1px solid hsl(var(--border)); border-radius: 8px; }
+.bps-debug-table { width: 100%; border-collapse: collapse; }
+.bps-debug-table th, .bps-debug-table td { text-align: left; padding: 8px 12px; vertical-align: top; }
+.bps-debug-table thead th {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em;
+    color: hsl(var(--muted-foreground)); font-weight: 700;
+    border-bottom: 1px solid hsl(var(--border));
+    white-space: nowrap;
+}
+.bps-debug-table tbody tr + tr { border-top: 1px solid hsl(var(--border) / 0.6); }
+.bps-debug-name, .bps-debug-hw { font-family: monospace; }
+.bps-debug-hw { color: hsl(var(--muted-foreground)); }
+.bps-debug-none { color: hsl(var(--muted-foreground)); font-style: italic; }
+.bps-debug-row.bps-status-unmatched .bps-debug-name { color: hsl(0 74% 52%); }
+.bps-debug-readings { display: flex; flex-wrap: wrap; gap: 5px; }
+.bps-debug-reading {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 1px 4px 1px 7px;
     border-radius: 6px;
-    font-size: 11px;
     font-family: monospace;
     background: hsl(var(--muted) / 0.5);
 }
-.bps-linking-reading.is-live { background: hsl(142 71% 45% / 0.14); }
-.bps-linking-reading.is-silent { background: hsl(38 92% 50% / 0.14); color: hsl(var(--muted-foreground)); }
-.bps-linking-detail { color: hsl(var(--muted-foreground)); margin-top: 4px; }
-.bps-linking-note { margin-top: 8px; color: hsl(var(--muted-foreground)); }
-.bps-linking-help { margin-top: 8px; color: hsl(var(--muted-foreground)); font-size: 11px; line-height: 1.4; }
+.bps-debug-reading.is-live { background: hsl(142 71% 45% / 0.14); }
+.bps-debug-reading.is-silent { background: hsl(38 92% 50% / 0.14); color: hsl(var(--muted-foreground)); }
+.bps-debug-dev { opacity: 0.85; }
+.bps-debug-val { font-weight: 700; padding: 0 5px; border-radius: 4px; background: hsl(var(--background) / 0.6); }
+.bps-debug-subtitle { margin: 18px 0 8px; font-size: 13px; }
+.bps-debug-help { margin-top: 12px; color: hsl(var(--muted-foreground)); font-size: 12px; line-height: 1.5; }
 
 .bps-scale-status { margin-top: 10px; }
 .bps-scale-line {

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -10,6 +10,7 @@
         <nav class="bps-tabs" role="tablist">
             <button type="button" class="bps-tab active" data-tab="map" role="tab">Map &amp; Setup</button>
             <button type="button" class="bps-tab" data-tab="calibration" role="tab">Receiver Calibration</button>
+            <button type="button" class="bps-tab" data-tab="debugging" role="tab">Debugging</button>
             <button type="button" id="themeToggle" class="bps-theme-toggle" title="Toggle light / dark theme" aria-label="Toggle theme">🌙</button>
         </nav>
 
@@ -133,9 +134,9 @@
                     <!-- Naming-mismatch warnings (issue #64): placed receivers with no
                          Bermuda sensor, and scanners reporting a distance but unplaced. -->
                     <div id="scannerissues"></div>
-                    <!-- On-demand debug view (issue #64): how each placed receiver links
-                         to Bermuda distance sensors and whether each is reporting right
-                         now. Collapsed by default; fetched live when expanded. -->
+                    <!-- Compact "not reporting" heads-up (issue #64): placed receivers on
+                         this floor that are linked but have no distance right now (names
+                         only). Full per-entity linking detail lives in the Debugging tab. -->
                     <div id="scannerlinking" class="bps-linking"></div>
                     <p class="bps-hint">Enable “Move receivers”, drag one on the map, then Save Floor Plan.</p>
                     <div class="bps-scale-status">
@@ -183,6 +184,19 @@
                 </div>
                 <div id="calibStatus" class="bps-calib-status"></div>
                 <div id="calibResults" class="bps-calib-matrix"></div>
+            </div>
+        </section>
+
+        <!-- ============================ DEBUGGING ============================ -->
+        <section class="bps-tabpanel" data-tabpanel="debugging">
+            <div class="bps-card">
+                <div class="bps-section-head">
+                    <h3>Receiver linking</h3>
+                    <span class="tooltip">❓
+                        <span class="tooltip-text">How each placed receiver maps to its Bermuda distance sensors, and whether each is reporting a distance right now. Use this to tell a real naming mismatch (Unmatched) apart from a receiver that is linked correctly but simply not reporting at the moment (No reading). This is a live snapshot — press Refresh to re-check.</span>
+                    </span>
+                </div>
+                <div id="debuglinking" class="bps-debug"></div>
             </div>
         </section>
     </div>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -59,12 +59,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     // with no matching Bermuda sensor (each with a suggested live scanner), and
     // scanners reporting a distance that aren't placed anywhere.
     let scannerDiagnostics = { unmatched_receivers: [], unplaced_scanners: [] };
-    // On-demand "Scanner linking" debug section (issue #64). Collapsed by
-    // default; each time it opens it fetches a fresh live snapshot from
-    // /api/bps/scanner_linking so a scanner renamed in Bermuda re-checks without
-    // a page reload. Kept independent of the map redraw so it never refetches
-    // on every canvas repaint.
-    let scannerLinkingOpen = false;
+    // Receiver-linking snapshot from /api/bps/scanner_linking (issue #64): every
+    // placed receiver with its Bermuda distance sensors + live states. Feeds the
+    // full Debugging tab and the compact "not reporting" heads-up in the map
+    // sidebar. Refreshed on load, on Refresh, and when the Debugging tab opens.
     let scannerLinkingLoading = false;
     let scannerLinkingData = null;
     // A placed receiver is "offline" when its scanner's distance sensors are
@@ -345,9 +343,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (tmpsaved){
             await fetchBPSData();
         }
-        // Show the collapsed "Scanner linking (debug)" header; its body loads on
-        // demand when expanded.
-        renderScannerLinking();
+        // Load the linking snapshot so the sidebar's "not reporting" heads-up and
+        // the Debugging tab are populated on load (both re-check on Refresh / when
+        // the Debugging tab is opened).
+        loadScannerLinking();
 
 
         let stoptrackstat = false;
@@ -881,16 +880,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             return;
         }
-        // Scanner-linking debug section (issue #64). Refresh is checked first so
-        // a click on its button (which lives in the body) doesn't also toggle.
+        // Debugging tab Refresh — re-fetch the receiver-linking snapshot (issue #64).
         if (event.target.closest('[data-type="refreshlinking"]')) {
             if (!scannerLinkingLoading) loadScannerLinking();
-            return;
-        }
-        if (event.target.closest('[data-type="togglelinking"]')) {
-            scannerLinkingOpen = !scannerLinkingOpen;
-            renderScannerLinking();
-            if (scannerLinkingOpen && !scannerLinkingLoading) loadScannerLinking();
             return;
         }
         if (event.target.closest('[data-type="removezone"]')) {
@@ -1031,6 +1023,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         renderEntityTree(null);
         const issues = document.getElementById("scannerissues");
         if (issues) issues.innerHTML = ""; // clear stale mismatch warnings + Re-link buttons
+        // No floor is loaded now, so drop the floor-scoped "not reporting" heads-up
+        // (Clear Canvas doesn't route through drawElements, which would re-scope it).
+        const linking = document.getElementById("scannerlinking");
+        if (linking) linking.innerHTML = "";
     });
 
     function clearCanvas(){
@@ -2311,6 +2307,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         drawAdjustGhost();
         renderEntityTree(floor);
         renderScannerIssues();
+        renderScannerLinkingSidebar(); // re-scope the "not reporting" heads-up to this floor (cached data, no refetch)
 
         // Keep the map's Save/Cancel actions in sync with tool state. Every
         // activation and every exit path routes through drawElements, so this
@@ -2398,12 +2395,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         return state !== null && state !== "" && state !== "unknown" && state !== "unavailable";
     }
 
-    // Fetch a fresh linking snapshot each time the section opens or Refresh is
-    // pressed. Live HA state changes constantly, so there's no useful cache to
-    // keep across opens; a stale/failed fetch just shows an empty snapshot.
+    // Fetch a fresh linking snapshot, then repaint both consumers: the compact
+    // "not reporting" heads-up in the map sidebar and the full Debugging tab.
+    // Live HA state changes constantly, so there's no useful cache to keep — a
+    // stale/failed fetch just shows an empty snapshot.
     async function loadScannerLinking() {
         scannerLinkingLoading = true;
-        renderScannerLinking();
+        renderDebugView();
         let data = { placed: [], unplaced: [] };
         try {
             const res = await fetch('/api/bps/scanner_linking');
@@ -2419,70 +2417,114 @@ document.addEventListener('DOMContentLoaded', async () => {
         } catch (e) { /* transient; show an empty snapshot */ }
         scannerLinkingData = data;
         scannerLinkingLoading = false;
-        renderScannerLinking();
+        renderScannerLinkingSidebar();
+        renderDebugView();
     }
 
     const LINKING_STATUS_LABEL = { live: "Live", silent: "No reading", unmatched: "Unmatched" };
     const LINKING_STATUS_RANK = { unmatched: 0, silent: 1, live: 2 };
+    const linkingStatusOf = r => (LINKING_STATUS_RANK.hasOwnProperty(r && r.status) ? r.status : "unmatched");
 
-    function renderLinkingBody() {
-        if (scannerLinkingLoading) return '<p class="bps-linking-msg">Loading…</p>';
-        const data = scannerLinkingData;
-        if (!data) return '<p class="bps-linking-msg">No data.</p>';
-        let html = '<div class="bps-linking-actions"><button type="button" class="bps-btn bps-btn-outline bps-linking-refresh" data-type="refreshlinking">Refresh</button></div>';
-        const rows = (data.placed || []).slice().sort((a, b) =>
-            (LINKING_STATUS_RANK[a.status] - LINKING_STATUS_RANK[b.status])
-            || String(a.floor || "").localeCompare(String(b.floor || ""))
-            || String(a.entity_id).localeCompare(String(b.entity_id)));
-        if (!rows.length) {
-            html += '<p class="bps-linking-msg">No receivers placed yet.</p>';
-        } else {
-            html += '<ul class="bps-linking-list">';
-            rows.forEach(r => {
-                const status = LINKING_STATUS_RANK.hasOwnProperty(r.status) ? r.status : "unmatched";
-                let detail;
-                if (status === "unmatched") {
-                    detail = '<div class="bps-linking-detail">No distance sensor named “' + escHtml(r.entity_id) + '”'
-                        + (r.token ? ' (hardware ' + escHtml(r.token) + ')' : '') + '</div>';
-                } else {
-                    const readings = (r.sensors || []).map(s => {
-                        const live = linkingHasReading(s.state);
-                        const val = (s.state === null || s.state === "") ? "—" : s.state;
-                        return '<span class="bps-linking-reading ' + (live ? 'is-live' : 'is-silent') + '" title="' + escHtml(s.entity_id) + '">'
-                            + escHtml(s.device) + ': ' + escHtml(val) + '</span>';
-                    }).join("");
-                    detail = '<div class="bps-linking-readings">' + (readings || '<span class="bps-linking-detail">no sensors</span>') + '</div>';
-                }
-                html += '<li class="bps-linking-row bps-status-' + status + '">'
-                    + '<div class="bps-linking-row-head">'
-                    + '<span class="bps-linking-name" title="' + escHtml(r.entity_id) + '">' + escHtml(r.entity_id) + '</span>'
-                    + (r.floor ? '<span class="bps-linking-floor">' + escHtml(r.floor) + '</span>' : '')
-                    + '<span class="bps-linking-chip bps-chip-' + status + '">' + LINKING_STATUS_LABEL[status] + '</span>'
-                    + '</div>'
-                    + detail
-                    + '</li>';
-            });
-            html += '</ul>';
-        }
-        const unplaced = (data.unplaced || []);
-        if (unplaced.length) {
-            html += '<div class="bps-linking-note"><strong>Sensors not placed on any floor:</strong> '
-                + unplaced.map(u => escHtml(u.entity_id) + (u.reporting_count ? "" : " (silent)")).join(", ") + '</div>';
-        }
-        html += '<p class="bps-linking-help">“No reading” means the name matches a Bermuda sensor but it has no distance right now — usually just no recent BLE contact, not a naming problem. “Unmatched” means no sensor carries that name at all.</p>';
-        return html;
-    }
-
-    // Collapsible "Scanner linking (debug)" section (issue #64). Header is
-    // always shown so the tool is discoverable; the body renders only when open.
-    function renderScannerLinking() {
+    // Map-view sidebar: a compact heads-up listing only placed receivers on the
+    // CURRENT floor that are linked but silent (no distance right now), names
+    // only. The full per-entity picture lives in the Debugging tab. Hidden
+    // entirely when nothing on this floor is silent. Uses the cached snapshot,
+    // so it's re-scoped to the viewed floor on each drawElements without a
+    // refetch.
+    function renderScannerLinkingSidebar() {
         const host = document.getElementById("scannerlinking");
         if (!host) return;
-        let html = '<div class="bps-linking-head' + (scannerLinkingOpen ? ' bps-open' : '') + '" data-type="togglelinking">'
-            + '<span class="bps-linking-caret">' + (scannerLinkingOpen ? "▾" : "▸") + '</span>'
-            + '<span class="bps-linking-title">Scanner linking (debug)</span>'
+        const data = scannerLinkingData;
+        if (!data) { host.innerHTML = ""; return; }
+        const silent = (data.placed || []).filter(r =>
+            linkingStatusOf(r) === "silent" && (!SelMapName || sameFloorName(r.floor, SelMapName)));
+        if (!silent.length) { host.innerHTML = ""; return; }
+        silent.sort((a, b) => String(a.entity_id).localeCompare(String(b.entity_id)));
+        host.innerHTML = '<div class="bps-linking-mini">'
+            + '<div class="bps-linking-mini-title">Not reporting right now</div>'
+            + '<ul class="bps-linking-mini-list">'
+            + silent.map(r => '<li title="' + escHtml(r.entity_id) + '">' + escHtml(r.entity_id) + '</li>').join("")
+            + '</ul>'
+            + '<div class="bps-linking-mini-hint">Linked, but no distance right now. See the <strong>Debugging</strong> tab for details.</div>'
             + '</div>';
-        if (scannerLinkingOpen) html += '<div class="bps-linking-body">' + renderLinkingBody() + '</div>';
+    }
+
+    // Debugging tab: the complete receiver-linking picture, laid out as a table
+    // for easy visual scanning — every placed receiver, its status, and the
+    // per-device Bermuda distance sensors feeding it with their live states.
+    function renderDebugView() {
+        const host = document.getElementById("debuglinking");
+        if (!host) return;
+        if (scannerLinkingLoading && !scannerLinkingData) { host.innerHTML = '<p class="bps-debug-msg">Loading…</p>'; return; }
+        const data = scannerLinkingData;
+        if (!data) { host.innerHTML = '<p class="bps-debug-msg">No data yet. <button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button></p>'; return; }
+
+        const rows = (data.placed || []).slice().sort((a, b) =>
+            (LINKING_STATUS_RANK[linkingStatusOf(a)] - LINKING_STATUS_RANK[linkingStatusOf(b)])
+            || String(a.floor || "").localeCompare(String(b.floor || ""))
+            || String(a.entity_id).localeCompare(String(b.entity_id)));
+        const counts = { live: 0, silent: 0, unmatched: 0 };
+        rows.forEach(r => { counts[linkingStatusOf(r)]++; });
+
+        let html = '<div class="bps-debug-toolbar">'
+            + '<button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button>'
+            + '<span class="bps-debug-summary">'
+            + '<span class="bps-linking-chip bps-chip-live">' + counts.live + ' Live</span>'
+            + '<span class="bps-linking-chip bps-chip-silent">' + counts.silent + ' No reading</span>'
+            + '<span class="bps-linking-chip bps-chip-unmatched">' + counts.unmatched + ' Unmatched</span>'
+            + '</span></div>';
+
+        if (!rows.length) {
+            html += '<p class="bps-debug-msg">No receivers placed yet. Place receivers on the Map &amp; Setup tab.</p>';
+        } else {
+            html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
+                + '<th>Receiver</th><th>Floor</th><th>Status</th><th>Hardware</th><th>Bermuda distance sensors (device: reading)</th>'
+                + '</tr></thead><tbody>';
+            rows.forEach(r => {
+                const status = linkingStatusOf(r);
+                let cell;
+                if (status === "unmatched") {
+                    cell = '<span class="bps-debug-none">No distance sensor carries this name</span>';
+                } else if (!(r.sensors || []).length) {
+                    cell = '<span class="bps-debug-none">no sensors</span>';
+                } else {
+                    cell = '<div class="bps-debug-readings">' + r.sensors.map(s => {
+                        const live = linkingHasReading(s.state);
+                        const val = (s.state === null || s.state === "") ? "—" : s.state;
+                        return '<span class="bps-debug-reading ' + (live ? 'is-live' : 'is-silent') + '" title="' + escHtml(s.entity_id) + '">'
+                            + '<span class="bps-debug-dev">' + escHtml(s.device) + '</span>'
+                            + '<span class="bps-debug-val">' + escHtml(val) + '</span></span>';
+                    }).join("") + '</div>';
+                }
+                html += '<tr class="bps-debug-row bps-status-' + status + '">'
+                    + '<td class="bps-debug-name" title="' + escHtml(r.entity_id) + '">' + escHtml(r.entity_id) + '</td>'
+                    + '<td>' + (r.floor ? escHtml(r.floor) : "—") + '</td>'
+                    + '<td><span class="bps-linking-chip bps-chip-' + status + '">' + LINKING_STATUS_LABEL[status] + '</span></td>'
+                    + '<td class="bps-debug-hw">' + (r.token ? escHtml(r.token) : "—") + '</td>'
+                    + '<td>' + cell + '</td>'
+                    + '</tr>';
+            });
+            html += '</tbody></table></div>';
+        }
+
+        const unplaced = (data.unplaced || []).slice().sort((a, b) => String(a.entity_id).localeCompare(String(b.entity_id)));
+        if (unplaced.length) {
+            html += '<h4 class="bps-debug-subtitle">Scanners with distance sensors but not placed on any floor</h4>'
+                + '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
+                + '<th>Scanner</th><th>Hardware</th><th>Sensors</th><th>Reporting</th></tr></thead><tbody>';
+            unplaced.forEach(u => {
+                html += '<tr>'
+                    + '<td class="bps-debug-name" title="' + escHtml(u.entity_id) + '">' + escHtml(u.entity_id) + '</td>'
+                    + '<td class="bps-debug-hw">' + (u.token ? escHtml(u.token) : "—") + '</td>'
+                    + '<td>' + (u.sensor_count || 0) + '</td>'
+                    + '<td>' + (u.reporting_count || 0) + '</td>'
+                    + '</tr>';
+            });
+            html += '</tbody></table></div>';
+        }
+
+        html += '<p class="bps-debug-help"><strong>No reading</strong> = the name matches a Bermuda distance sensor but it has no value right now — usually just no recent BLE contact, not a naming problem. '
+            + '<strong>Unmatched</strong> = no distance sensor carries that name at all; fix it with the <em>Re-link</em> button in the Map view’s “Scanner issues” panel, or rename the entity in Bermuda.</p>';
         host.innerHTML = html;
     }
 
@@ -3333,6 +3375,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             tabButtons.forEach((b) => b.classList.toggle("active", b === btn));
             tabPanels.forEach((pnl) => pnl.classList.toggle("active", pnl.dataset.tabpanel === name));
             scheduleSidebarSync(); // sidebar becomes visible/hidden with the tab
+            // Opening the Debugging tab re-checks the linking snapshot so its live
+            // readings are current (they drift as devices move / go out of range).
+            if (name === "debugging" && !scannerLinkingLoading) loadScannerLinking();
         });
     });
 


### PR DESCRIPTION
Follow-up to #74/#75 (issue #64). The sidebar "Scanner linking" section put the full per-entity linking dump into a narrow column — accurate, but packed and hard to read at a glance. This splits it into a spacious debug view and a minimal heads-up.

## New "Debugging" tab

A third tab beside **Map & Setup** and **Receiver Calibration**, holding the complete receiver-linking picture as a table:

| Receiver | Floor | Status | Hardware | Bermuda distance sensors (device: reading) |
|---|---|---|---|---|

- One row per placed receiver, sorted **problems first** (Unmatched → No reading → Live), with a status chip, the hardware token, and each per-device sensor's live reading (green = live, amber = silent).
- A **status summary** (`N Live · N No reading · N Unmatched`) and a second table for **scanners that have sensors but aren't placed** anywhere.
- Refreshes when you open the tab and via a **Refresh** button (live state drifts as devices move).

## Slimmed map sidebar

The `#scannerlinking` section in the Map view is now a compact heads-up: it lists **only the receivers on the current floor that are linked but silent** ("No reading"), **names only** — no per-entity detail. It hides entirely when everything on the floor is reporting. Full detail lives in the Debugging tab.

## Notes

- Both consumers read one shared `/api/bps/scanner_linking` snapshot — **the endpoint is unchanged** (no backend change in this PR). The old collapsible section and its dead CSS are removed. **Frontend-only.**
- Clear Canvas now also drops the floor-scoped heads-up (it doesn't route through `drawElements`, which is what otherwise re-scopes it).

## Verification

- JS balance check; grep-confirmed no dangling references to the removed symbols (`renderScannerLinking`/`renderLinkingBody`/`scannerLinkingOpen`/`togglelinking`) or removed CSS classes.
- Browser harness against the real render code + CSS: sidebar shows only current-floor silent names (verified it re-scopes on floor switch and excludes other floors / live / unmatched); Debugging table renders all rows with correct sort, chips, per-device readings, summary counts (1 Live / 3 No reading / 1 Unmatched) and the unplaced table; Refresh re-fetches; a failed fetch degrades to an empty snapshot with no throw; table scrolls horizontally on narrow widths.
- 4-lens adversarial review (correctness / dangling-refs / wiring-state / escaping-css) with per-finding adversarial verify. One low-severity finding — Clear Canvas leaving the floor-scoped heads-up stale — **confirmed and fixed** in this PR; re-checked, nothing else.

Needs an HA restart only if not already on #75's backend (the endpoint shipped in #75); otherwise a panel hard-refresh is enough. Not yet exercised on David's live setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
