### PR TITLE
Show "unavailable" readings in bright orange-red in the Debugging tab (#64)

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3011,6 +3011,10 @@ select.bps-input { cursor: pointer; }
 }
 .bps-debug-reading.is-live { background: hsl(142 71% 45% / 0.14); }
 .bps-debug-reading.is-silent { background: hsl(38 92% 50% / 0.14); color: hsl(var(--muted-foreground)); }
+/* "unavailable" is a stronger signal than "unknown" — the entity is actually
+   gone, not just waiting on a value — so it reads bright orange-red. */
+.bps-debug-reading.is-unavailable { background: hsl(12 88% 53% / 0.22); color: hsl(12 85% 55%); }
+.bps-debug-reading.is-unavailable .bps-debug-val { background: hsl(12 88% 53% / 0.18); }
 .bps-debug-dev { opacity: 0.85; }
 .bps-debug-val { font-weight: 700; padding: 0 5px; border-radius: 4px; background: hsl(var(--background) / 0.6); }
 .bps-debug-subtitle { margin: 18px 0 8px; font-size: 13px; }

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2489,9 +2489,16 @@ document.addEventListener('DOMContentLoaded', async () => {
                     cell = '<span class="bps-debug-none">no sensors</span>';
                 } else {
                     cell = '<div class="bps-debug-readings">' + r.sensors.map(s => {
-                        const live = linkingHasReading(s.state);
-                        const val = (s.state === null || s.state === "") ? "—" : s.state;
-                        return '<span class="bps-debug-reading ' + (live ? 'is-live' : 'is-silent') + '" title="' + escHtml(s.entity_id) + '">'
+                        // Three states, worst to mildest: a real reading (live, green);
+                        // "unavailable" — the entity/scanner is actually gone (bright
+                        // orange-red, a real problem); "unknown"/empty — a matching
+                        // sensor with no value yet (amber, usually just no BLE contact).
+                        const st = (s.state === null || s.state === undefined) ? "" : String(s.state);
+                        let cls, val;
+                        if (linkingHasReading(s.state)) { cls = "is-live"; val = st; }
+                        else if (st.toLowerCase() === "unavailable") { cls = "is-unavailable"; val = st; }
+                        else { cls = "is-silent"; val = st === "" ? "—" : st; }
+                        return '<span class="bps-debug-reading ' + cls + '" title="' + escHtml(s.entity_id) + '">'
                             + '<span class="bps-debug-dev">' + escHtml(s.device) + '</span>'
                             + '<span class="bps-debug-val">' + escHtml(val) + '</span></span>';
                     }).join("") + '</div>';


### PR DESCRIPTION
Small visual follow-up to #76.

In the Debugging tab's per-device readings, `unknown` and `unavailable` both rendered as the same amber "No reading" pill. `unavailable` is a stronger signal — the entity/scanner is actually **gone**, not just waiting on a value — so it now reads **bright orange-red**, distinct from the amber `unknown`/no-value pill. Live numeric readings stay green.

Frontend-only (`script.js` classification + one `bpsstyle.css` rule); no backend change.

**Verified** via the browser harness (computed styles): `unavailable` → `rgb(238,82,43)` on an orange-red tint; `unknown` → unchanged amber; live → green. JS balance check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)