### PR TITLE
Debugging tab: render the Beacons view as a table like the Receivers view

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3083,11 +3083,6 @@ select.bps-input { cursor: pointer; }
 .bps-debug-val { font-weight: 700; padding: 0 5px; border-radius: 4px; background: hsl(var(--background) / 0.6); }
 .bps-debug-subtitle { margin: 18px 0 8px; font-size: 13px; }
 .bps-debug-help { margin-top: 12px; color: hsl(var(--muted-foreground)); font-size: 12px; line-height: 1.5; }
-/* Beacon view: one block per tracked device. */
-.bps-beacon { margin: 0 0 12px; }
-.bps-beacon-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
-.bps-beacon-name { font-family: monospace; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bps-beacon-count { flex: 0 0 auto; font-size: 11px; color: hsl(var(--muted-foreground)); }
 
 .bps-scale-status { margin-top: 10px; }
 .bps-scale-line {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2786,33 +2786,60 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // Beacons sub-view: per tracked device, the receivers currently detecting
-    // it, closest first (the inverse of the receivers view). Returns HTML.
+    // it, closest first (the inverse of the receivers view). Same table layout
+    // as the receivers view — summary chips, header row, one row per beacon —
+    // so the two read alike. Returns an HTML string.
     function debugBeaconsHtml(data) {
-        const beacons = (data.beacons || []);
+        const beacons = (data.beacons || []).slice().sort((a, b) => {
+            // Undetected beacons first (the anomaly worth seeing), then by name —
+            // mirrors the receivers view surfacing its problem rows at the top.
+            const ad = (a.receivers || []).length ? 1 : 0;
+            const bd = (b.receivers || []).length ? 1 : 0;
+            return (ad - bd) || String(a.device || "").localeCompare(String(b.device || ""));
+        });
+        const detected = beacons.filter(b => (b.receivers || []).length).length;
+        const undetected = beacons.length - detected;
+
+        let html = '<div class="bps-debug-summary">'
+            + '<span class="bps-linking-chip bps-chip-live">' + detected + ' Detected</span>'
+            + '<span class="bps-linking-chip bps-chip-silent">' + undetected + ' Not detected</span>'
+            + '</div>';
+
         if (!beacons.length) {
-            return '<p class="bps-debug-msg">No beacons yet — tracked devices appear here once Bermuda reports a distance to them.</p>';
+            html += '<p class="bps-debug-msg">No beacons yet — tracked devices appear here once Bermuda reports a distance to them.</p>';
+            return html;
         }
-        let html = '<p class="bps-debug-help">Receivers currently detecting each beacon, closest first.</p>';
+
+        html += '<div class="bps-debug-tablewrap"><table class="bps-debug-table"><thead><tr>'
+            + '<th>Beacon</th><th>Status</th><th>Receivers</th><th>Receivers detecting it (closest first)</th>'
+            + '</tr></thead><tbody>';
         beacons.forEach(b => {
             const recs = b.receivers || [];
-            html += '<div class="bps-beacon">'
-                + '<div class="bps-beacon-head">'
-                + '<span class="bps-beacon-name" title="' + escHtml(b.device) + '">' + escHtml(b.device) + '</span>'
-                + '<span class="bps-beacon-count">' + recs.length + ' receiver' + (recs.length === 1 ? '' : 's') + '</span>'
-                + '</div>';
-            if (!recs.length) {
-                html += '<p class="bps-debug-none">No receiver currently detects this beacon.</p>';
+            const isDetected = recs.length > 0;
+            const status = isDetected ? "live" : "silent";
+            let cell;
+            if (!isDetected) {
+                cell = '<span class="bps-debug-none">No receiver currently detects this beacon.</span>';
             } else {
-                // Same pill layout as the receivers view (name + reading), closest
-                // first left-to-right. Every one is a live reading, so all green.
-                html += '<div class="bps-debug-readings">' + recs.map(r =>
+                // Each receiver has a current distance, so every pill is a live (green)
+                // reading. The backend already sorts them closest first; keep that
+                // order left-to-right, matching the receivers view's pill cell.
+                cell = '<div class="bps-debug-readings">' + recs.map(r =>
                     '<span class="bps-debug-reading is-live" title="' + escHtml(r.scanner) + '">'
                     + '<span class="bps-debug-dev">' + escHtml(r.scanner) + '</span>'
                     + '<span class="bps-debug-val">' + escHtml(String(r.distance)) + ' ' + escHtml(r.unit || 'm') + '</span></span>'
                 ).join("") + '</div>';
             }
-            html += '</div>';
+            html += '<tr class="bps-debug-row bps-status-' + status + '">'
+                + '<td class="bps-debug-name" title="' + escHtml(b.device) + '">' + escHtml(b.device) + '</td>'
+                + '<td><span class="bps-linking-chip bps-chip-' + status + '">' + (isDetected ? "Detected" : "None") + '</span></td>'
+                + '<td>' + recs.length + '</td>'
+                + '<td>' + cell + '</td>'
+                + '</tr>';
         });
+        html += '</tbody></table></div>';
+        html += '<p class="bps-debug-help">Each row is a tracked device (beacon) and the receivers reporting a live distance to it right now, closest first. '
+            + '<strong>None</strong> = no receiver currently has a reading for it, usually because the device is off or out of range.</p>';
         return html;
     }
 


### PR DESCRIPTION
The Beacons sub-tab showed free-floating pills under each device name, which didn't read like the Receivers sub-tab. This reworks it into the same table layout.

**What changed**
- Summary chip row: **N Detected** (green) / **M Not detected** (amber), mirroring the Receivers summary.
- Header row + columns: `Beacon | Status | Receivers | Receivers detecting it (closest first)`.
- Each beacon is one `bps-debug-row`: monospace name cell, a status chip (`Detected` / `None`), the receiver count, and the detecting receivers rendered as green `is-live` pills (closest-first) in the last cell — reusing the exact receivers-view pill cell.
- Undetected beacons sort to the top with a `None` status chip, the same "surface the problem rows first" behavior the Receivers view uses.
- Removed the now-unused `.bps-beacon*` CSS (the standalone block layout is gone).

**Verification**
- Browser harness: 4 columns, summary chips, sort order, closest-first pills, empty-cell fallback, and table styling (bordered rounded wrap, uppercase headers, monospace name column) all confirmed identical to the Receivers table.
- 3-lens adversarial review (correctness/parity, HTML-escaping/edge-cases, CSS/dead-code) — 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)