### PR TITLE
Move Adjust Zones/Sub-zones actions onto the map (buttons at corner, knobs centered above)

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -117,29 +117,51 @@ canvas {
     transition: opacity 0.35s ease;
 }
 .bps-toast-out { opacity: 0; }
-/* Floating control for the "Adjust zones" preview (non-blocking, over the map). */
+/* "Adjust zones/sub-zones" controls, pinned to the map's top-left — the same
+   corner the layout tools use for ✓ Save / ✕ Cancel (the two can't coexist:
+   starting either cancels an open adjust preview via buttonreset). The Apply /
+   Cancel buttons match #mapToolActions; the Snap/Square knobs are adjust-only. */
 .bps-adjust-bar {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1900;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 20;
     display: flex;
     align-items: center;
-    gap: 14px;
-    flex-wrap: wrap;
-    max-width: calc(100% - 32px);
-    background: hsl(var(--card));
+    gap: 10px;
+    /* Stay a SINGLE row: the wrap is overflow:hidden with no min-height, so a
+       multi-row bar could grow past a short/landscape map's bottom (clipping
+       the Snap/Square controls) or cover the bottom-left #viewReset. A narrow
+       map scrolls the row horizontally instead — all controls stay reachable
+       and the bar height is fixed. */
+    flex-wrap: nowrap;
+    max-width: calc(100% - 20px);
+    overflow-x: auto;
+    background: hsl(var(--card) / 0.95);
     color: hsl(var(--foreground));
     border: 1px solid hsl(var(--border));
-    border-radius: 10px;
-    padding: 10px 14px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-    font-size: 13px;
+    border-radius: 8px;
+    padding: 6px 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    font-size: 12.5px;
 }
