### PR TITLE
Receiver mount heights: slant-corrected radii + 3D calibration truth (v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,48 @@ links) stands out of the mesh.
 - Unlike the two toggles above it needs **no active tracking session**; it is
   off by default and remembers its state.
 
+## Receiver mount heights
+
+BLE distances are **slant ranges** — the straight line through the air — but
+the map is flat. That mismatch costs accuracy twice:
+
+- **In calibration:** two receivers 3 m apart on the map, one on a shelf at
+  0.3 m and one on the ceiling at 2.2 m, are really **3.55 m** apart. Judged
+  against the flat 3 m, that pair reads "18% long" and the fit bakes the
+  phantom error into the receivers' corrections — shrinking **all** their
+  distances during tracking.
+- **In tracking:** a ceiling probe at 2.5 m reading 1.6 m to the person right
+  below it is really ~0.6 m away horizontally (with the beacon carried at
+  ~1 m). The inflated circle drags the fix toward nowhere — and it's worst on
+  the **nearest** receivers, exactly the ones the solver trusts most.
+
+Setting a receiver's **mount height** fixes both. Enter it when placing the
+receiver, or later via the **ruler button on its sidebar row** (the current
+value shows as a badge; leave it empty to keep the old flat behaviour):
+
+- Calibration judges each pair against the **true 3D distance** — heights
+  apply when **both** receivers in a pair have one. The Receiver-distances
+  overlay uses the same 3D truth, so changing a height flags its links to
+  other height-set receivers grey ("recalibrate") just like moving the
+  receiver would.
+- During tracking the vertical leg is removed from every reading
+  (`horizontal = √(slant² − Δz²)`) before trilateration, assuming trackers are
+  carried ~1 m above the floor (override with a top-level `"tracker_height"`
+  in `bpsdata.txt`, 0–5 m — e.g. `0.3` if you mostly track a pet; values
+  outside that range fall back to the 1 m default).
+- The **floor election is untouched** — it still compares the calibrated
+  slant ranges, because "which receiver is nearest" must be judged before any
+  floor-specific geometry can be assumed.
+- Alongside this, the solver's inverse-square distance weighting now caps the
+  influence of readings **under 0.5 m** (they are all equally "right here"):
+  previously a spuriously tiny reading could single-handedly own the fix by
+  a million-fold weight. This applies to every setup, heights or not.
+
+**Recalibrate after setting or changing heights**: existing corrections were
+learned against the flat distances and would double-correct otherwise. (The
+panel reminds you, and blocks a calibration Apply while unsaved layout edits
+are pending.)
+
 ---
 
 ## Receivers on the map card

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -19,6 +19,7 @@ from scipy.optimize import least_squares
 import voluptuous as vol
 import logging
 import asyncio
+import math
 import os
 import json
 import re
@@ -95,9 +96,34 @@ KF_MAX_GAP_S = 30.0          # gap beyond which state is reset (tracker was away
 # during movement.
 RADIUS_JUMP_TOL = 0.5
 
+# --- Receiver mount heights (optional per-receiver "height", metres) ---------
+# Bermuda's distance estimates are line-of-sight SLANT ranges, but the map
+# solve is 2D: a ceiling probe reading 2.3 m to a tracker right below it is
+# really ~0.6 m away horizontally. When a receiver's mount height is set in
+# the panel, the vertical leg is removed before trilateration
+# (horizontal = sqrt(slant^2 - dz^2)). Trackers are assumed to be carried at
+# TRACKER_HEIGHT_M above the floor; override with a top-level
+# "tracker_height" (metres) in bpsdata.txt.
+TRACKER_HEIGHT_M = 1.0
+# Slant->horizontal legitimately produces very short radii (tracker nearly
+# under a ceiling probe). The solver's geometric 1/r^2 weight would explode
+# there and let that one receiver dominate the fit, so for WEIGHTING (not for
+# the residual) radii are clamped to this physical minimum, converted to each
+# floor's pixel scale.
+MIN_WEIGHT_RADIUS_M = 0.5
+
 # Per-tracker Kalman state: entity -> {"x": np.array(4), "P": np.array(4,4),
 # "ts": float, "floor": str}. Reset on floor change, long gap, or prune.
 _kf_position_state = {}
