### PR TITLE
Calibration: match renamed scanners + report missing receivers (#63)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -40,6 +40,7 @@ from .calibration import (
     async_restore_calibration_state,
     async_shutdown_calibration,
     async_start_auto_if_enabled,
+    refresh_receivers_from_coords,
 )
 from .zone_adjust import adjust_zones, adjust_subzones
 
@@ -1188,6 +1189,10 @@ class BPSSaveAPIText(HomeAssistantView):
                 error = await self._write_save(bpsdata_file_path, maps_path, data, coordinates)
             if error is not None:
                 return error
+            # A calibration window may be sampling right now; hand it the
+            # edited placements so a re-linked/added receiver starts matching
+            # on the next dump instead of after the next window/solve cycle.
+            refresh_receivers_from_coords(hass, coordinates)
             _LOGGER.info(f"Saved coordinates to bpsdata: {coordinates}")
             return web.Response(status=200, text="Coordinates saved successfully")
 

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import logging
 import math
+import re
 import time
 from collections import deque
 from datetime import datetime, timezone
@@ -78,6 +79,49 @@ NEG_SCALE = 0.4
 
 def _normalize(value):
     return str(value or "").strip().lower()
+
+
+# Mirrors __init__._scanner_token (calibration cannot import __init__ — it
+# would be circular): the trailing MAC-derived hex group in a scanner slug,
+# a stable hardware identity that survives renames.
+_SCANNER_TOKEN_RE = re.compile(r"^[0-9a-f]{5,12}$")
+
+
+def _scanner_token(slug):
+    if not slug:
+        return None
+    last = str(slug).rsplit("_", 1)[-1].lower()
+    return last if _SCANNER_TOKEN_RE.match(last) else None
+
+
+def _address_tail(address):
+    """Last 3 bytes of a MAC as 6 hex chars, e.g. 'aa:bb:cc:4e:88:d8' -> '4e88d8'."""
+    hexonly = re.sub(r"[^0-9a-f]", "", str(address or "").lower())
+    return hexonly[-6:] if len(hexonly) >= 6 else None
+
+
+def _token_matches_address(token, address):
+    """Whether a slug's hardware token plausibly names this Bluetooth MAC.
+
+    ESPHome derives device-name suffixes from the base/WiFi MAC while the
+    scanner advertises from its Bluetooth MAC; ESP-IDF derives both from the
+    base MAC as +0..+3 in the last octet, wrapping uint8 (0xfe -> 0x00, no
+    carry). That offset is strictly one-way — a derived MAC is never BELOW
+    the base the token came from — so use a directional modular window.
+    Espressif allocates base MACs in blocks of 4, so a symmetric window would
+    admit the previous same-batch chip (its BT MAC sits 2 BELOW a neighbor's
+    base): different hardware, and the reason this must stay directional.
+    """
+    tail = _address_tail(address)
+    if not token or not tail:
+        return False
+    tok = str(token).lower()[-6:]
+    if len(tok) != 6:
+        return False
+    try:
+        return tok[:4] == tail[:4] and (int(tail[4:6], 16) - int(tok[4:6], 16)) % 256 <= 3
+    except ValueError:
+        return False
 
 
 def _bpsdata_path(hass) -> Path:
@@ -199,13 +243,105 @@ def _build_receiver_map(coords, floor_name=None) -> dict:
         for receiver in floor.get("receivers", []):
             cords = receiver.get("cords") or {}
             if receiver.get("entity_id") and cords.get("x") is not None and cords.get("y") is not None:
+                uid = receiver.get("scanner_uid")
                 receivers[str(receiver["entity_id"])] = {
                     "x": float(cords["x"]),
                     "y": float(cords["y"]),
                     "scale": float(scale),
                     "floor": floor.get("name"),
+                    # Hardware identity stored by a panel re-link (issue #64);
+                    # lets calibration match the scanner after a rename.
+                    "uid": uid if isinstance(uid, str) and uid else None,
                 }
     return receivers
