### PR TITLE
Declutter the map: show receiver names on hover/focus only

### DIFF
--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1957,15 +1957,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             r.cords && Math.hypot(r.cords.x - pos.x, r.cords.y - pos.y) <= hitRadius) || null;
     }
 
-    // On-map receiver label: drop the "bermuda_" prefix and "_probe" suffix
-    // boilerplate so names are shorter (the full entity_id stays in the sidebar).
-    function receiverLabel(id) {
-        let s = String(id || "");
-        if (s.startsWith("bermuda_")) s = s.slice(8);
-        if (s.endsWith("_probe")) s = s.slice(0, -6);
-        return s || String(id || "");
-    }
-
     function endReceiverDrag() {
         if (!dragReceiverRef) return;
         dragReceiverRef = null;
@@ -2311,7 +2302,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     if (labelY < 24) {
                         labelY = y + iconSize / 2 + 24;
                     }
-                    drawCenteredLabel((recOffline ? "(Offline) " : "") + receiverLabel(item.entity_id), x, labelY,
+                    drawCenteredLabel((recOffline ? "(Offline) " : "") + item.entity_id, x, labelY,
                         "600 22px system-ui, sans-serif", recOffline ? OFFLINE_RED : "#111111");
                 }
             }

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2046,6 +2046,30 @@ document.addEventListener('DOMContentLoaded', async () => {
         redrawAll();
     });
 
+    // Hovering a receiver row in the sidebar list also reveals that receiver's
+    // name on the map (same hoveredReceiver state as the map hover). Delegated
+    // mouseover/mouseout because the tree is re-rendered; repaint only on change.
+    document.addEventListener("mouseover", (event) => {
+        const row = event.target.closest('[data-type="focusrec"]');
+        if (!row || receiversHidden()) return;
+        const id = row.getAttribute("data-id");
+        if (id !== hoveredReceiver) {
+            hoveredReceiver = id;
+            if (mapReady()) redrawAll();
+        }
+    });
+    document.addEventListener("mouseout", (event) => {
+        const row = event.target.closest('[data-type="focusrec"]');
+        if (!row) return;
+        // Leaving a receiver row: clear unless the pointer is entering another row.
+        const into = event.relatedTarget && event.relatedTarget.closest
+            && event.relatedTarget.closest('[data-type="focusrec"]');
+        if (!into && hoveredReceiver !== null) {
+            hoveredReceiver = null;
+            if (mapReady()) redrawAll();
+        }
+    });
+
     document.addEventListener("mouseup", () => {
         endReceiverDrag();
         if (!panState) return;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1886,6 +1886,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let panState = null;
     let clickCandidate = null;
     let focusedReceiver = null;
+    let hoveredReceiver = null; // receiver under the cursor; its name shows (names are hidden otherwise)
     // Sidebar zone groups the user has expanded, keyed by zone id (synthetic
     // "__unzoned__" / "__orphan_subs__" keys for the two special groups). Groups
     // start COLLAPSED on every page load (this set begins empty and is not
@@ -1956,6 +1957,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             r.cords && Math.hypot(r.cords.x - pos.x, r.cords.y - pos.y) <= hitRadius) || null;
     }
 
+    // On-map receiver label: drop the "bermuda_" prefix and "_probe" suffix
+    // boilerplate so names are shorter (the full entity_id stays in the sidebar).
+    function receiverLabel(id) {
+        let s = String(id || "");
+        if (s.startsWith("bermuda_")) s = s.slice(8);
+        if (s.endsWith("_probe")) s = s.slice(0, -6);
+        return s || String(id || "");
+    }
+
     function endReceiverDrag() {
         if (!dragReceiverRef) return;
         dragReceiverRef = null;
@@ -2017,6 +2027,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             clampView();
             redrawAll();
         }
+        if (dragReceiverRef || panState) return;
+        // Hover reveals the name of the receiver under the cursor (names are
+        // hidden by default to avoid overlap). Repaint only when it changes.
+        const hit = (drawToolActive() || !mapReady()) ? null : hitReceiverAt(zoneMousePos(event));
+        const next = hit ? hit.entity_id : null;
+        if (next !== hoveredReceiver) {
+            hoveredReceiver = next;
+            canvas.style.cursor = next ? "pointer" : "";
+            redrawAll();
+        }
+    });
+
+    canvas.addEventListener("mouseleave", () => {
+        if (hoveredReceiver === null) return;
+        hoveredReceiver = null;
+        canvas.style.cursor = "";
+        redrawAll();
     });
 
     document.addEventListener("mouseup", () => {
@@ -2250,14 +2277,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const recOffline = isReceiverOffline(item.entity_id);
                 drawReceiverIcon(x, y, iconSize, recOffline);
 
-                // Name centered above the icon; below it when too close to
-                // the top edge.
-                let labelY = y - iconSize / 2 - 8;
-                if (labelY < 24) {
-                    labelY = y + iconSize / 2 + 24;
+                // Names are hidden by default (too many receivers overlap);
+                // show one only when it's hovered or focused. The full list of
+                // names lives in the Zones & Receivers sidebar.
+                if (item.entity_id === hoveredReceiver || item.entity_id === focusedReceiver) {
+                    // Name centered above the icon; below it when too close to
+                    // the top edge.
+                    let labelY = y - iconSize / 2 - 8;
+                    if (labelY < 24) {
+                        labelY = y + iconSize / 2 + 24;
+                    }
+                    drawCenteredLabel((recOffline ? "(Offline) " : "") + receiverLabel(item.entity_id), x, labelY,
+                        "600 22px system-ui, sans-serif", recOffline ? OFFLINE_RED : "#111111");
                 }
-                drawCenteredLabel((recOffline ? "(Offline) " : "") + item.entity_id, x, labelY,
-                    "600 22px system-ui, sans-serif", recOffline ? OFFLINE_RED : "#111111");
             }
             if (item.type == "zone"){
                 const pts = zonePerimeterPoints(item);


### PR DESCRIPTION
On a floor with many receivers, every name was drawn at once and the labels overlapped into an unreadable pile.

## Change
- Receiver names are **hidden by default** — the map shows just the icons.
- A name appears only for the receiver you're pointing at:
  - **hovering its icon on the map**, or
  - **hovering its row in the Zones & Receivers sidebar list**, or
  - the **focused** receiver (click).
- The **full `entity_id`** is shown (no prefix/suffix trimming — naming conventions vary).

Both hover paths share one `hoveredReceiver` state. The map hover reuses the existing hit-test (`hitReceiverAt`); the sidebar hover is delegated `mouseover`/`mouseout` on the receiver rows. Either way it **repaints only when the hovered receiver changes**, and clears on `mouseleave` (map) or when leaving the list. No names are shown while a layout tool is active (receivers are hidden then anyway).

## Verification
- JS balance check.
- Harnesses: the show-gate (nothing by default; exactly the hovered/focused one shown) and the sidebar-row event transitions (row/child resolves to the row, switching rows updates, re-hover no repaint, leaving clears, non-rows ignored).
- Adversarial review across hover-wiring, render-gate, and the sidebar/map/focus/repaint interaction — **0 findings**.

Independent of the zone-colour PR (#82) — different code regions. Frontend-only; panel hard-refresh to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)