+
+
+def _tracker_height(data):
+    """Assumed tracker height above the floor (m); "tracker_height" override."""
+    if isinstance(data, dict):
+        configured = data.get("tracker_height")
+        if isinstance(configured, (int, float)) and 0 <= configured <= 5:
+            return float(configured)
+    return TRACKER_HEIGHT_M
 
 
 def _floor_scale(data, entity, floor_name):
@@ -683,6 +709,7 @@ async def update_receiver_liveness(hass):
 
 async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
+    tracker_h = _tracker_height(eids["data"])
     for floor in (f for f in eids["data"]["floor"] if f["scale"] is not None):
         for receiver in floor["receivers"]:
             entity_id = "sensor." + eids["entity"] + "_distance_to_" + receiver["entity_id"]
@@ -705,10 +732,31 @@ async def update_receiver_radii(hass, eids):
                     correction = receiver.get("correction")
                     if isinstance(correction, (int, float)) and correction > 0:
                         distance = distance * correction
-                    receiver["cords"]["r"] = floor["scale"] * distance
-                    # Raw distance for the floor election: radii are in
+                    # Known mount height: the estimate is a slant range, so
+                    # remove the vertical leg (mount height vs the assumed
+                    # tracker height) to get the horizontal distance the 2D
+                    # solve actually needs. A slant shorter than the vertical
+                    # leg means "practically underneath" — horizontal ~ 0; the
+                    # solver's MIN_WEIGHT_RADIUS_M clamp keeps such a near-zero
+                    # radius from monopolizing the fit. The range guard also
+                    # rejects NaN/Infinity from a hand-edited data file (NaN
+                    # fails both comparisons), which would otherwise poison
+                    # every solve on the floor.
+                    horizontal = distance
+                    height = receiver.get("height")
+                    if isinstance(height, (int, float)) and 0 <= height <= 10:
+                        dz = float(height) - tracker_h
+                        horizontal = math.sqrt(max(distance * distance - dz * dz, 0.0))
+                    receiver["cords"]["r"] = floor["scale"] * horizontal
+                    # Raw SLANT distance for the floor election: radii are in
                     # per-floor pixel scales and must not be compared across
-                    # floors.
+                    # floors — and the dz correction must not leak in here
+                    # either. sqrt(d^2 - dz^2) is only valid when the tracker
+                    # is on the receiver's own floor, which is exactly what
+                    # the election hasn't decided yet: electing on corrected
+                    # values lets a high-mounted probe hearing the tracker
+                    # through the slab shrink its through-floor slant and
+                    # steal the election from the correct floor.
                     receiver["distance"] = distance
                 except ValueError:
                     #_LOGGER.info(f"Invalid numerical value: {rec_value.state}")
@@ -746,17 +794,29 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     # Get previous r-values for this entity
     last_r = update_trilateration_and_zone.last_r_values.get(entity, {})
 
+    # Physical floor for the geometric weight and the jump comparison, in this
+    # floor's pixels. Slant correction (known mount heights) makes near-zero
+    # radii a normal reading, and 1/r^2 must not hand one such receiver the
+    # whole fit.
+    scale = _floor_scale(new_global_data, entity, lowest_floor_name)
+    min_wr = MIN_WEIGHT_RADIUS_M * scale if scale else 1e-3
+
     # Soft radius-jump weighting (replaces the old hard 50% discard). A receiver
     # whose radius jumped versus its previous update is DOWN-WEIGHTED rather than
     # dropped, so the solver keeps enough points to fix a position even while
     # every distance is legitimately changing during movement. The key includes
     # the floor: radii are in per-floor pixel scales, so the same pixel coords on