+
+
+def _match_scanners(cal: dict, devices: dict) -> dict:
+    """Map scanner MAC -> placed receiver slug (issue #63).
+
+    Tier 1: slugify(current device name) == placed slug — names still in sync.
+    Tier 2: hardware identity for placements no name matched: the stored
+    scanner_uid (panel re-link, issue #64) or the MAC-derived hex tail in the
+    placed slug, matched against a remaining device's name tail or Bluetooth
+    MAC. Entity ids freeze at creation while device names follow renames, so
+    tier 1 alone silently dropped renamed/moved probes from calibration —
+    always the same ones, with tracking still fine. Only a UNIQUE candidate
+    wins, so a rename can never quietly pair two different scanners.
+
+    Placed slugs that matched anything are timestamped in cal["matched_placed"]
+    so the report can tell "no matching scanner" apart from "matched but no
+    adverts sampled".
+    """
+    scanners = []
+    for dev in devices.values():
+        if not isinstance(dev, dict) or dev.get("_is_scanner") is not True:
+            continue
+        address = str(dev.get("address") or "").lower()
+        scanners.append((address, slugify(str(dev.get("name") or ""))))
+
+    scanner_slug_by_mac = {}
+    for address, name_slug in scanners:
+        if name_slug in cal["receivers"]:
+            scanner_slug_by_mac[address] = name_slug
+
+    matched_slugs = set(scanner_slug_by_mac.values())
+    # Tier-2 candidates: devices tier 1 didn't claim, excluding any whose
+    # current name belongs to a placement on ANY floor — a manual run maps
+    # only its own floor, so without the all-floors guard a name-synced
+    # scanner placed elsewhere would look free here and could be captured
+    # while a placement's true scanner happens to be offline.
+    all_placed = cal.get("all_placed_slugs") or set(cal["receivers"])
+    free_devs = [
+        (a, n) for a, n in scanners
+        if a not in scanner_slug_by_mac and n not in all_placed
+    ]
+    # Iterate to a fixpoint: consuming a device can turn a previously
+    # ambiguous placement unique, and bpsdata receiver order must not decide
+    # who gets matched.
+    pending = [s for s in cal["receivers"] if s not in matched_slugs]
+    progress = True
+    while progress and pending:
+        progress = False
+        for slug in list(pending):
+            token = cal["receivers"][slug].get("uid") or _scanner_token(slug)
+            if not token:
+                pending.remove(slug)
+                continue
+            candidates = {
+                a for a, n in free_devs
+                if _scanner_token(n) == token or _token_matches_address(token, a)
+            }
+            if len(candidates) == 1:
+                address = candidates.pop()
+                scanner_slug_by_mac[address] = slug
+                matched_slugs.add(slug)
+                free_devs = [(a, n) for a, n in free_devs if a != address]
+                pending.remove(slug)
+                progress = True
+
+    # slug -> when it last matched. Timestamps (not a grow-only set) so an
+    # unbounded auto window doesn't keep reporting "matched" for a placement
+    # whose match broke long ago.
+    matched = cal.get("matched_placed")
+    if not isinstance(matched, dict):
+        matched = {}
+        cal["matched_placed"] = matched
+    now = time.time()
+    for slug in matched_slugs:
+        matched[slug] = now
+    return scanner_slug_by_mac
+
+
+def _all_placed_slugs(coords) -> set:
+    """Every placed receiver slug across ALL floors — tier-2 matching must not
+    treat another floor's (or any placed) scanner as a free candidate."""
+    slugs = set()
+    for floor in coords.get("floor", []):
+        for receiver in floor.get("receivers", []):
+            eid = receiver.get("entity_id")
+            if isinstance(eid, str) and eid:
+                slugs.add(eid)
+    return slugs
 
 
 def _ingest_dump(cal: dict, devices: dict) -> None:
@@ -214,13 +350,7 @@ def _ingest_dump(cal: dict, devices: dict) -> None:
         return
 
     # Scanner MAC -> receiver slug, restricted to receivers on this floor.
-    scanner_slug_by_mac = {}
-    for dev in devices.values():
-        if not isinstance(dev, dict) or dev.get("_is_scanner") is not True:
-            continue
-        slug = slugify(str(dev.get("name") or ""))
-        if slug in cal["receivers"]:
-            scanner_slug_by_mac[str(dev.get("address") or "").lower()] = slug
+    scanner_slug_by_mac = _match_scanners(cal, devices)
 
     # Monotonic "now": the freshest advert stamp in the payload.
     newest = 0.0
