### PR TITLE
Debugging tab: Beacon view (receivers detecting each beacon, closest first)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -360,6 +360,45 @@ def _scanner_linking(hass, coordinates_json):
     return {"placed": rows, "unplaced": unplaced}
 
 
+def _beacon_links(hass):
+    """Debug view: for every tracked device (beacon), the receivers currently
+    detecting it, sorted closest -> farthest. The inverse of _scanner_linking
+    (grouped by the tracked device instead of by the scanner). Distances are
+    normalized to metres only for sorting — Bermuda reports per-entity feet or
+    metres — while the value is shown in its own unit. A beacon with no live
+    reading still appears (empty list) so a device that's gone dark is visible.
+    """
+    beacons = {}  # device -> [{scanner, distance, unit}]
+    for st in hass.states.async_all("sensor"):
+        eid = st.entity_id
+        if "_distance_to_" not in eid:
+            continue
+        device_part, slug = eid.split("_distance_to_", 1)
+        device = device_part[len("sensor."):] if device_part.startswith("sensor.") else device_part
+        beacons.setdefault(device, [])
+        if st.state in _NO_DISTANCE_STATES:
+            continue
+        try:
+            val = float(st.state)
+        except (ValueError, TypeError):
+            continue
+        unit = st.attributes.get("unit_of_measurement")
+        meters = val * 0.3048 if unit == "ft" else val
+        beacons[device].append({
+            "scanner": slug,
+            "distance": round(val, 2),
+            "unit": unit if isinstance(unit, str) and unit else "m",
+            "_m": meters,
+        })
+    out = []
+    for device in sorted(beacons):
+        recs = sorted(beacons[device], key=lambda r: r["_m"])
+        for r in recs:
+            r.pop("_m", None)  # internal sort key only
+        out.append({"device": device, "receivers": recs})
+    return out
+
+
 def _refresh_dump_ages(hass, dom, devices):
     """Update the cached per-scanner Bermuda-liveness ages from a dump payload.
 
@@ -1391,10 +1430,16 @@ class BPSScannerLinkingAPI(HomeAssistantView):
             _LOGGER.info(f"scanner_linking: could not read bpsdata: {e}")
             content = ""
         try:
-            return web.json_response(_scanner_linking(hass, content))
+            data = _scanner_linking(hass, content)
         except Exception as e:
             _LOGGER.error(f"scanner_linking failed: {e}")
-            return web.json_response({"placed": [], "unplaced": []})
+            data = {"placed": [], "unplaced": []}
+        try:
+            data["beacons"] = _beacon_links(hass)
+        except Exception as e:
+            _LOGGER.error(f"beacon_links failed: {e}")
+            data["beacons"] = []
+        return web.json_response(data)
 
 
 class BPSMapsListAPI(HomeAssistantView):

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3070,6 +3070,11 @@ select.bps-input { cursor: pointer; }
 .bps-debug-val { font-weight: 700; padding: 0 5px; border-radius: 4px; background: hsl(var(--background) / 0.6); }
 .bps-debug-subtitle { margin: 18px 0 8px; font-size: 13px; }
 .bps-debug-help { margin-top: 12px; color: hsl(var(--muted-foreground)); font-size: 12px; line-height: 1.5; }
+/* Beacon view: one block per tracked device. */
+.bps-beacon { margin: 0 0 12px; }
+.bps-beacon-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.bps-beacon-name { font-family: monospace; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bps-beacon-count { flex: 0 0 auto; font-size: 11px; color: hsl(var(--muted-foreground)); }
 
 .bps-scale-status { margin-top: 10px; }
 .bps-scale-line {

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3037,7 +3037,20 @@ select.bps-input { cursor: pointer; }
 .bps-debug { font-size: 13px; }
 .bps-debug-msg { color: hsl(var(--muted-foreground)); margin: 8px 0; }
 .bps-debug-toolbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
-.bps-debug-summary { display: flex; gap: 6px; flex-wrap: wrap; }
+.bps-debug-summary { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; }
+/* Debugging-tab sub-tabs (Receivers / Beacons). */
+.bps-subtabs { display: inline-flex; gap: 4px; }
+.bps-subtab {
+    padding: 5px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    background: hsl(var(--background) / 0.6);
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+}
+.bps-subtab.active { background: hsl(var(--sidebar-primary)); border-color: hsl(var(--sidebar-primary)); color: hsl(var(--sidebar-primary-foreground)); }
 .bps-debug-tablewrap { overflow-x: auto; border: 1px solid hsl(var(--border)); border-radius: 8px; }
 .bps-debug-table { width: 100%; border-collapse: collapse; }
 .bps-debug-table th, .bps-debug-table td { text-align: left; padding: 8px 12px; vertical-align: top; }

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2650,7 +2650,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     async function loadScannerLinking() {
         scannerLinkingLoading = true;
         renderDebugView();
-        let data = { placed: [], unplaced: [] };
+        let data = { placed: [], unplaced: [], beacons: [] };
         try {
             const res = await fetch('/api/bps/scanner_linking');
             if (res.ok) {
@@ -2659,6 +2659,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     data = {
                         placed: Array.isArray(parsed.placed) ? parsed.placed : [],
                         unplaced: Array.isArray(parsed.unplaced) ? parsed.unplaced : [],
+                        beacons: Array.isArray(parsed.beacons) ? parsed.beacons : [],
                     };
                 }
             }
@@ -2780,6 +2781,36 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         html += '<p class="bps-debug-help"><strong>No reading</strong> = the name matches a Bermuda distance sensor but it has no value right now — usually just no recent BLE contact, not a naming problem. '
             + '<strong>Unmatched</strong> = no distance sensor carries that name at all; fix it with the <em>Re-link</em> button in the Map view’s “Scanner issues” panel, or rename the entity in Bermuda.</p>';
+
+        // Beacon view: per tracked device, the receivers currently detecting it,
+        // closest first (the inverse of the receiver table above).
+        const beacons = (data.beacons || []);
+        if (beacons.length) {
+            html += '<h4 class="bps-debug-subtitle">Beacons — receivers detecting each (closest first)</h4>';
+            beacons.forEach(b => {
+                const recs = b.receivers || [];
+                html += '<div class="bps-beacon">'
+                    + '<div class="bps-beacon-head">'
+                    + '<span class="bps-beacon-name" title="' + escHtml(b.device) + '">' + escHtml(b.device) + '</span>'
+                    + '<span class="bps-beacon-count">' + recs.length + ' receiver' + (recs.length === 1 ? '' : 's') + '</span>'
+                    + '</div>';
+                if (!recs.length) {
+                    html += '<p class="bps-debug-none">No receiver currently detects this beacon.</p>';
+                } else {
+                    html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
+                        + '<th>#</th><th>Receiver</th><th>Distance</th></tr></thead><tbody>';
+                    recs.forEach((r, i) => {
+                        html += '<tr>'
+                            + '<td class="bps-debug-hw">' + (i + 1) + '</td>'
+                            + '<td class="bps-debug-name" title="' + escHtml(r.scanner) + '">' + escHtml(r.scanner) + '</td>'
+                            + '<td>' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</td>'
+                            + '</tr>';
+                    });
+                    html += '</tbody></table></div>';
+                }
+                html += '</div>';
+            });
+        }
         host.innerHTML = html;
     }
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2803,16 +2803,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!recs.length) {
                 html += '<p class="bps-debug-none">No receiver currently detects this beacon.</p>';
             } else {
-                html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
-                    + '<th>#</th><th>Receiver</th><th>Distance</th></tr></thead><tbody>';
-                recs.forEach((r, i) => {
-                    html += '<tr>'
-                        + '<td class="bps-debug-hw">' + (i + 1) + '</td>'
-                        + '<td class="bps-debug-name" title="' + escHtml(r.scanner) + '">' + escHtml(r.scanner) + '</td>'
-                        + '<td>' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</td>'
-                        + '</tr>';
-                });
-                html += '</tbody></table></div>';
+                // Same pill layout as the receivers view (name + reading), closest
+                // first left-to-right. Every one is a live reading, so all green.
+                html += '<div class="bps-debug-readings">' + recs.map(r =>
+                    '<span class="bps-debug-reading is-live" title="' + escHtml(r.scanner) + '">'
+                    + '<span class="bps-debug-dev">' + escHtml(r.scanner) + '</span>'
+                    + '<span class="bps-debug-val">' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</span></span>'
+                ).join("") + '</div>';
             }
             html += '</div>';
         });

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // sidebar. Refreshed on load, on Refresh, and when the Debugging tab opens.
     let scannerLinkingLoading = false;
     let scannerLinkingData = null;
+    let debugSubtab = "receivers"; // Debugging tab sub-view: "receivers" | "beacons"
     // A placed receiver is "offline" when its scanner's distance sensors are
     // gone (slug no longer in the reported list) OR Bermuda hasn't heard the
     // scanner recently (backend liveness). Guarded on the list being loaded so
@@ -1021,6 +1022,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Debugging tab Refresh — re-fetch the receiver-linking snapshot (issue #64).
         if (event.target.closest('[data-type="refreshlinking"]')) {
             if (!scannerLinkingLoading) loadScannerLinking();
+            return;
+        }
+        // Debugging-tab sub-tabs (Receivers / Beacons) — re-render the active view.
+        if (event.target.closest('[data-type="debugsubtab"]')) {
+            const tab = event.target.closest('[data-type="debugsubtab"]').getAttribute('data-tab');
+            if (tab && tab !== debugSubtab) { debugSubtab = tab; renderDebugView(); }
             return;
         }
         if (event.target.closest('[data-type="removezone"]')) {
@@ -2701,13 +2708,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Debugging tab: the complete receiver-linking picture, laid out as a table
     // for easy visual scanning — every placed receiver, its status, and the
     // per-device Bermuda distance sensors feeding it with their live states.
-    function renderDebugView() {
-        const host = document.getElementById("debuglinking");
-        if (!host) return;
-        if (scannerLinkingLoading && !scannerLinkingData) { host.innerHTML = '<p class="bps-debug-msg">Loading…</p>'; return; }
-        const data = scannerLinkingData;
-        if (!data) { host.innerHTML = '<p class="bps-debug-msg">No data yet. <button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button></p>'; return; }
-
+    // Receivers sub-view: every placed receiver, its status, and the per-device
+    // Bermuda sensors feeding it. Returns an HTML string.
+    function debugReceiversHtml(data) {
         const rows = (data.placed || []).slice().sort((a, b) =>
             (LINKING_STATUS_RANK[linkingStatusOf(a)] - LINKING_STATUS_RANK[linkingStatusOf(b)])
             || String(a.floor || "").localeCompare(String(b.floor || ""))
@@ -2715,13 +2718,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         const counts = { live: 0, silent: 0, unmatched: 0 };
         rows.forEach(r => { counts[linkingStatusOf(r)]++; });
 
-        let html = '<div class="bps-debug-toolbar">'
-            + '<button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button>'
-            + '<span class="bps-debug-summary">'
+        let html = '<div class="bps-debug-summary">'
             + '<span class="bps-linking-chip bps-chip-live">' + counts.live + ' Live</span>'
             + '<span class="bps-linking-chip bps-chip-silent">' + counts.silent + ' No reading</span>'
             + '<span class="bps-linking-chip bps-chip-unmatched">' + counts.unmatched + ' Unmatched</span>'
-            + '</span></div>';
+            + '</div>';
 
         if (!rows.length) {
             html += '<p class="bps-debug-msg">No receivers placed yet. Place receivers on the Map &amp; Setup tab.</p>';
@@ -2781,36 +2782,61 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         html += '<p class="bps-debug-help"><strong>No reading</strong> = the name matches a Bermuda distance sensor but it has no value right now — usually just no recent BLE contact, not a naming problem. '
             + '<strong>Unmatched</strong> = no distance sensor carries that name at all; fix it with the <em>Re-link</em> button in the Map view’s “Scanner issues” panel, or rename the entity in Bermuda.</p>';
+        return html;
+    }
 
-        // Beacon view: per tracked device, the receivers currently detecting it,
-        // closest first (the inverse of the receiver table above).
+    // Beacons sub-view: per tracked device, the receivers currently detecting
+    // it, closest first (the inverse of the receivers view). Returns HTML.
+    function debugBeaconsHtml(data) {
         const beacons = (data.beacons || []);
-        if (beacons.length) {
-            html += '<h4 class="bps-debug-subtitle">Beacons — receivers detecting each (closest first)</h4>';
-            beacons.forEach(b => {
-                const recs = b.receivers || [];
-                html += '<div class="bps-beacon">'
-                    + '<div class="bps-beacon-head">'
-                    + '<span class="bps-beacon-name" title="' + escHtml(b.device) + '">' + escHtml(b.device) + '</span>'
-                    + '<span class="bps-beacon-count">' + recs.length + ' receiver' + (recs.length === 1 ? '' : 's') + '</span>'
-                    + '</div>';
-                if (!recs.length) {
-                    html += '<p class="bps-debug-none">No receiver currently detects this beacon.</p>';
-                } else {
-                    html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
-                        + '<th>#</th><th>Receiver</th><th>Distance</th></tr></thead><tbody>';
-                    recs.forEach((r, i) => {
-                        html += '<tr>'
-                            + '<td class="bps-debug-hw">' + (i + 1) + '</td>'
-                            + '<td class="bps-debug-name" title="' + escHtml(r.scanner) + '">' + escHtml(r.scanner) + '</td>'
-                            + '<td>' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</td>'
-                            + '</tr>';
-                    });
-                    html += '</tbody></table></div>';
-                }
-                html += '</div>';
-            });
+        if (!beacons.length) {
+            return '<p class="bps-debug-msg">No beacons yet — tracked devices appear here once Bermuda reports a distance to them.</p>';
         }
+        let html = '<p class="bps-debug-help">Receivers currently detecting each beacon, closest first.</p>';
+        beacons.forEach(b => {
+            const recs = b.receivers || [];
+            html += '<div class="bps-beacon">'
+                + '<div class="bps-beacon-head">'
+                + '<span class="bps-beacon-name" title="' + escHtml(b.device) + '">' + escHtml(b.device) + '</span>'
+                + '<span class="bps-beacon-count">' + recs.length + ' receiver' + (recs.length === 1 ? '' : 's') + '</span>'
+                + '</div>';
+            if (!recs.length) {
+                html += '<p class="bps-debug-none">No receiver currently detects this beacon.</p>';
+            } else {
+                html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
+                    + '<th>#</th><th>Receiver</th><th>Distance</th></tr></thead><tbody>';
+                recs.forEach((r, i) => {
+                    html += '<tr>'
+                        + '<td class="bps-debug-hw">' + (i + 1) + '</td>'
+                        + '<td class="bps-debug-name" title="' + escHtml(r.scanner) + '">' + escHtml(r.scanner) + '</td>'
+                        + '<td>' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</td>'
+                        + '</tr>';
+                });
+                html += '</tbody></table></div>';
+            }
+            html += '</div>';
+        });
+        return html;
+    }
+
+    function renderDebugView() {
+        const host = document.getElementById("debuglinking");
+        if (!host) return;
+        if (scannerLinkingLoading && !scannerLinkingData) { host.innerHTML = '<p class="bps-debug-msg">Loading…</p>'; return; }
+        const data = scannerLinkingData;
+        if (!data) { host.innerHTML = '<p class="bps-debug-msg">No data yet. <button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button></p>'; return; }
+
+        // Two sub-tabs so each view is short: Receivers (per scanner) and
+        // Beacons (per tracked device). Refresh is shared (one snapshot feeds both).
+        const sub = debugSubtab === "beacons" ? "beacons" : "receivers";
+        let html = '<div class="bps-debug-toolbar">'
+            + '<div class="bps-subtabs">'
+            + '<button type="button" class="bps-subtab' + (sub === "receivers" ? " active" : "") + '" data-type="debugsubtab" data-tab="receivers">Receivers</button>'
+            + '<button type="button" class="bps-subtab' + (sub === "beacons" ? " active" : "") + '" data-type="debugsubtab" data-tab="beacons">Beacons</button>'
+            + '</div>'
+            + '<button type="button" class="bps-btn bps-btn-outline" data-type="refreshlinking">Refresh</button>'
+            + '</div>';
+        html += (sub === "beacons") ? debugBeaconsHtml(data) : debugReceiversHtml(data);
         host.innerHTML = html;
     }
 


### PR DESCRIPTION
The Debugging tab already lists each **receiver** and the Bermuda sensors feeding it. This adds the **inverse** view: for every **beacon** (tracked device), the receivers currently detecting it, **sorted closest → farthest**.

## Backend
`_beacon_links(hass)` scans all `sensor.*_distance_to_*` states, groups by the tracked-device prefix, and for each beacon lists `{scanner, distance, unit}` for the sensors with a live reading — sorted by a metres-normalized value (feet × 0.3048) so mixed-unit installs sort correctly, while each value is shown in **its own unit**. A beacon with no live reading still appears (empty list) so a device that's gone dark is visible. Returned as `data["beacons"]` from the existing `/api/bps/scanner_linking` endpoint, wrapped in its own try/except so it never 500s (placed/unplaced unaffected).

## Frontend
`renderDebugView` appends a **"Beacons"** section under the receiver-linking tables: per beacon a header (device + "N receivers") and a `# | Receiver | Distance` table (closest first), or a "No receiver currently detects this beacon." line. All values escaped.

## Verification
- `py_compile`; JS balance check.
- Backend standalone test: grouping, closest-first incl. **ft-vs-m normalization** (2.0 m sorts before 10 ft = 3.05 m), dark beacon appears empty, junk/`unavailable` skipped, no internal sort-key leak.
- DOM harness: beacon order, per-beacon counts, empty-beacon message, distances shown with their unit.
- Adversarial review (backend + frontend lenses) — **0 findings**.

Frontend + one backend helper; the endpoint is fetched only when the Debugging tab is open. Needs an HA restart (backend) to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)