-    # two floors must not be compared against each other.
+    # two floors must not be compared against each other. Radii are clamped to
+    # the physical minimum for the comparison: slant correction turns noisy
+    # near-readings into exact 0.0, and an untamed 0 <-> nonzero transition is
+    # an infinite relative jump that used to escape the gate entirely (r > 0
+    # guard) and enter the fit fully trusted at maximum geometric weight.
     weighted = []
     for (x, y, r) in filtered_cords:
         prev_r = last_r.get((lowest_floor_name, x, y))
-        if prev_r is not None and prev_r > 0 and r > 0:
-            rel = max(r / prev_r, prev_r / r)  # symmetric relative change, >= 1
+        if prev_r is not None:
+            r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
+            rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
             w = 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
         else:
             w = 1.0  # first sighting on this floor: no basis to distrust it
@@ -783,13 +843,12 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
     floor_bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
 
-    tricords = trilaterate(weighted, bounds=floor_bounds)
+    tricords = trilaterate(weighted, bounds=floor_bounds, min_weight_radius=min_wr)
     if tricords is not None:
         # Constant-velocity Kalman smoothing of the published position. The RAW
         # trilaterated fix feeds the filter (so the estimate is never biased by
         # the zone snapping applied below); the filtered output is clipped to the
         # floor bounds inside the helper.
-        scale = _floor_scale(new_global_data, entity, lowest_floor_name)
         avg_x, avg_y = _kalman_position_update(
             entity, lowest_floor_name, tricords, scale, floor_bounds
         )
@@ -1858,7 +1917,7 @@ class BPSEntityWebSocket:
         _LOGGER.info("All WebSocket commands registered successfully.")
     
 # Trilateration function
-def trilaterate(known_points, bounds=None):
+def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     """Weighted least-squares position fit.
 
     known_points are (x, y, r) or (x, y, r, w) tuples. The optional w is a
@@ -1869,6 +1928,13 @@ def trilaterate(known_points, bounds=None):
     bounds, when given as (minx, miny, maxx, maxy), constrains the solution to
     the floor's extent: the fit then finds the best position WITHIN the map,
     which lands on the boundary when an unconstrained fit would escape it.
+
+    min_weight_radius clamps the radius used in the 1/r^2 WEIGHT (never the
+    residual). Callers pass a physical floor in pixels (MIN_WEIGHT_RADIUS_M x
+    floor scale): a near-zero radius — device at the receiver, or a slant range
+    fully consumed by a known mount height — is an honest reading, but its
+    weight must stay finite or that single receiver decides the whole fit. The
+    default keeps the bare no-scale fallback safe against division by zero.
     """
     num_points = len(known_points)
 
@@ -1884,10 +1950,7 @@ def trilaterate(known_points, bounds=None):
             xi, yi, ri = pt[0], pt[1], pt[2]
             wi = pt[3] if len(pt) > 3 else 1.0
             residuals.append(np.sqrt((xi - x)**2 + (yi - y)**2) - ri)
-            # Clamp the radius for the weight: a 0 reading (device right at
-            # the receiver) must not divide by zero and abort the whole
-            # positioning cycle; sub-millipixel radii are trusted like 1e-3 px.
-            weights.append(wi / max(ri, 1e-3)**2)  # reliability x geometric (1/r^2) weight
+            weights.append(wi / max(ri, min_weight_radius)**2)  # reliability x geometric (1/r^2) weight
         return np.sqrt(np.array(weights)) * np.array(residuals)
 
     # Start from the receiver centroid: it is always a plausible position,

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -244,6 +244,7 @@ def _build_receiver_map(coords, floor_name=None) -> dict:
             cords = receiver.get("cords") or {}
             if receiver.get("entity_id") and cords.get("x") is not None and cords.get("y") is not None:
                 uid = receiver.get("scanner_uid")