@@ -290,10 +420,40 @@ def solve(cal: dict, floor_name: str):
             continue
         pairs.append((tx_slug, rx_slug, true_m, measured, len(values)))
 
+    # Placed receivers absent from the matrix, split by cause so the report
+    # can say WHY (issue #63): never matched to any Bermuda scanner (identity
+    # drift — a rename left the device name out of sync with the frozen
+    # entity-id slug) vs matched but no usable adverts (not beaconing, or too
+    # few/too-close samples). Computed BEFORE the too-few-pairs gate so the
+    # strongest mismatch case (so few matches the solve can't even run) still
+    # names its culprits. "Matched" counts only recent matches, so a match
+    # that broke mid-window ages out instead of masking the drift.
+    participating = {p[0] for p in pairs} | {p[1] for p in pairs}
+    matched = cal.get("matched_placed")
+    if not isinstance(matched, dict):
+        matched = {}
+    cutoff = time.time() - STATE_MAX_AGE
+    matched_fresh = {
+        s for s, ts in matched.items() if isinstance(ts, (int, float)) and ts >= cutoff
+    }
+    placed_on_floor = sorted(
+        s for s, r in cal["receivers"].items()
+        if _normalize(r["floor"]) == _normalize(floor_name)
+    )
+    missing_unmatched = [s for s in placed_on_floor if s not in participating and s not in matched_fresh]
+    missing_no_data = [s for s in placed_on_floor if s not in participating and s in matched_fresh]
+
     if len(pairs) < MIN_PAIRS:
+        hint = ""
+        if missing_unmatched:
+            hint = (
+                " Placed receivers with no matching Bermuda scanner (renamed device?): "
+                + ", ".join(missing_unmatched) + "."
+            )
         raise ValueError(
             f"Only {len(pairs)} usable receiver pairs (need at least {MIN_PAIRS}). "
             "Sample longer, or check that the probes are advertising their iBeacon."
+            + hint
         )
 
     participants = sorted({p[0] for p in pairs} | {p[1] for p in pairs})
@@ -415,6 +575,8 @@ def solve(cal: dict, floor_name: str):
         "error_factor_before": round(10 ** before, 3),
         "error_factor_after": round(10 ** after, 3),
         "matrix": matrix,
+        "missing_unmatched": missing_unmatched,
+        "missing_no_data": missing_no_data,
     }
 
 
@@ -501,16 +663,35 @@ async def _auto_loop(hass, cal: dict) -> None:
 
 async def _auto_solve_and_apply(hass, cal: dict) -> None:
     """Re-solve every floor and persist corrections that changed enough."""
+    # Refresh the receiver map and re-match BEFORE taking the file lock: every
+    # ingest so far this cycle ran against the OLD map, so a receiver placed
+    # or re-linked since would be misreported as "no matching scanner" (a
+    # rename hint) for a whole solve interval despite matching perfectly. And
+    # dump_devices is an external RPC with no timeout — awaiting it under
+    # BPS_FILE_LOCK would let a wedged Bermuda hang every bpsdata writer
+    # (panel saves included), where pre-lock it only delays this solve.
+    coords = await _read_coords(hass)
+    if not coords:
+        return
+    cal["receivers"] = _build_receiver_map(coords)
+    cal["all_placed_slugs"] = _all_placed_slugs(coords)
+    try:
+        _ingest_dump(cal, await _dump_devices(hass))
+    except Exception as e:
+        _LOGGER.debug("Pre-solve dump failed; missing-receiver buckets may lag one cycle: %s", e)
     async with BPS_FILE_LOCK:
         await _auto_solve_and_apply_locked(hass, cal)
 
 
 async def _auto_solve_and_apply_locked(hass, cal: dict) -> None:
+    # Re-read inside the lock so a concurrent writer is not clobbered; the
+    # wrapper's pre-lock read was only to refresh the matching state.
     coords = await _read_coords(hass)
     if not coords:
         return
     # Floors and receivers may have been edited since the last cycle.
     cal["receivers"] = _build_receiver_map(coords)
+    cal["all_placed_slugs"] = _all_placed_slugs(coords)
 
     changed = False
     for floor in coords.get("floor", []):
@@ -589,6 +770,8 @@ async def start_calibration(hass, floor_name: str, duration: int) -> dict:
             "duration": duration,
             "samples": {},
             "receivers": receivers,
