### PR TITLE
Trace path: draw the route taken during a tracking session

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The setup panel
 Accuracy
 - [Receiver auto-calibration](#receiver-auto-calibration) — the probes calibrate each other, continuously.
 - [Trilateration visualization](#trilateration-visualization) — see the distance circles that place each device.
+- [Trace path](#trace-path) — replay the route a tracked device took during the session, faded by age.
 
 The Lovelace card
 - [Receivers on the map card](#receivers-on-the-map-card) — show your proxies, colored by online/offline status.
@@ -453,6 +454,26 @@ visible at a glance.
   any calibration corrections — not a separate estimate.
 
 ![Distance circles during tracking: each receiver's circle and distance pill in its own color](img/screenshots/distance-circles.png)
+
+## Trace path
+
+A second tracking toggle, **Trace path**, draws the route the tracked device
+has taken since the session started — handy for judging how stable and
+responsive the positioning really is (does the path hug the hallway, or
+zig-zag through walls?).
+
+- The path **fades with age**: the newest stretch is brightest, so the
+  direction of travel reads at a glance. A dot marks where the session began.
+- It draws **on top of everything** — distance circles included — so it stays
+  visible with both debugging overlays on.
+- Fixes are recorded for the whole session even while the toggle is off, so
+  flipping it on mid-session shows the full route so far. Starting a new
+  session clears the previous trace.
+- Only fixes belonging to the floor on screen are drawn; a stretch spent on
+  another floor breaks the line instead of connecting through it.
+
+Like Distance circles, the toggle appears only during an active tracking
+session, is **off by default**, and remembers its state.
 
 ---
 

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2703,11 +2703,12 @@ body {
 /* Pin the grid toggle to one width so cycling off -> m -> ft never resizes it
    or bumps it onto a second row (its label was the only variable-width item). */
 #gridToggle { min-width: 74px; }
-/* Distance-circles control: groups the switch + its help tooltip so they show
-   or hide as one unit (only while tracking). inline-flex keeps the spacing they
-   had as separate view-row items; an inline style="display:none" hides it until
-   JS reveals it by clearing that inline display. */
-#circleControl { display: inline-flex; align-items: center; gap: 8px; }
+/* Distance-circles / trace-path controls: each groups a switch + its help
+   tooltip so they show or hide as one unit (only while tracking). inline-flex
+   keeps the spacing they had as separate view-row items; an inline
+   style="display:none" hides them until JS reveals them by clearing that
+   inline display. */
+#circleControl, #traceControl { display: inline-flex; align-items: center; gap: 8px; }
 
 /* Inputs */
 .bps-input {

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -98,6 +98,16 @@
                                         <span class="tooltip-text">Draw each receiver's measured distance as a circle around it — where the circles intersect is where the trilateration places the device.</span>
                                     </span>
                                 </span>
+                                <span id="traceControl" style="display: none">
+                                    <label class="bps-switch">
+                                        <input type="checkbox" id="traceToggle">
+                                        <span class="bps-slider"></span>
+                                        <span>Trace path</span>
+                                    </label>
+                                    <span class="tooltip">❓
+                                        <span class="tooltip-text">Draw the path the device has taken since tracking started — brighter is more recent. The trace clears when a new tracking session starts.</span>
+                                    </span>
+                                </span>
                                 <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
                                 <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const starttrackbtn = document.getElementById('starttrack');
     const stoptrackbtn = document.getElementById('stoptrack');
     const circleControl = document.getElementById('circleControl');
+    const traceControl = document.getElementById('traceControl');
     const cancelToolBtn = document.getElementById('cancelToolBtn');
     const saveToolBtn = document.getElementById('saveToolBtn');
     const mapToolActions = document.getElementById('mapToolActions');
@@ -356,9 +357,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         function startTrackfunc(){
             stoptrackstat = false;
             pollTrackActive = true;
+            tracePoints.length = 0; // each session traces from its own start
             starttrackbtn.style.display = "none";
             stoptrackbtn.style.display = "";
             if (circleControl) circleControl.style.display = ""; // reveal while tracking
+            if (traceControl) traceControl.style.display = "";
             const interval = setInterval(async () => {
                 if (stoptrackstat) {
                     clearInterval(interval);
@@ -368,6 +371,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     starttrackbtn.style.display = "";
                     stoptrackbtn.style.display = "none";
                     if (circleControl) circleControl.style.display = "none"; // hide when not tracking
+                    if (traceControl) traceControl.style.display = "none";
                     zonediv.style.display = "none";
                     if (img.naturalWidth > 0) redrawAll();
                     return;
@@ -381,6 +385,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     return;
                 }
                 let dt = {x: result.cords[0], y:result.cords[1]};
+                // Record every fix for the trace-path overlay, whether or not
+                // the toggle is on: the trace must show the whole session when
+                // switched on mid-session. Points are tagged with the fix's own
+                // floor because cords are in that floor's pixel space.
+                recordTracePoint(dt.x, dt.y, result.floor || null);
                 // A missing floor can't be judged off-floor, so treat it as the
                 // current one (no dim/badge/switch) rather than a false warning.
                 const sameFloor = !result.floor || sameFloorName(result.floor, SelMapName);
@@ -442,6 +451,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Red pill under the icon spelling out which floor it's really on.
             drawLabelPill(`on ${lastTrack.floor}`, lastTrack.x, lastTrack.y + iconSize / 2 + 16, 0);
         }
+        // Last so the trace sits on top of everything — circles, icon, pills.
+        drawTracePath();
     }
 
     // Hue keyed to the receiver's index on the floor (matched by placed
@@ -684,6 +695,97 @@ document.addEventListener('DOMContentLoaded', async () => {
                 : `${meters.toFixed(1)} m`;
             drawLabelPill(text, c[0], c[1], floorReceiverHue(c[0], c[1]));
         });
+    }
+
+    // =================================================================
+    // Trace path (the route taken during the active tracking session)
+    // =================================================================
+
+    // Fixes recorded since the session started, in their own floor's pixel
+    // space: {x, y, floor}. Recorded regardless of the toggle so switching it
+    // on mid-session shows the whole path; cleared when a session starts.
+    let tracePoints = [];
+    const TRACE_MAX_POINTS = 5000; // oldest dropped beyond this
+    const TRACE_HUE = 320;         // magenta — not tied to any receiver hue
+
+    function recordTracePoint(x, y, floor) {
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+        const last = tracePoints[tracePoints.length - 1];
+        // Skip sub-pixel moves so an idle device doesn't burn the point budget.
+        if (last && last.floor === floor && Math.hypot(x - last.x, y - last.y) < 1) return;
+        tracePoints.push({ x, y, floor });
+        if (tracePoints.length > TRACE_MAX_POINTS) tracePoints.shift();
+    }
+
+    // The polyline through this session's fixes, faded by recency (newest
+    // brightest) so the direction of travel is readable. Only fixes belonging
+    // to the floor on screen are drawn — an off-floor stretch breaks the line
+    // rather than connecting two coordinates from different pixel spaces (a
+    // missing floor is treated as the current one, like the tracking loop
+    // does). Called last from drawTrackOverlay so it sits on top of everything.
+    function drawTracePath() {
+        if (!traceToggle.checked || tracePoints.length === 0) return;
+        const onFloor = (p) => !p.floor || sameFloorName(p.floor, SelMapName);
+        // Segments between consecutive fixes with both ends on this floor.
+        const segs = [];
+        for (let i = 1; i < tracePoints.length; i++) {
+            const a = tracePoints[i - 1], b = tracePoints[i];
+            if (onFloor(a) && onFloor(b)) segs.push([a, b, i]);
+        }
+        ctx.save();
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        if (segs.length) {
+            // Casing pass: one dark stroke under the whole path so the colored
+            // line stays readable over map art, circle fills, and labels.
+            // moveTo only where the previous segment isn't adjacent, so joints
+            // stay inside one subpath and don't double-composite into beads.
+            ctx.beginPath();
+            let prev = -2;
+            segs.forEach(([a, b, i]) => {
+                if (i !== prev + 1) ctx.moveTo(a.x, a.y);
+                ctx.lineTo(b.x, b.y);
+                prev = i;
+            });
+            ctx.strokeStyle = "rgba(15, 15, 20, 0.55)";
+            ctx.lineWidth = 7;
+            ctx.stroke();
+            // Colored pass in a few recency buckets: one stroke per alpha level
+            // instead of per segment, so long traces stay cheap to repaint.
+            const BUCKETS = 8;
+            const denom = Math.max(tracePoints.length - 1, 1);
+            const bucketOf = (i) => Math.min(BUCKETS - 1, Math.floor(((i - 1) / denom) * BUCKETS));
+            for (let bkt = 0; bkt < BUCKETS; bkt++) {
+                ctx.beginPath();
+                let any = false;
+                prev = -2;
+                segs.forEach(([a, b, i]) => {
+                    if (bucketOf(i) !== bkt) return;
+                    if (i !== prev + 1) ctx.moveTo(a.x, a.y);
+                    ctx.lineTo(b.x, b.y);
+                    prev = i;
+                    any = true;
+                });
+                if (any) {
+                    ctx.strokeStyle = `hsla(${TRACE_HUE}, 95%, 60%, ${(0.25 + 0.7 * ((bkt + 1) / BUCKETS)).toFixed(3)})`;
+                    ctx.lineWidth = 3.5;
+                    ctx.stroke();
+                }
+            }
+        }
+        // Session-start marker so the path's origin is readable.
+        const first = tracePoints[0];
+        if (onFloor(first)) {
+            ctx.beginPath();
+            ctx.arc(first.x, first.y, 7, 0, Math.PI * 2);
+            ctx.fillStyle = "rgba(15, 15, 20, 0.55)";
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(first.x, first.y, 4, 0, Math.PI * 2);
+            ctx.fillStyle = `hsl(${TRACE_HUE}, 95%, 60%)`;
+            ctx.fill();
+        }
+        ctx.restore();
     }
 
     function drawTracker(tricords, circles, opts){
@@ -3002,6 +3104,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         // The toggle is only shown while tracking, so redraw the tracking view
         // (circles + receiver tints) immediately instead of waiting for the next
         // poll tick. redrawAll is a no-op-safe full repaint.
+        if (img.naturalWidth > 0) redrawAll();
+    });
+
+    // Trace-path toggle: same lifecycle as the circles toggle (revealed only
+    // while tracking, persisted, off by default).
+    const traceToggle = document.getElementById("traceToggle");
+    traceToggle.checked = localStorage.getItem("bpsTracePath") === "on"; // off by default
+    traceToggle.addEventListener("change", () => {
+        localStorage.setItem("bpsTracePath", traceToggle.checked ? "on" : "off");
         if (img.naturalWidth > 0) redrawAll();
     });
 


### PR DESCRIPTION
## What

Adds a **Trace path** toggle to the Tracking section of the panel, beside Distance circles. While a tracking session runs, it draws the route the device has taken **since the session started** as a recency-faded polyline — the newest stretch is brightest, so the direction of travel reads at a glance, and a dot marks where the session began.

![toggle placement: Tracking section, next to Distance circles]

## Behavior

- **Same lifecycle as Distance circles**: the control is revealed only during an active tracking session, **defaults to off**, and remembers its state (`localStorage`).
- **Drawn on top of everything** — distance circles, the tracker icon, and label pills — so it stays visible with both debugging overlays enabled.
- Fixes are recorded for the whole session even while the toggle is off, so flipping it on mid-session shows the full route so far. **Starting a new session clears the previous trace** (changing the tracked device stops the session, so a new device always traces fresh).
- **Floor-aware**: each fix is tagged with its own floor; only fixes belonging to the floor on screen are drawn, and a stretch spent on another floor breaks the line instead of connecting coordinates from two different pixel spaces. Switch floors and that floor's part of the route shows there.
- Cheap to repaint: sub-pixel dedup while idle, a 5000-point cap, and the fade rendered as 8 bucketed strokes (plus one casing pass) rather than per-segment strokes.

## Verification

Drove the **real panel** (real script.js/index.html/css) in a browser harness with stubbed `/api/bps/*` endpoints and a scripted device walking a 4-leg route, then sampled canvas pixels:

- trace present along every walked leg, zero magenta anywhere off-route;
- fade monotonic: oldest leg dimmest → newest brightest;
- z-order: at the point where **all three distance circles + the tracker icon + the path** coincide, the trace wins;
- toggle off → gone on the next frame, on → back (localStorage persisted both ways);
- stop → control hidden, overlay cleared; restart → old trace gone, fresh start marker only;
- no console errors through the whole flow.

A 3-lens adversarial review of the diff (canvas rendering / state lifecycle / integration) returned zero findings.

No version bump here — #90 (open) already claims 1.4.0; happy to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)