+                height = receiver.get("height")
                 receivers[str(receiver["entity_id"])] = {
                     "x": float(cords["x"]),
                     "y": float(cords["y"]),
@@ -252,6 +253,13 @@ def _build_receiver_map(coords, floor_name=None) -> dict:
                     # Hardware identity stored by a panel re-link (issue #64);
                     # lets calibration match the scanner after a rename.
                     "uid": uid if isinstance(uid, str) and uid else None,
+                    # Mount height (m) set in the panel; makes the pair's
+                    # ground-truth distance 3D (see _true_distance_m). The
+                    # range guard also drops NaN/Infinity from a hand-edited
+                    # file (NaN fails both comparisons), which would poison
+                    # true_m and error out every solve on the floor.
+                    "height": float(height)
+                    if isinstance(height, (int, float)) and 0 <= height <= 10 else None,
                 }
     return receivers
 
@@ -396,7 +404,16 @@ def _true_distance_m(cal: dict, slug_a: str, slug_b: str):
     b = cal["receivers"].get(slug_b)
     if not a or not b or _normalize(a["floor"]) != _normalize(b["floor"]) or not a["scale"]:
         return None
-    return math.hypot(a["x"] - b["x"], a["y"] - b["y"]) / a["scale"]
+    horizontal = math.hypot(a["x"] - b["x"], a["y"] - b["y"]) / a["scale"]
+    # Known mount heights make the truth 3D: the probes' adverts travel the
+    # slant path, so judging them against the flat map distance reads pure
+    # geometry as RSSI bias — a 0.3 m vs 2.2 m pair 3 m apart on the map is
+    # really 3.55 m apart, an 18% phantom error the fit would otherwise bake
+    # into that receiver's correction. Applied only when BOTH heights are set;
+    # a lone height says nothing about the pair's geometry.
+    if a.get("height") is not None and b.get("height") is not None:
+        return math.hypot(horizontal, a["height"] - b["height"])
+    return horizontal
 
 
 def solve(cal: dict, floor_name: str):

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -105,6 +105,18 @@ canvas {
 }
 .bps-modal-msg { font-size: 14px; line-height: 1.5; margin-bottom: 18px; }
 .bps-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+/* Numeric input of bpsPromptNumber (receiver mount height). */