+            "matched_placed": {},  # fresh window: re-learn which placements match
+            "all_placed_slugs": _all_placed_slugs(coords),
             "error": None,
         }
     )
@@ -636,6 +819,8 @@ async def set_auto_calibration(hass, enabled: bool) -> None:
                 "ends_at": None,
                 "duration": None,
                 "receivers": _build_receiver_map(coords),
+                "matched_placed": {},  # fresh window: re-learn which placements match
+                "all_placed_slugs": _all_placed_slugs(coords),
                 "error": None,
             }
         )

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -612,6 +612,15 @@ async def _sample_loop(hass, cal: dict) -> None:
                     return
             await asyncio.sleep(SAMPLE_INTERVAL)
 
+        # One final dump before solving so placements edited late in the
+        # window (re-link + save inside the last sample gap) are matched and
+        # classified against reality — mirrors the auto loop's pre-solve
+        # ingest. A failed dump just falls back to what the window gathered.
+        try:
+            _ingest_dump(cal, await _dump_devices(hass))
+        except Exception as e:
+            _LOGGER.debug("Final calibration dump failed: %s", e)
+
         result = solve(cal, cal["floor"])
         cal["results"][result["floor"]] = result
         cal["last_solved_at"] = result["solved_at"]
@@ -828,6 +837,37 @@ async def set_auto_calibration(hass, enabled: bool) -> None:
     else:
         cal["state"] = "idle"
         cal["mode"] = "off"
+
+
+def refresh_receivers_from_coords(hass, coordinates_json) -> None:
+    """Keep an ACTIVE calibration window tracking placements edited mid-run.
+
+    Called by the panel-save endpoint right after bpsdata.txt is written: a
+    re-linked, added, or removed receiver takes effect on the next dump
+    instead of waiting for the next manual window or auto solve cycle (up to
+    15 minutes of ingesting — and reporting missing — against stale slugs).
+    """
+    cal = hass.data.get(DOMAIN, {}).get("calibration")
+    if not cal or cal.get("state") != "sampling":
+        return
+    try:
+        coords = json.loads(coordinates_json) if coordinates_json else None
+        if not isinstance(coords, dict):
+            return
+        floor = cal.get("floor") if cal.get("mode") == "manual" else None
+        new_map = _build_receiver_map(coords, floor_name=floor)
+        if floor is not None and not new_map:
+            # The floor this manual window is calibrating vanished from the
+            # save (deleted or de-scaled mid-run). Keep the start-of-run
+            # snapshot rather than blinding the window — an empty map would
+            # end the run with a misleading "0 usable pairs / check iBeacon"
+            # error instead of a coherent (if now moot) report.
+            return
+        cal["receivers"] = new_map
+        cal["all_placed_slugs"] = _all_placed_slugs(coords)
+    except Exception as e:
+        # A save must never fail because of calibration bookkeeping.
+        _LOGGER.debug("Could not refresh calibration receivers from save: %s", e)
 
 
 async def async_start_auto_if_enabled(hass) -> None:

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3061,6 +3061,7 @@ select.bps-input { cursor: pointer; }
 }
 .bps-calib-missing-title { font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: hsl(38 92% 45%); margin-bottom: 6px; }
 .bps-calib-missing p { margin: 4px 0; }
+.bps-calib-missing-note { color: hsl(var(--muted-foreground)); font-style: italic; }
 /* Diagonal (45°) column headers so long scanner names aren't cut off. */
 .bps-calib-matrix th.bps-calib-colhead {
     height: 130px;

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3049,6 +3049,18 @@ select.bps-input { cursor: pointer; }
 }
 .bps-calib-status { font-size: 13px; color: hsl(var(--muted-foreground)); margin: 6px 0 12px; }
 .bps-calib-matrix { overflow-x: auto; }
