### PR TITLE
Fix zone colour picker opening then closing immediately

### DIFF
--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -954,6 +954,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         zone.color = el.value;
         zone.uncolored = false; // picking a colour re-enables a removed zone
         savebuttondiv.appendChild(saveButton);
+        // Drop focus so the render guard doesn't skip the tree rebuild — the new
+        // colour needs to reach the swatch + header tint now that the picker is done.
+        el.blur();
         clearCanvas();
         drawElements(); // repaints the map and re-renders the sidebar header tint
         bpsToast("Zone colour updated — Save Floor Plan to keep it.");
@@ -2794,6 +2797,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             } else {
                 zoneColorsToggle.style.display = "none";
             }
+        }
+        // A zone colour swatch is focused right now — its native colour picker
+        // is likely open. Rebuilding the tree would replace that <input> and
+        // slam the picker shut (it "appears and disappears"), so leave the tree
+        // DOM intact this pass; a later render (after focus leaves the swatch)
+        // refreshes it. The canvas still redraws around this.
+        const active = document.activeElement;
+        if (tree && active && active.classList && active.classList.contains("bps-zone-swatch") && tree.contains(active)) {
+            return;
         }
         if (!floor) {
             tree.innerHTML = '<p class="bps-empty">Select a floor to see its zones and receivers.</p>';


### PR DESCRIPTION
Clicking a zone's colour swatch in the Zones & Receivers sidebar opened the native OS colour picker, which then **closed immediately** (reported via screen recording).

**Cause:** the sidebar tree (`#entitytree`) is rebuilt via `innerHTML` on many repaints — the 10 s liveness poll (`fetchReceiverStatus`), hover redraws, etc. Rebuilding replaces the `<input type=color>`, and destroying the element slams its open native picker shut.

**Fix:** `renderEntityTree` now skips rebuilding the tree while a `.bps-zone-swatch` is the focused element (its picker is open) — the canvas still redraws, only the tree DOM is left intact — and the colour-change handler blurs the swatch before repainting so the picked colour refreshes the sidebar once you're done.

Follow-up to #82 (which was already merged, so this couldn't go on that branch). Frontend-only.

## Verification
- JS balance check; DOM harness: focusing the swatch then triggering a re-render preserves the same `<input>` (no rebuild); after blur the tree rebuilds with the new colour.
- Adversarial review (guard correctness + regressions) — **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)