+.bps-modal-input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 18px;
+    padding: 8px 10px;
+    font-size: 14px;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+}
 .bps-btn-danger { background: #d32f2f; color: #ffffff; }
 .bps-btn-danger:hover { background: #b71c1c; }
 .bps-toast-host {
@@ -112,7 +124,9 @@ canvas {
     bottom: 24px;
     left: 50%;
     transform: translateX(-50%);
-    z-index: 2000;
+    /* Above .bps-modal-overlay (2000): modal validation toasts must not
+       render dimmed underneath the backdrop. */
+    z-index: 2100;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -3058,6 +3072,20 @@ select.bps-input { cursor: pointer; }
 .bps-zone-group li.bps-rec-focused:hover {
     background: hsl(var(--sidebar-accent));
     box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
+/* Mount-height badge on a receiver row (set via the ruler button). The border
+   keeps the pill legible on hovered/focused rows, whose background is the
+   same --sidebar-accent the badge fill uses. */
+.bps-rec-height {
+    flex: 0 0 auto;
+    padding: 0 6px;
+    font-size: 11px;
+    line-height: 16px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--sidebar-accent));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    white-space: nowrap;
 }
 .bps-icon-btn {
     flex: 0 0 auto;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -102,7 +102,7 @@
                                         <span>Receiver distances</span>
                                     </label>
                                     <span class="tooltip">❓
-                                        <span class="tooltip-text">Lines link receivers that measure each other. Colour = distance error (see legend); grey dashed = moved, recalibrate. Hover a line or receiver to read its detected (real) distance. The options below limit the count, filter by colour, and switch the detected distance between calibrated and raw. Click a line/pill to isolate, a receiver for its links.</span>
+                                        <span class="tooltip-text">Lines link receivers that measure each other. Colour = distance error (see legend); grey dashed = moved, recalibrate. Hover a line or receiver to read its detected (real) distance. The options below limit the count, filter by colour, and switch the detected distance between calibrated and raw. Click a line/pill to isolate, a receiver for its links. When both receivers have a mount height set (ruler button in the sidebar), the real distance is the true 3D distance between them.</span>
                                     </span>
                                 </span>
                                 <!-- Distance lines only make sense while tracking, so this control

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -231,6 +231,90 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
+    // A modal with one numeric input. Resolves to the entered number, to null
+    // when the value is cleared (empty Save), or to undefined on cancel/Esc.
+    // Used for the receiver mount height.
+    function bpsPromptNumber(message, opts = {}) {
+        const { initial = "", placeholder = "", min = 0, max = 10, confirmText = "Save" } = opts;
+        return new Promise(resolve => {
+            const overlay = document.createElement("div");
+            overlay.className = "bps-modal-overlay";
+            const dialog = document.createElement("div");
+            dialog.className = "bps-modal";
+            const msg = document.createElement("div");
+            msg.className = "bps-modal-msg";
+            msg.textContent = message;
+            const input = document.createElement("input");
+            input.type = "number";
+            input.className = "bps-modal-input";
+            input.step = "0.1";
+            input.min = String(min);
+            input.max = String(max);
+            input.placeholder = placeholder;
+            if (initial !== "" && Number.isFinite(initial)) input.value = String(initial);
+            const row = document.createElement("div");
+            row.className = "bps-modal-actions";
+            const cancelBtn = document.createElement("button");
+            cancelBtn.type = "button";
+            cancelBtn.className = "bps-btn bps-btn-outline";
+            cancelBtn.textContent = "Cancel";
+            const okBtn = document.createElement("button");
+            okBtn.type = "button";
+            okBtn.className = "bps-btn bps-btn-primary";
+            okBtn.textContent = confirmText;
+            row.appendChild(cancelBtn);
+            row.appendChild(okBtn);
+            dialog.appendChild(msg);
+            dialog.appendChild(input);
+            dialog.appendChild(row);
+            overlay.appendChild(dialog);
+            document.body.appendChild(overlay);
+            const openedAt = Date.now();
+            const close = (val) => {
+                overlay.remove();
+                document.removeEventListener("keydown", onKey);
+                resolve(val);
+            };
+            const commit = () => {
+                // Unparsable content in a number input reads back as "" but
+                // sets validity.badInput — it must fail validation, not be
+                // mistaken for "cleared" and silently unset the stored value.
+                if (input.validity.badInput) {
+                    bpsToast(`Enter a number between ${min} and ${max}.`);
+                    input.focus();
+                    return;                                 // keep the modal open
+                }
+                const raw = input.value.trim();
+                if (raw === "") { close(null); return; }   // cleared = unset
+                const v = parseFloat(raw);
+                if (!Number.isFinite(v) || v < min || v > max) {
+                    bpsToast(`Enter a number between ${min} and ${max}.`);
+                    input.focus();
+                    return;                                 // keep the modal open
+                }
+                close(v);
+            };
+            cancelBtn.addEventListener("click", () => close(undefined));
+            okBtn.addEventListener("click", commit);
+            // Backdrop click cancels — but not within the opening instant: the
+            // second click of a double-click on the launcher lands on the
+            // overlay and would open-and-instantly-cancel the dialog.
+            overlay.addEventListener("click", (e) => {
+                if (e.target === overlay && Date.now() - openedAt > 300) close(undefined);
+            });
+            function onKey(e) {
+                if (e.key === "Escape") close(undefined);
+                // Enter on the focused Cancel button must cancel, not save.
+                else if (e.key === "Enter") {
+                    if (document.activeElement === cancelBtn) close(undefined);
+                    else commit();
+                }
+            }
+            document.addEventListener("keydown", onKey);
+            input.focus();
+        });
+    }
+
     const createZoneId = () => `zone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let isDrawing = false;
     let SelMapName = "";
@@ -949,6 +1033,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const bySlug = new Map((floor.receivers || [])
             .filter(r => r && r.cords && Number.isFinite(r.cords.x) && Number.isFinite(r.cords.y))
             .map(r => [r.entity_id, r.cords]));
+        // Mount heights (m), for the live 3D truth below. null = not set.
+        const heightBySlug = new Map((floor.receivers || [])
+            .filter(r => r && r.entity_id)
+            .map(r => [r.entity_id, Number.isFinite(r.height) ? r.height : null]));
         // Which detected distance the pill shows and the colour is judged on:
         // "calibrated" = the measured distance after the per-receiver correction
         // (residual error after calibration); "raw" = the uncorrected reading
@@ -987,8 +1075,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             // distance), the whole row is stale: judging the new geometry with
             // the old numbers would flag a placement change as a calibration
             // error. Such links are drawn neutral until the next solve.
-            const liveM = floor.scale
+            // Mount heights make the live truth 3D, matching the backend's
+            // true_m — so setting or changing a height after a solve flags the
+            // link stale (grey, "recalibrate") exactly like moving it would.
+            let liveM = floor.scale
                 ? Math.hypot(A.x - B.x, A.y - B.y) / floor.scale : null;
+            const hA = heightBySlug.get(link.a), hB = heightBySlug.get(link.b);
+            if (liveM !== null && Number.isFinite(hA) && Number.isFinite(hB)) {
+                liveM = Math.hypot(liveM, hA - hB);
+            }
             const stale = liveM !== null
                 && Math.abs(liveM - link.true_m) > Math.max(0.1, 0.02 * link.true_m);
             // Colour, and the filter category taken FROM that same hue so the
@@ -1655,6 +1750,31 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
             return;
         }
+        // Ruler button on a receiver row: set/clear its mount height (m above
+        // this floor). Checked before focusrec so editing never focuses.
+        if (event.target.closest('[data-type="recheight"]')) {
+            const recId = event.target.closest('[data-type="recheight"]').getAttribute('data-id');
+            // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const rec = floor && (floor.receivers || []).find(r => r && r.entity_id === recId);
+            if (!rec) return;
+            bpsPromptNumber(
+                `Mount height of "${recId}" above this floor, in metres (empty = unknown). `
+                + `Used to remove the vertical leg from its distances and to judge calibration `
+                + `against the true 3D distance — recalibrate after changing it.`,
+                { initial: Number.isFinite(rec.height) ? rec.height : "", placeholder: "e.g. 2.2" }
+            ).then(val => {
+                if (val === undefined) return;                       // cancelled
+                if (val === null) delete rec.height; else rec.height = val;
+                savebuttondiv.appendChild(saveButton);               // reveal Save Floor Plan
+                clearCanvas();
+                drawElements();                                      // re-renders the sidebar badge
+                bpsToast(val === null
+                    ? `Height of "${recId}" cleared — Save Floor Plan to keep it, then recalibrate.`
+                    : `Height of "${recId}" set to ${val} m — Save Floor Plan to keep it, then recalibrate.`);
+            });
+            return;
+        }
         // Clicking a receiver row focuses it on the map (only that receiver and
         // its circle stay visible); clicking it again clears the focus. Mirrors
         // clicking the receiver's icon on the map. Checked after removerec so
@@ -2172,6 +2292,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
         const newReceiver = { entity_id: receiverName, cords: tmpcords };
+        // Optional mount height (m). Empty = unknown: distances stay slant
+        // ranges and calibration truth stays 2D, exactly as before.
+        // badInput = unparsable content reading back as "": reject it rather
+        // than silently placing the receiver without the height typed in.
+        if (receiverHeightInput && receiverHeightInput.validity.badInput) {
+            bpsToast("Mount height must be a number between 0 and 10 metres.");
+            return;
+        }
+        const heightRaw = receiverHeightInput ? receiverHeightInput.value.trim() : "";
+        if (heightRaw !== "") {
+            const h = parseFloat(heightRaw);
+            if (!Number.isFinite(h) || h < 0 || h > 10) {
+                bpsToast("Mount height must be a number between 0 and 10 metres.");
+                return;
+            }
+            newReceiver.height = h;
+        }
         // Committing: drop the placement click listener up front. On a duplicate
         // name addDataToFloor itself toasts + resets the UI and returns false, so
         // removing here (not only in the success branch) avoids stranding the
@@ -2566,6 +2703,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let receiverSelect = null;
     let receiverCustomInput = null;
     let receiverSearchInput = null;
+    let receiverHeightInput = null; // optional mount height (m) for the new receiver
     let receiverCancelBtn = null; // X that cancels receiver placement
     let availableReceiverNames = []; // unplaced receiver names, for the search filter
     const CUSTOM_RECEIVER_OPTION = "__custom__";
@@ -2637,6 +2775,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.value = "";
             receiverCustomInput.style.display = "none";
         }
+        if (receiverHeightInput) receiverHeightInput.value = "";
     }
 
     addDeviceButton.addEventListener('click', () => {
@@ -2699,6 +2838,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.classList.add("rec-input");
             receiverCustomInput.style.display = "none";
 
+            // Optional mount height (m above this floor). Bermuda distances
+            // are slant ranges: with the height known, the backend removes the
+            // vertical leg before trilateration and calibration judges the
+            // pair against the true 3D distance. Editable later from the
+            // receiver's row in the Zones & Receivers sidebar.
+            receiverHeightInput = document.createElement("input");
+            receiverHeightInput.type = "number";
+            receiverHeightInput.id = "receiverHeight";
+            receiverHeightInput.placeholder = "Mount height m (optional)";
+            receiverHeightInput.min = "0";
+            receiverHeightInput.max = "10";
+            receiverHeightInput.step = "0.1";
+            receiverHeightInput.title = "Height above this floor the receiver is mounted at, in metres";
+            receiverHeightInput.classList.add("rec-input");
+
             receiverCancelBtn = document.createElement("button");
             receiverCancelBtn.type = "button";
             receiverCancelBtn.textContent = "✕";
@@ -2709,6 +2863,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             entityInput.appendChild(receiverSearchInput);
             entityInput.appendChild(receiverSelect);
             entityInput.appendChild(receiverCustomInput);
+            entityInput.appendChild(receiverHeightInput);
             entityInput.appendChild(receiverCancelBtn);
             document.body.appendChild(entityInput);
             // Populate only on creation; the session-start populate happens
@@ -3652,6 +3807,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         const trashSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>';
         const pencilSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>';
+        // Vertical double-arrow: the receiver mount-height editor.
+        const rulerSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"></path><path d="M8 7l4-4 4 4"></path><path d="M8 17l4 4 4-4"></path></svg>';
         const chevronSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>';
         // Toggle a zone's colour on/off: filled drop = add, slashed circle = remove.
         const colorOnSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor"></circle></svg>';
@@ -3694,8 +3851,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             // circle stay visible), mirroring a click on its icon. The trash
             // button's handler runs first, so removing never focuses.
             const cls = "bps-rec-row" + (r.entity_id === focusedReceiver ? " bps-rec-focused" : "");
+            // Mount height badge + editor. The ruler button prompts for the
+            // height (m above this floor); the badge shows the current value.
+            const hBadge = Number.isFinite(r.height)
+                ? `<span class="bps-rec-height" title="Mount height above this floor">${escHtml(String(r.height))} m</span>` : "";
             return `<li class="${cls}" data-type="focusrec" data-id="${escHtml(r.entity_id)}">`
                 + `<span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
+                + hBadge
+                + `<button class="bps-icon-btn" title="Set mount height (m)" data-type="recheight" data-id="${escHtml(r.entity_id)}">${rulerSvg}</button>`
                 + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
         };
 
@@ -4631,6 +4794,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     calibApply.addEventListener('click', async () => {
+        // Applying reloads bpsdata.txt from disk (below), which would silently
+        // discard any unsaved layout edit (moved receiver, height, zone colour)
+        // while the sidebar kept showing it — the badge and Save button would
+        // lie. Block instead of losing work; heights in particular route users
+        // here ("recalibrate after changing it").
+        if (savebuttondiv.contains(saveButton)) {
+            bpsToast("Save Floor Plan first — applying reloads the floor data and would discard your unsaved edits.");
+            return;
+        }
         try {
             const data = await calibRequest({ action: 'apply', floor: mapname.value });
             bpsToast(`Corrections applied to ${data.applied} receiver(s).`);
@@ -4645,6 +4817,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     calibReset.addEventListener('click', async () => {
         if (!mapname.value) {
             bpsToast('Select a floor first.');
+            return;
+        }
+        // Same reload-from-disk hazard as Apply: don't discard unsaved edits.
+        if (savebuttondiv.contains(saveButton)) {
+            bpsToast("Save Floor Plan first — resetting reloads the floor data and would discard your unsaved edits.");
             return;
         }
         const warning = calibAuto.checked

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.6.0"
+    "version": "1.7.0"
 }


### PR DESCRIPTION
## What

BLE distances are **slant ranges** (straight line through the air) but the map solve is 2D. This PR adds an optional per-receiver **mount height** (metres above its floor) and uses it in the two places where the vertical leg is deterministically recoverable:

### 1. Tracking: slant → horizontal correction
With a height set, the vertical leg is removed from every reading before trilateration: `horizontal = √(slant² − Δz²)`, with trackers assumed carried ~1 m above the floor (top-level `"tracker_height"` in `bpsdata.txt`, 0–5 m, overrides — e.g. `0.3` for a pet). A ceiling probe at 2.5 m reading 1.6 m to the person below it is really ~0.6 m away horizontally; the inflation is worst on the **nearest** receivers, exactly the ones the solver's 1/r² weighting trusts most.

### 2. Calibration: true 3D ground truth
When **both** receivers of a pair have heights, calibration judges them against their true 3D distance. Today a 0.3 m vs 2.2 m pair 3 m apart on the map is really 3.55 m apart — an **18% phantom "measures long"** that the fit misreads as RSSI bias and bakes into a ~0.85 correction, shrinking **all** of that receiver's tracking distances. The receiver-distances overlay computes its live truth in 3D too, so changing a height flags the affected links grey ("recalibrate") exactly like moving the receiver would.

### Deliberately unchanged
The **floor election still compares uncorrected slants**: `√(d² − Δz²)` is only valid if the tracker is on the receiver's own floor — which is precisely what the election hasn't decided yet. Electing on corrected values would let a high-mounted probe hearing the tracker through the slab shrink its through-floor slant and steal the election (caught in adversarial review).

## UI
- Height input in the receiver-placement picker (optional).
- **Ruler button** on each receiver's sidebar row → numeric modal (empty = clear); the value shows as a badge. Save reminds you to save the floor plan and recalibrate.
- Calibration **Apply/Reset now refuse to run over unsaved layout edits** instead of silently reloading them away (pre-existing hazard, promoted by this feature's "recalibrate now" flow).

## Solver safety net (applies to all setups)
- The 1/r² geometric weight now clamps radii to a **physical 0.5 m minimum**: slant correction makes near-zero radii routine, and the old `1e-3 px` clamp let a single such reading own the whole fit by a million-fold weight. Sub-half-metre readings now all count as equally "right here".
- The radius-jump gate compares **clamped** radii, so a 0 ↔ nonzero transition reads as a huge (distrusted) jump instead of escaping the `r > 0` guard at full weight.

## Hardening (from adversarial review, 17 findings fixed)
- Heights outside 0–10 m rejected everywhere — including `NaN`/`Infinity` from a hand-edited file, which would otherwise kill every solve on the floor (NaN) or hijack every election (Infinity).
- Modal: unparsable input no longer mistaken for "clear"; double-click can't open-and-instantly-cancel; Enter on a focused Cancel cancels; validation toasts render above the overlay.
- Height badge stays legible on hovered/focused rows.

## Verification
- 24 regression tests against the real modules (HA stubbed): slant math, election-on-slant, tracker-height override & garbage rejection, NaN/inf heights, 3D vs 2D calibration truth, weight-clamp equalization, zero-radius survival.
- Full browser-harness pass: placement with height, ruler modal set/clear/validation flows, badge rendering, stale-flip of overlay links when heights change (pixel-verified), zero console errors.

**After setting or changing heights: recalibrate.** Existing corrections were learned against flat distances and would double-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)