+/* Placed receivers absent from the calibration report, with why (issue #63). */
+.bps-calib-missing {
+    margin-top: 10px;
+    padding: 8px 10px;
+    border: 1px solid hsl(38 92% 50% / 0.5);
+    border-radius: 8px;
+    background: hsl(38 92% 50% / 0.08);
+    font-size: 12px;
+    line-height: 1.5;
+}
+.bps-calib-missing-title { font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: hsl(38 92% 45%); margin-bottom: 6px; }
+.bps-calib-missing p { margin: 4px 0; }
 /* Diagonal (45°) column headers so long scanner names aren't cut off. */
 .bps-calib-matrix th.bps-calib-colhead {
     height: 130px;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2883,6 +2883,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             saveButton.remove();
             bpsToast('Saved successfully!');
             getSavedMaps();
+            // Placements changed: re-render the calibration report so its
+            // missing-receiver block reconciles against the new data now
+            // (the idle-state poll never fires on its own), and refresh the
+            // linking snapshot the sidebar/Debugging tab read.
+            pollCalibration();
+            if (!scannerLinkingLoading) loadScannerLinking();
         }
     });
 
@@ -3191,8 +3197,34 @@ document.addEventListener('DOMContentLoaded', async () => {
         return data;
     }
 
+    // The missing lists are baked into the solve-result snapshot, but
+    // placements can change afterwards (re-link, add, remove + save).
+    // Reconcile against the CURRENT floor data so a replaced receiver drops
+    // out immediately instead of being reported missing until the next solve,
+    // and anything placed since the solve is listed as pending, not missing.
+    function calibMissingNow(result) {
+        const floorNow = (finalcords.floor || []).find(f => sameFloorName(f.name, result.floor));
+        const placedNow = floorNow
+            ? new Set((floorNow.receivers || []).map(r => r && r.entity_id).filter(Boolean))
+            : null;
+        const still = list => placedNow ? list.filter(s => placedNow.has(s)) : list.slice();
+        const missUnmatched = still(result.missing_unmatched || []);
+        const missNoData = still(result.missing_no_data || []);
+        let placedSince = [];
+        if (placedNow) {
+            const inReport = new Set([
+                ...Object.keys(result.receivers || {}),
+                ...(result.missing_unmatched || []),
+                ...(result.missing_no_data || []),
+            ]);
+            placedSince = [...placedNow].filter(s => !inReport.has(s)).sort();
+        }
+        return { missUnmatched, missNoData, placedSince };
+    }
+
     function renderCalibrationResult(result) {
-        const missingCount = (result.missing_unmatched || []).length + (result.missing_no_data || []).length;
+        const miss = calibMissingNow(result);
+        const missingCount = miss.missUnmatched.length + miss.missNoData.length;
         calibStatus.textContent =
             `Floor ${result.floor}: ${result.pairs_used} pairs (${result.bidirectional_pairs} bidirectional), ` +
             `typical error ×${result.error_factor_before} → ×${result.error_factor_after} predicted after correction.` +
@@ -3232,21 +3264,32 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         // Placed receivers absent from the matrix, with WHY (issue #63): the
         // report is built only from scanners that produced matched samples, so
-        // without this a drifted or silent scanner just vanished.
-        const missUnmatched = result.missing_unmatched || [];
-        const missNoData = result.missing_no_data || [];
-        if (missUnmatched.length || missNoData.length) {
+        // without this a drifted or silent scanner just vanished. Lists come
+        // from calibMissingNow, reconciled against the current placements —
+        // which include UNSAVED edits, so say so (and if unsaved edits emptied
+        // the list, keep the block with just the note rather than silently
+        // hiding a receiver the backend still reports missing).
+        const unsavedEdits = savebuttondiv.contains(saveButton);
+        const rawMissing = (result.missing_unmatched || []).length + (result.missing_no_data || []).length;
+        if (miss.missUnmatched.length || miss.missNoData.length || miss.placedSince.length || (unsavedEdits && rawMissing)) {
             html += '<div class="bps-calib-missing">'
                 + '<div class="bps-calib-missing-title">Placed on this floor but missing from this report</div>';
-            if (missUnmatched.length) {
-                html += `<p><strong>No matching Bermuda scanner:</strong> ${escHtml(missUnmatched.join(', '))} — `
+            if (miss.missUnmatched.length) {
+                html += `<p><strong>No matching Bermuda scanner:</strong> ${escHtml(miss.missUnmatched.join(', '))} — `
                     + 'the device name no longer matches the placed id (usually a rename after moving the probe). '
                     + 'Check the <strong>Debugging</strong> tab, or rename the device/entity so they match.</p>';
             }
-            if (missNoData.length) {
-                html += `<p><strong>Matched, but no beacon samples:</strong> ${escHtml(missNoData.join(', '))} — `
+            if (miss.missNoData.length) {
+                html += `<p><strong>Matched, but no beacon samples:</strong> ${escHtml(miss.missNoData.join(', '))} — `
                     + 'the scanner was found but produced no usable probe-to-probe adverts. '
                     + 'Check the probe is advertising its iBeacon (or sample longer).</p>';
+            }
+            if (miss.placedSince.length) {
+                html += `<p><strong>Placed since this report:</strong> ${escHtml(miss.placedSince.join(', '))} — `
+                    + 'will be included on the next calibration run (auto mode re-solves every 15 minutes).</p>';
+            }
+            if (unsavedEdits) {
+                html += '<p class="bps-calib-missing-note">Reflects unsaved edits — Save Floor Plan to apply them.</p>';
             }
             html += '</div>';
         }
@@ -3279,8 +3322,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 line += ` · floor ${result.floor}: ${result.pairs_used} pairs used, `
                     + `typical error ×${result.error_factor_before} → ×${result.error_factor_after}`;
                 // Keep the missing-receiver pointer (issue #63) — this line
-                // replaces the one renderCalibrationResult just wrote.
-                const missing = (result.missing_unmatched || []).length + (result.missing_no_data || []).length;
+                // replaces the one renderCalibrationResult just wrote. Same
+                // reconciled lists so a replaced receiver isn't counted.
+                const m = calibMissingNow(result);
+                const missing = m.missUnmatched.length + m.missNoData.length;
                 if (missing) line += ` · ${missing} placed receiver${missing > 1 ? "s" : ""} missing — see below`;
             }
             calibStatus.textContent = line;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -3192,9 +3192,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function renderCalibrationResult(result) {
+        const missingCount = (result.missing_unmatched || []).length + (result.missing_no_data || []).length;
         calibStatus.textContent =
             `Floor ${result.floor}: ${result.pairs_used} pairs (${result.bidirectional_pairs} bidirectional), ` +
-            `typical error ×${result.error_factor_before} → ×${result.error_factor_after} predicted after correction.`;
+            `typical error ×${result.error_factor_before} → ×${result.error_factor_after} predicted after correction.` +
+            (missingCount ? ` ${missingCount} placed receiver${missingCount > 1 ? "s" : ""} missing — see below.` : "");
 
         const slugs = Object.keys(result.receivers).sort();
         const cells = {};
@@ -3228,6 +3230,26 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (lowConfidence.length) {
             html += `<p class="text-sm text-gray-500" style="margin-top:6px">⚠ Low confidence (aggressive correction or few pairs): ${escHtml(lowConfidence.join(', '))} — verify those receivers before applying.</p>`;
         }
+        // Placed receivers absent from the matrix, with WHY (issue #63): the
+        // report is built only from scanners that produced matched samples, so
+        // without this a drifted or silent scanner just vanished.
+        const missUnmatched = result.missing_unmatched || [];
+        const missNoData = result.missing_no_data || [];
+        if (missUnmatched.length || missNoData.length) {
+            html += '<div class="bps-calib-missing">'
+                + '<div class="bps-calib-missing-title">Placed on this floor but missing from this report</div>';
+            if (missUnmatched.length) {
+                html += `<p><strong>No matching Bermuda scanner:</strong> ${escHtml(missUnmatched.join(', '))} — `
+                    + 'the device name no longer matches the placed id (usually a rename after moving the probe). '
+                    + 'Check the <strong>Debugging</strong> tab, or rename the device/entity so they match.</p>';
+            }
+            if (missNoData.length) {
+                html += `<p><strong>Matched, but no beacon samples:</strong> ${escHtml(missNoData.join(', '))} — `
+                    + 'the scanner was found but produced no usable probe-to-probe adverts. '
+                    + 'Check the probe is advertising its iBeacon (or sample longer).</p>';
+            }
+            html += '</div>';
+        }
         calibResults.innerHTML = html;
     }
 
@@ -3256,6 +3278,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (result) {
                 line += ` · floor ${result.floor}: ${result.pairs_used} pairs used, `
                     + `typical error ×${result.error_factor_before} → ×${result.error_factor_after}`;
+                // Keep the missing-receiver pointer (issue #63) — this line
+                // replaces the one renderCalibrationResult just wrote.
+                const missing = (result.missing_unmatched || []).length + (result.missing_no_data || []).length;
+                if (missing) line += ` · ${missing} placed receiver${missing > 1 ? "s" : ""} missing — see below`;
             }
             calibStatus.textContent = line;
             return;


### PR DESCRIPTION
Fixes #63.

## Root cause

The calibration matrix only shows scanners that produced matched probe-to-probe samples — and the beacon→receiver matching required `slugify(current device name) == placed slug` exactly. Entity ids **freeze at creation** while device names **follow renames**, so a renamed/moved probe never matched (both the tx and rx side of every sample resolve through that map) and silently vanished from the report. Deterministic → always the same scanners. Tracking kept working because the map matches on the entity id itself — which is why only calibration looked broken.

David's screenshots show it exactly: 18 receivers placed on the Second Floor, 240 pairs = 16 participants, and the two missing (`butler_pantry_rrn00_4e88d8`, `morning_room_rrn00_4e88e8`) are the only ones named after *ground-floor* rooms but placed upstairs — moved probes whose device names were updated while the frozen entity ids kept the old names. (The ground floor's "six missing, all no zone" is a red herring — zones play no part in calibration; that'll be the same identity drift and/or non-beaconing hardware, which the new report now distinguishes.)

Direct answer to the issue's question: the report showed only scanners with ≥5 matched samples in the window — neither "all known" nor purely "had traffic", because a name mismatch filtered a scanner out *before* any traffic counted. Both gaps are addressed below.

## Fix 1 — match by hardware identity, not just name (issue #64's machinery)

- **Tier 1 (unchanged):** exact name-slug match.
- **Tier 2** for still-unmatched placements: the stored `scanner_uid` (from the panel's Re-link) or the MAC-derived hex tail in the placed slug, matched against a remaining scanner's name tail **or its Bluetooth MAC**. The MAC window is **directional modular** (+0..+3 with uint8 wrap): ESP-IDF derives the BT/WiFi MACs *above* the base MAC, and Espressif allocates bases in blocks of 4 — a symmetric window would capture the previous same-batch chip (wrong hardware).
- **Safety:** only a *unique* candidate wins; a device whose name belongs to a placement on **any** floor is never a tier-2 candidate (manual runs are floor-scoped — a name-synced scanner from another floor must not be captured while a placement's true scanner happens to be offline); tier 2 iterates to a fixpoint so receiver order in `bpsdata.txt` can't decide who matches.

## Fix 2 — the report says who's missing and why

`solve()` results now carry two buckets, rendered as an amber block under the matrix plus a status-line count (manual **and** auto mode):

- **No matching Bermuda scanner** — identity drift (rename); points at the Debugging tab / renaming so they match.
- **Matched, but no beacon samples** — the scanner exists but produced no usable adverts (not beaconing, or sample longer).

Computed *before* the too-few-pairs gate, so even the strongest mismatch case ("only 2 pairs, need 4") now names its culprits in the error message. "Matched" is timestamped and ages out (6 h), so an unbounded auto window doesn't keep claiming a match that broke mid-run.

## Verification

- 30-assertion standalone test importing the **real module** (stubbed HA deps, real scipy): all match tiers incl. David's exact renamed-probe cases, directional-window bounds (+2 accepted, sibling-below rejected, 0xFE→0x00 wraparound), ambiguity + fixpoint order-independence, other-floor exclusion, stale-timestamp bucketing, enriched error text, JSON-serializability.
- Browser harness: amber block + status-line count render correctly; matrix unaffected.
- **Two adversarial review rounds**: round 1 (4 lenses + per-finding verify) confirmed 9 defects in my first cut — including the symmetric MAC window capturing same-batch sibling chips, greedy-order stranding, and misclassification windows in auto mode — all 9 fixed; round 2 re-verified each fix resolved with no new issues, and a fresh-eyes pass caught one last robustness item (the pre-solve `dump_devices` call ran under `BPS_FILE_LOCK` — a wedged Bermuda would have hung every bpsdata writer; moved outside the lock).

Backend change → **HA restart** to deploy. Not exercised against David's live setup; on his Second Floor the two renamed probes should now either rejoin the matrix via tier 2 or be named explicitly in the missing block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