-.bps-adjust-summary { font-weight: 500; }
-.bps-adjust-ctl { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; white-space: nowrap; }
-.bps-adjust-bar .bps-btn { height: 32px; padding: 4px 12px; }
+/* The summary is the only shrinkable item (ellipsis); buttons and knobs keep
+   their size so they never scroll off before the summary does. */
+.bps-adjust-summary { font-weight: 500; color: hsl(var(--muted-foreground)); flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bps-adjust-ctl { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; white-space: nowrap; flex: 0 0 auto; }
+.bps-adjust-bar button {
+    flex: 0 0 auto;
+    padding: 6px 12px;
+    font-size: 12.5px;
+    font-weight: 600;
+    border-radius: 8px;
+    background: hsl(var(--background) / 0.92);
+    cursor: pointer;
+}
+#bpsAdjustApply { border: 1px solid hsl(142 71% 40%); color: hsl(142 71% 32%); }
+#bpsAdjustApply:hover { background: hsl(142 71% 40%); color: #fff; }
+#bpsAdjustCancel { border: 1px solid hsl(0 84% 60%); color: hsl(0 84% 55%); }
+#bpsAdjustCancel:hover { background: hsl(0 84% 60%); color: #fff; }
 .rec-input {
     padding: 2px;
     border-color: #000000;

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -117,40 +117,19 @@ canvas {
     transition: opacity 0.35s ease;
 }
 .bps-toast-out { opacity: 0; }
-/* "Adjust zones/sub-zones" controls, pinned to the map's top-left — the same
-   corner the layout tools use for ✓ Save / ✕ Cancel (the two can't coexist:
-   starting either cancels an open adjust preview via buttonreset). The Apply /
-   Cancel buttons match #mapToolActions; the Snap/Square knobs are adjust-only. */
-.bps-adjust-bar {
+/* Adjust preview: ✓ Apply / ✕ Cancel pinned to the map's top-left corner,
+   exactly where the layout tools show ✓ Save / ✕ Cancel (the two can't coexist:
+   starting either cancels an open adjust preview via buttonreset). The tuning
+   knobs live in .bps-adjust-controls, a separate strip above the map. */
+.bps-adjust-actions {
     position: absolute;
     top: 10px;
     left: 10px;
     z-index: 20;
     display: flex;
-    align-items: center;
-    gap: 10px;
-    /* Stay a SINGLE row: the wrap is overflow:hidden with no min-height, so a
-       multi-row bar could grow past a short/landscape map's bottom (clipping
-       the Snap/Square controls) or cover the bottom-left #viewReset. A narrow
-       map scrolls the row horizontally instead — all controls stay reachable
-       and the bar height is fixed. */
-    flex-wrap: nowrap;
-    max-width: calc(100% - 20px);
-    overflow-x: auto;
-    background: hsl(var(--card) / 0.95);
-    color: hsl(var(--foreground));
-    border: 1px solid hsl(var(--border));
-    border-radius: 8px;
-    padding: 6px 10px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-    font-size: 12.5px;
+    gap: 8px;
 }
-/* The summary is the only shrinkable item (ellipsis); buttons and knobs keep
-   their size so they never scroll off before the summary does. */
-.bps-adjust-summary { font-weight: 500; color: hsl(var(--muted-foreground)); flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bps-adjust-ctl { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; white-space: nowrap; flex: 0 0 auto; }
-.bps-adjust-bar button {
-    flex: 0 0 auto;
+.bps-adjust-actions button {
     padding: 6px 12px;
     font-size: 12.5px;
     font-weight: 600;
@@ -162,6 +141,29 @@ canvas {
 #bpsAdjustApply:hover { background: hsl(142 71% 40%); color: #fff; }
 #bpsAdjustCancel { border: 1px solid hsl(0 84% 60%); color: hsl(0 84% 55%); }
 #bpsAdjustCancel:hover { background: hsl(0 84% 60%); color: #fff; }
+
+/* Adjust tuning knobs: a centered pill ABOVE the map (between the setup cards
+   and the canvas), out of the way of the zones being adjusted. margin:auto
+   centers it; the whole thing hides when no preview is open. */
+.bps-adjust-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    width: fit-content;
+    max-width: 100%;
+    margin: 10px auto 0;
+    padding: 8px 14px;
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+    font-size: 13px;
+}
+.bps-adjust-summary { font-weight: 500; color: hsl(var(--muted-foreground)); }
+.bps-adjust-ctl { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; white-space: nowrap; }
 .rec-input {
     padding: 2px;
     border-color: #000000;
@@ -2643,17 +2645,24 @@ body {
         /* Map takes ~80% of the width; the setup column on the left and the
            zones column on the right are equal (~10% each). */
         grid-template-columns: minmax(240px, 1fr) minmax(0, 8fr) minmax(240px, 1fr);
-        grid-template-rows: auto 1fr;
+        /* Map column stacks: zone bar (row 1), adjust knobs (row 2), map (row 3).
+           Both bar rows are `auto`, so they collapse to 0 when their element is
+           display:none — the map fills the height when neither is shown. */
+        grid-template-rows: auto auto 1fr;
         align-items: start;
     }
     /* Let the stacked cards' controls spread across the wider column. */
     .bps-setup-row > .bps-setup-col { flex: 0 0 auto; width: 100%; }
     .bps-content { display: contents; }
-    .bps-setup-row { grid-column: 1; grid-row: 1 / 3; flex-direction: column; }
+    .bps-setup-row { grid-column: 1; grid-row: 1 / 4; flex-direction: column; }
     .bps-setup-row > .bps-setup-col { flex: 0 0 auto; }
     #zonediv { grid-column: 2; grid-row: 1; }
-    .bps-canvas-wrap { grid-column: 2; grid-row: 2; }
-    .bps-sidebar { grid-column: 3; grid-row: 1 / 3; }
+    /* Own row (not shared with #zonediv) — tracking and an adjust preview can be
+       open at once, so sharing a cell would overlap them. Explicit placement is
+       required: display:contents would otherwise auto-drop it into the grid. */
+    #bpsAdjustControls { grid-column: 2; grid-row: 2; }
+    .bps-canvas-wrap { grid-column: 2; grid-row: 3; }
+    .bps-sidebar { grid-column: 3; grid-row: 1 / 4; }
 }
 
 /* Setup: three side-by-side column cards (Floor / Tools / Tracking) */

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -113,6 +113,12 @@
                         <button type="button" id="switchFloorBtn" class="bps-btn bps-btn-outline bps-switch-floor" style="display: none"></button>
                     </div>
 
+                    <!-- Adjust-preview tuning knobs (summary + Snap + Square), a
+                         centered strip ABOVE the map so they don't cover the zones
+                         being adjusted; its ✓ Apply / ✕ Cancel live at the map's
+                         top-left corner with the other tools. Filled/shown by JS. -->
+                    <div id="bpsAdjustControls" class="bps-adjust-controls" style="display: none"></div>
+
                     <div class="bps-canvas-wrap">
                         <canvas id="canvas"></canvas>
                         <button type="button" id="viewReset" title="Reset zoom and position">⤢ Reset view</button>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2998,17 +2998,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         const bar = document.createElement('div');
         bar.id = 'bpsAdjustBar';
         bar.className = 'bps-adjust-bar';
+        // Buttons lead, so the map's top-left corner shows ✓ Apply / ✕ Cancel
+        // exactly where the layout tools show ✓ Save / ✕ Cancel; the Snap and
+        // Square knobs (adjust-only) trail.
         bar.innerHTML = `
+            <button type="button" id="bpsAdjustApply">✓ Apply</button>
+            <button type="button" id="bpsAdjustCancel">✕ Cancel</button>
             <span id="bpsAdjustSummary" class="bps-adjust-summary">Computing…</span>
             <label class="bps-adjust-ctl">Snap
                 <input type="range" id="bpsAdjustTol" min="6" max="60" step="2" value="${defaultPx}">
                 <span id="bpsAdjustTolVal">${cmFor(defaultPx)}</span>
             </label>
             <label class="bps-adjust-ctl"><input type="checkbox" id="bpsAdjustSquare" checked> Square rooms</label>
-            <button type="button" id="bpsAdjustCancel" class="bps-btn bps-btn-outline">Cancel</button>
-            <button type="button" id="bpsAdjustApply" class="bps-btn bps-btn-primary">Apply</button>
         `;
-        document.body.appendChild(bar);
+        // Inside the map wrap so it pins to the map's top-left (like #mapToolActions),
+        // not the viewport.
+        (document.querySelector('.bps-canvas-wrap') || document.body).appendChild(bar);
         const tol = bar.querySelector('#bpsAdjustTol');
         const tolVal = bar.querySelector('#bpsAdjustTolVal');
         let debounce = null;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2933,17 +2933,21 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     async function runAdjustPreview() {
         const floor = currentFloor();
-        const bar = document.getElementById('bpsAdjustBar');
-        if (!floor || !bar) return;
+        // #bpsAdjustActions is the "adjust UI open" sentinel; the knobs live in
+        // the separate centered strip above the map.
+        const open = document.getElementById('bpsAdjustActions');
+        const tolEl = document.getElementById('bpsAdjustTol');
+        const squareEl = document.getElementById('bpsAdjustSquare');
+        const summary = document.getElementById('bpsAdjustSummary');
+        if (!floor || !open || !tolEl || !squareEl || !summary) return;
         // Capture the run + floor + target so a slow response that arrives after
         // the user cancelled, switched floors/target, or moved the slider again
         // is dropped (no stale/wrong ghost; last change wins).
         const myFloor = SelMapName;
         const myTarget = adjustTarget;
         const myRun = ++adjustRunSeq;
-        const tolPx = Number(bar.querySelector('#bpsAdjustTol').value);
-        const square = bar.querySelector('#bpsAdjustSquare').checked;
-        const summary = bar.querySelector('#bpsAdjustSummary');
+        const tolPx = Number(tolEl.value);
+        const square = squareEl.checked;
         summary.textContent = 'Computing…';
         try {
             const res = await fetch('/api/bps/adjust_zones', {
@@ -2957,7 +2961,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }),
             });
             const data = res.ok ? await res.json() : null;
-            if (myRun !== adjustRunSeq || !document.getElementById('bpsAdjustBar')
+            if (myRun !== adjustRunSeq || !document.getElementById('bpsAdjustActions')
                 || !sameFloorName(SelMapName, myFloor)) {
                 return; // superseded / cancelled / floor changed
             }
@@ -2972,7 +2976,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             summary.textContent = adjustSummaryText(adjustPreview);
             if (mapReady()) redrawAll();
         } catch (e) {
-            if (myRun === adjustRunSeq && document.getElementById('bpsAdjustBar')) {
+            if (myRun === adjustRunSeq && document.getElementById('bpsAdjustActions')) {
                 summary.textContent = 'Adjust failed.';
             }
         }
@@ -2995,45 +2999,55 @@ document.addEventListener('DOMContentLoaded', async () => {
         hideAdjustBar();
         const scale = (currentFloor() || {}).scale;
         const cmFor = px => scale ? `${(px / scale * 100).toFixed(0)}cm` : `${px}px`;
-        const bar = document.createElement('div');
-        bar.id = 'bpsAdjustBar';
-        bar.className = 'bps-adjust-bar';
-        // Buttons lead, so the map's top-left corner shows ✓ Apply / ✕ Cancel
-        // exactly where the layout tools show ✓ Save / ✕ Cancel; the Snap and
-        // Square knobs (adjust-only) trail.
-        bar.innerHTML = `
+        // ✓ Apply / ✕ Cancel pinned to the map's top-left corner, exactly where
+        // the layout tools show ✓ Save / ✕ Cancel. #bpsAdjustActions doubles as
+        // the "adjust UI open" sentinel (created here, removed in hideAdjustBar).
+        const actions = document.createElement('div');
+        actions.id = 'bpsAdjustActions';
+        actions.className = 'bps-adjust-actions';
+        actions.innerHTML = `
             <button type="button" id="bpsAdjustApply">✓ Apply</button>
             <button type="button" id="bpsAdjustCancel">✕ Cancel</button>
-            <span id="bpsAdjustSummary" class="bps-adjust-summary">Computing…</span>
-            <label class="bps-adjust-ctl">Snap
-                <input type="range" id="bpsAdjustTol" min="6" max="60" step="2" value="${defaultPx}">
-                <span id="bpsAdjustTolVal">${cmFor(defaultPx)}</span>
-            </label>
-            <label class="bps-adjust-ctl"><input type="checkbox" id="bpsAdjustSquare" checked> Square rooms</label>
         `;
-        // Inside the map wrap so it pins to the map's top-left (like #mapToolActions),
-        // not the viewport.
-        (document.querySelector('.bps-canvas-wrap') || document.body).appendChild(bar);
-        const tol = bar.querySelector('#bpsAdjustTol');
-        const tolVal = bar.querySelector('#bpsAdjustTolVal');
-        let debounce = null;
-        tol.addEventListener('input', () => {
-            tolVal.textContent = cmFor(Number(tol.value));
-            clearTimeout(debounce);
-            debounce = setTimeout(runAdjustPreview, 250);
-        });
-        bar.querySelector('#bpsAdjustSquare').addEventListener('change', runAdjustPreview);
-        bar.querySelector('#bpsAdjustCancel').addEventListener('click', cancelAdjust);
-        bar.querySelector('#bpsAdjustApply').addEventListener('click', applyAdjust);
+        (document.querySelector('.bps-canvas-wrap') || document.body).appendChild(actions);
+        actions.querySelector('#bpsAdjustApply').addEventListener('click', applyAdjust);
+        actions.querySelector('#bpsAdjustCancel').addEventListener('click', cancelAdjust);
+
+        // Summary + tuning knobs go in a centered strip ABOVE the map (a static
+        // container between the setup row and the canvas), so they never cover
+        // the zones being adjusted.
+        const controls = document.getElementById('bpsAdjustControls');
+        if (controls) {
+            controls.innerHTML = `
+                <span id="bpsAdjustSummary" class="bps-adjust-summary">Computing…</span>
+                <label class="bps-adjust-ctl">Snap
+                    <input type="range" id="bpsAdjustTol" min="6" max="60" step="2" value="${defaultPx}">
+                    <span id="bpsAdjustTolVal">${cmFor(defaultPx)}</span>
+                </label>
+                <label class="bps-adjust-ctl"><input type="checkbox" id="bpsAdjustSquare" checked> Square rooms</label>
+            `;
+            controls.style.display = '';
+            const tol = controls.querySelector('#bpsAdjustTol');
+            const tolVal = controls.querySelector('#bpsAdjustTolVal');
+            let debounce = null;
+            tol.addEventListener('input', () => {
+                tolVal.textContent = cmFor(Number(tol.value));
+                clearTimeout(debounce);
+                debounce = setTimeout(runAdjustPreview, 250);
+            });
+            controls.querySelector('#bpsAdjustSquare').addEventListener('change', runAdjustPreview);
+        }
     }
 
     function hideAdjustBar() {
-        const bar = document.getElementById('bpsAdjustBar');
-        if (bar) bar.remove();
+        const actions = document.getElementById('bpsAdjustActions');
+        if (actions) actions.remove();
+        const controls = document.getElementById('bpsAdjustControls');
+        if (controls) { controls.innerHTML = ''; controls.style.display = 'none'; }
     }
 
     function cancelAdjust() {
-        const had = adjustPreview || document.getElementById('bpsAdjustBar');
+        const had = adjustPreview || document.getElementById('bpsAdjustActions');
         adjustRunSeq++; // invalidate any in-flight preview response
         adjustPreview = null;
         hideAdjustBar();


### PR DESCRIPTION
The **Adjust Zones** / **Adjust Sub-zones** preview showed its Apply/Cancel in a viewport-fixed bottom-center bar of its own — inconsistent with every other layout tool (Draw Zone, Draw Sub-Zone, Set Scale, Place Receiver), whose green **✓ Save** / red **✕ Cancel** sit at the map's top-left via `#mapToolActions`.

## Change

The adjust control bar now pins to the **map's top-left corner** (`position:absolute` inside `.bps-canvas-wrap`), leading with **✓ Apply** / **✕ Cancel** styled pixel-identically to the tool Save/Cancel buttons (green/red, same padding/size/radius). The adjust-only knobs (Snap tolerance slider, Square-rooms toggle, summary) trail after them.

The two corner controls can't collide: opening an adjust preview and starting a draw tool both route through `buttonreset()`, which already calls `cancelAdjust()` — so `#mapToolActions` and the adjust bar are mutually exclusive.

## Verification

- JS balance check; computed-style comparison confirms the Apply/Cancel buttons are byte-identical to `#saveToolBtn`/`#cancelToolBtn` and sit at the same 11px top-left offset as `#mapToolActions`.
- One adversarial review round flagged two edge-case regressions from putting a wider bar inside the `overflow:hidden` map wrap — on a **narrow viewport + short/landscape plan** it could wrap to multiple rows, get vertically clipped (Snap/Square unreachable), or cover the bottom-left Reset-view button. **Both fixed** by keeping the bar a single non-wrapping row that scrolls horizontally instead; re-verified at 375px over a 120px-tall map: bar stays one 47px row, fully within the wrap, clears Reset-view, and all controls remain reachable.

Frontend-only. A panel hard-refresh is enough to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)