### PR TITLE
Floor election by hypothesis competition (v1.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,37 @@ learned against the flat distances and would double-correct otherwise. (The
 panel reminds you, and blocks a calibration Apply while unsaved layout edits
 are pending.)
 
+## Floor election by hypothesis competition
+
+Which floor a tracker is on used to be decided by **one number**: the floor
+of the single receiver reporting the smallest distance. BLE passes straight
+through ceilings, so one noisy reading from the floor above could steal the
+tracker for a cycle — the kitchen ↔ bedroom flapping of
+[#94](https://github.com/maxi1134/BPS-improved/issues/94).
+
+The election is now a **competition between floors**, each judged on how
+well it explains *all* of its receivers (the way ESPresense scores its
+per-floor scenarios) instead of on a single loudest reading:
+
+- Each cycle, the nearest floors that have **at least three receivers
+  hearing the tracker** are each solved (the incumbent floor always defends
+  its title when it can solve), and each fit is scored by how well the
+  position agrees with **every reporting receiver on that floor** (weighted
+  residual, in metres, corrected for receiver count) plus how many receivers
+  corroborate it. A through-ceiling reading fits one receiver and
+  contradicts the rest — it scores poorly.
+- Scores feed **smoothed per-floor probabilities**. A challenger must lead
+  the incumbent for **several consecutive cycles** before the floor
+  switches (~3 s when you really change floors), and a cycle where the
+  incumbent floor briefly drops below three receivers simply **holds the
+  last position** instead of handing the tracker to whoever else was
+  solvable that instant. A single blip no longer flaps the floor, the
+  published zone, or the position filter.
+- The probabilities are published per tracker (`floors` in
+  `/api/bps/cords`), so "why did it pick this floor" is now inspectable.
+- Bonus: a tracker heard by too few receivers on the nearest floor but by
+  three or more on another now gets a position instead of none.
+
 ---
 
 ## Receivers on the map card

--- a/README.md
+++ b/README.md
@@ -556,6 +556,48 @@ links) stands out of the mesh.
 - Unlike the two toggles above it needs **no active tracking session**; it is
   off by default and remembers its state.
 
+## Receiver mount heights
+
+BLE distances are **slant ranges** — the straight line through the air — but
+the map is flat. That mismatch costs accuracy twice:
+
+- **In calibration:** two receivers 3 m apart on the map, one on a shelf at
+  0.3 m and one on the ceiling at 2.2 m, are really **3.55 m** apart. Judged
+  against the flat 3 m, that pair reads "18% long" and the fit bakes the
+  phantom error into the receivers' corrections — shrinking **all** their
+  distances during tracking.
+- **In tracking:** a ceiling probe at 2.5 m reading 1.6 m to the person right
+  below it is really ~0.6 m away horizontally (with the beacon carried at
+  ~1 m). The inflated circle drags the fix toward nowhere — and it's worst on
+  the **nearest** receivers, exactly the ones the solver trusts most.
+
+Setting a receiver's **mount height** fixes both. Enter it when placing the
+receiver, or later via the **ruler button on its sidebar row** (the current
+value shows as a badge; leave it empty to keep the old flat behaviour):
+
+- Calibration judges each pair against the **true 3D distance** — heights
+  apply when **both** receivers in a pair have one. The Receiver-distances
+  overlay uses the same 3D truth, so changing a height flags its links to
+  other height-set receivers grey ("recalibrate") just like moving the
+  receiver would.
+- During tracking the vertical leg is removed from every reading
+  (`horizontal = √(slant² − Δz²)`) before trilateration, assuming trackers are
+  carried ~1 m above the floor (override with a top-level `"tracker_height"`
+  in `bpsdata.txt`, 0–5 m — e.g. `0.3` if you mostly track a pet; values
+  outside that range fall back to the 1 m default).
+- The **floor election is untouched** — it still compares the calibrated
+  slant ranges, because "which receiver is nearest" must be judged before any
+  floor-specific geometry can be assumed.
+- Alongside this, the solver's inverse-square distance weighting now caps the
+  influence of readings **under 0.5 m** (they are all equally "right here"):
+  previously a spuriously tiny reading could single-handedly own the fix by
+  a million-fold weight. This applies to every setup, heights or not.
+
+**Recalibrate after setting or changing heights**: existing corrections were
+learned against the flat distances and would double-correct otherwise. (The
+panel reminds you, and blocks a calibration Apply while unsaved layout edits
+are pending.)
+
 ---
 
 ## Receivers on the map card

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -19,6 +19,7 @@ from scipy.optimize import least_squares
 import voluptuous as vol
 import logging
 import asyncio
+import math
 import os
 import json
 import re
@@ -95,9 +96,34 @@ KF_MAX_GAP_S = 30.0          # gap beyond which state is reset (tracker was away
 # during movement.
 RADIUS_JUMP_TOL = 0.5
 
+# --- Receiver mount heights (optional per-receiver "height", metres) ---------
+# Bermuda's distance estimates are line-of-sight SLANT ranges, but the map
+# solve is 2D: a ceiling probe reading 2.3 m to a tracker right below it is
+# really ~0.6 m away horizontally. When a receiver's mount height is set in
+# the panel, the vertical leg is removed before trilateration
+# (horizontal = sqrt(slant^2 - dz^2)). Trackers are assumed to be carried at
+# TRACKER_HEIGHT_M above the floor; override with a top-level
+# "tracker_height" (metres) in bpsdata.txt.
+TRACKER_HEIGHT_M = 1.0
+# Slant->horizontal legitimately produces very short radii (tracker nearly
+# under a ceiling probe). The solver's geometric 1/r^2 weight would explode
+# there and let that one receiver dominate the fit, so for WEIGHTING (not for
+# the residual) radii are clamped to this physical minimum, converted to each
+# floor's pixel scale.
+MIN_WEIGHT_RADIUS_M = 0.5
+
 # Per-tracker Kalman state: entity -> {"x": np.array(4), "P": np.array(4,4),
 # "ts": float, "floor": str}. Reset on floor change, long gap, or prune.
 _kf_position_state = {}
+
+
+def _tracker_height(data):
+    """Assumed tracker height above the floor (m); "tracker_height" override."""
+    if isinstance(data, dict):
+        configured = data.get("tracker_height")
+        if isinstance(configured, (int, float)) and 0 <= configured <= 5:
+            return float(configured)
+    return TRACKER_HEIGHT_M
 
 
 def _floor_scale(data, entity, floor_name):
@@ -683,6 +709,7 @@ async def update_receiver_liveness(hass):
 
 async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
+    tracker_h = _tracker_height(eids["data"])
     for floor in (f for f in eids["data"]["floor"] if f["scale"] is not None):
         for receiver in floor["receivers"]:
             entity_id = "sensor." + eids["entity"] + "_distance_to_" + receiver["entity_id"]
@@ -705,10 +732,31 @@ async def update_receiver_radii(hass, eids):
                     correction = receiver.get("correction")
                     if isinstance(correction, (int, float)) and correction > 0:
                         distance = distance * correction
-                    receiver["cords"]["r"] = floor["scale"] * distance
-                    # Raw distance for the floor election: radii are in
+                    # Known mount height: the estimate is a slant range, so
+                    # remove the vertical leg (mount height vs the assumed
+                    # tracker height) to get the horizontal distance the 2D
+                    # solve actually needs. A slant shorter than the vertical
+                    # leg means "practically underneath" — horizontal ~ 0; the
+                    # solver's MIN_WEIGHT_RADIUS_M clamp keeps such a near-zero
+                    # radius from monopolizing the fit. The range guard also
+                    # rejects NaN/Infinity from a hand-edited data file (NaN
+                    # fails both comparisons), which would otherwise poison
+                    # every solve on the floor.
+                    horizontal = distance
+                    height = receiver.get("height")
+                    if isinstance(height, (int, float)) and 0 <= height <= 10:
+                        dz = float(height) - tracker_h
+                        horizontal = math.sqrt(max(distance * distance - dz * dz, 0.0))
+                    receiver["cords"]["r"] = floor["scale"] * horizontal
+                    # Raw SLANT distance for the floor election: radii are in
                     # per-floor pixel scales and must not be compared across
-                    # floors.
+                    # floors — and the dz correction must not leak in here
+                    # either. sqrt(d^2 - dz^2) is only valid when the tracker
+                    # is on the receiver's own floor, which is exactly what
+                    # the election hasn't decided yet: electing on corrected
+                    # values lets a high-mounted probe hearing the tracker
+                    # through the slab shrink its through-floor slant and
+                    # steal the election from the correct floor.
                     receiver["distance"] = distance
                 except ValueError:
                     #_LOGGER.info(f"Invalid numerical value: {rec_value.state}")
@@ -746,17 +794,29 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     # Get previous r-values for this entity
     last_r = update_trilateration_and_zone.last_r_values.get(entity, {})
 
+    # Physical floor for the geometric weight and the jump comparison, in this
+    # floor's pixels. Slant correction (known mount heights) makes near-zero
+    # radii a normal reading, and 1/r^2 must not hand one such receiver the
+    # whole fit.
+    scale = _floor_scale(new_global_data, entity, lowest_floor_name)
+    min_wr = MIN_WEIGHT_RADIUS_M * scale if scale else 1e-3
+
     # Soft radius-jump weighting (replaces the old hard 50% discard). A receiver
     # whose radius jumped versus its previous update is DOWN-WEIGHTED rather than
     # dropped, so the solver keeps enough points to fix a position even while
     # every distance is legitimately changing during movement. The key includes
     # the floor: radii are in per-floor pixel scales, so the same pixel coords on
-    # two floors must not be compared against each other.
+    # two floors must not be compared against each other. Radii are clamped to
+    # the physical minimum for the comparison: slant correction turns noisy
+    # near-readings into exact 0.0, and an untamed 0 <-> nonzero transition is
+    # an infinite relative jump that used to escape the gate entirely (r > 0
+    # guard) and enter the fit fully trusted at maximum geometric weight.
     weighted = []
     for (x, y, r) in filtered_cords:
         prev_r = last_r.get((lowest_floor_name, x, y))
-        if prev_r is not None and prev_r > 0 and r > 0:
-            rel = max(r / prev_r, prev_r / r)  # symmetric relative change, >= 1
+        if prev_r is not None:
+            r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
+            rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
             w = 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
         else:
             w = 1.0  # first sighting on this floor: no basis to distrust it
@@ -783,13 +843,12 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
     floor_bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
 
-    tricords = trilaterate(weighted, bounds=floor_bounds)
+    tricords = trilaterate(weighted, bounds=floor_bounds, min_weight_radius=min_wr)
     if tricords is not None:
         # Constant-velocity Kalman smoothing of the published position. The RAW
         # trilaterated fix feeds the filter (so the estimate is never biased by
         # the zone snapping applied below); the filtered output is clipped to the
         # floor bounds inside the helper.
-        scale = _floor_scale(new_global_data, entity, lowest_floor_name)
         avg_x, avg_y = _kalman_position_update(
             entity, lowest_floor_name, tricords, scale, floor_bounds
         )
@@ -1858,7 +1917,7 @@ class BPSEntityWebSocket:
         _LOGGER.info("All WebSocket commands registered successfully.")
     
 # Trilateration function
-def trilaterate(known_points, bounds=None):
+def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     """Weighted least-squares position fit.
 
     known_points are (x, y, r) or (x, y, r, w) tuples. The optional w is a
@@ -1869,6 +1928,13 @@ def trilaterate(known_points, bounds=None):
     bounds, when given as (minx, miny, maxx, maxy), constrains the solution to
     the floor's extent: the fit then finds the best position WITHIN the map,
     which lands on the boundary when an unconstrained fit would escape it.
+
+    min_weight_radius clamps the radius used in the 1/r^2 WEIGHT (never the
+    residual). Callers pass a physical floor in pixels (MIN_WEIGHT_RADIUS_M x
+    floor scale): a near-zero radius — device at the receiver, or a slant range
+    fully consumed by a known mount height — is an honest reading, but its
+    weight must stay finite or that single receiver decides the whole fit. The
+    default keeps the bare no-scale fallback safe against division by zero.
     """
     num_points = len(known_points)
 
@@ -1884,10 +1950,7 @@ def trilaterate(known_points, bounds=None):
             xi, yi, ri = pt[0], pt[1], pt[2]
             wi = pt[3] if len(pt) > 3 else 1.0
             residuals.append(np.sqrt((xi - x)**2 + (yi - y)**2) - ri)
-            # Clamp the radius for the weight: a 0 reading (device right at
-            # the receiver) must not divide by zero and abort the whole
-            # positioning cycle; sub-millipixel radii are trusted like 1e-3 px.
-            weights.append(wi / max(ri, 1e-3)**2)  # reliability x geometric (1/r^2) weight
+            weights.append(wi / max(ri, min_weight_radius)**2)  # reliability x geometric (1/r^2) weight
         return np.sqrt(np.array(weights)) * np.array(residuals)
 
     # Start from the receiver centroid: it is always a plausible position,

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -112,6 +112,30 @@ TRACKER_HEIGHT_M = 1.0
 # floor's pixel scale.
 MIN_WEIGHT_RADIUS_M = 0.5
 
+# --- Floor election by hypothesis competition ---------------------------------
+# The floor used to be elected by the single nearest receiver — one noisy
+# reading through a ceiling could steal the tracker for a cycle (kitchen <->
+# bedroom flapping, issue #94). Now every plausible floor is SOLVED and
+# SCORED: the fit's agreement with all of that floor's receivers feeds a
+# smoothed per-floor probability, and the elected floor only changes when a
+# challenger clearly and persistently outscores the incumbent.
+FLOOR_CANDIDATES = 3         # solve at most this many floors per cycle
+FLOOR_PROB_SMOOTHING = 0.7   # EMA weight on the previous probability
+FLOOR_SWITCH_MARGIN = 0.05   # probability lead that starts/keeps a challenge
+FLOOR_SWITCH_CYCLES = 3      # consecutive leading cycles before the floor switches
+FLOOR_DARK_GRACE_CYCLES = 3  # cycles a dark incumbent holds everything frozen
+FLOOR_RESIDUAL_SCALE_M = 2.0 # weighted RMS residual (m) at which fit quality = 0.5
+COVERAGE_TARGET_N = 5.0      # heard receivers at which the coverage term saturates
+
+# Per-tracker election state, all reset when the tracker is pruned:
+# smoothed floor probabilities (entity -> {floor name: P}), the pending
+# challenge (a floor out-scoring the incumbent, counted per cycle: entity ->
+# {"floor": name, "count": n}), and how many consecutive cycles the incumbent
+# floor has been dark (unsolvable) while a competitor solved.
+_floor_probability = {}
+_floor_challenge = {}
+_floor_dark_cycles = {}
+
 # Per-tracker Kalman state: entity -> {"x": np.array(4), "P": np.array(4,4),
 # "ts": float, "floor": str}. Reset on floor change, long gap, or prune.
 _kf_position_state = {}
@@ -766,84 +790,186 @@ async def update_receiver_radii(hass, eids):
                 pass
 
 async def update_trilateration_and_zone(hass, new_global_data, entity):
-    """Trilateration with soft radius-jump weighting and Kalman position smoothing."""
+    """Trilateration with floor hypothesis competition, soft radius-jump
+    weighting and Kalman position smoothing.
+
+    The floor used to be elected by the single nearest receiver before any
+    position existed — one noisy reading through a ceiling could steal the
+    tracker for a cycle (issue #94). Now the top FLOOR_CANDIDATES floors (by
+    nearest receiver) are each SOLVED, scored by how well the fix explains
+    that floor's whole receiver ensemble, folded into smoothed per-floor
+    probabilities, and elected with incumbent hysteresis. The winning floor's
+    fix continues into the unchanged Kalman/zone/publish pipeline.
+    """
     global apitricords
 
     # Store last r-values per sensor and entity (for soft radius-jump weighting).
     if not hasattr(update_trilateration_and_zone, "last_r_values"):
         update_trilateration_and_zone.last_r_values = {}
+    if not hasattr(update_trilateration_and_zone, "last_floor"):
+        update_trilateration_and_zone.last_floor = {}
 
-    lowest_floor_name, filtered_cords = extract_floor_and_receivers(new_global_data, entity)
-    # filtered_cords: list of (x, y, r)
+    candidates = extract_candidate_floors(new_global_data, entity)
 
-    if lowest_floor_name is None:
+    if not candidates:
         # No receiver reports any distance for this device: it is out of
         # range. The zone/floor sensors keep their last value (historical
         # behavior), but nearest-zone explicitly reports unknown.
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", "unknown")
         return
 
-    if not hasattr(update_trilateration_and_zone, "last_floor"):
-        update_trilateration_and_zone.last_floor = {}
+    # Get previous r-values for this entity
+    last_r = update_trilateration_and_zone.last_r_values.get(entity, {})
+
+    # Remember radii for EVERY floor with data — not only the ones solved
+    # below — so a floor stays jump-gated even while unelected or briefly
+    # pushed out of the candidate cut (keys include the floor: radii are in
+    # per-floor pixel scales and must not be compared across floors).
+    new_last_r = {}
+    for cand in candidates:
+        new_last_r.update({(cand["name"], x, y): r for (x, y, r) in cand["cords"]})
+
+    incumbent = update_trilateration_and_zone.last_floor.get(entity)
+
+    # Only floors with enough receivers to trilaterate compete for the solve
+    # slots: an unsolvable floor whose single through-slab receiver reads
+    # short must not consume a slot and push the only solvable floor out.
+    # The incumbent, when solvable, ALWAYS defends its title — even ranked
+    # below the cut — so nearest-slant noise alone can never evict it.
+    solvable = [c for c in candidates if len(c["cords"]) >= 3]
+    to_solve = solvable[:FLOOR_CANDIDATES]
+    if incumbent is not None and not any(c["name"] == incumbent for c in to_solve):
+        inc_cand = next((c for c in solvable if c["name"] == incumbent), None)
+        if inc_cand is not None:
+            to_solve.append(inc_cand)
+
+    solved = {}  # floor name -> everything the publish pipeline needs
+    for cand in to_solve:
+        floor_name, cords = cand["name"], cand["cords"]
+
+        # Physical floor for the geometric weight and the jump comparison, in
+        # this floor's pixels. Slant correction (known mount heights) makes
+        # near-zero radii a normal reading, and 1/r^2 must not hand one such
+        # receiver the whole fit.
+        scale = _floor_scale(new_global_data, entity, floor_name)
+        min_wr = MIN_WEIGHT_RADIUS_M * scale if scale else 1e-3
+
+        # Soft radius-jump weighting (replaces the old hard 50% discard). A
+        # receiver whose radius jumped versus its previous update is
+        # DOWN-WEIGHTED rather than dropped, so the solver keeps enough points
+        # to fix a position even while every distance is legitimately changing
+        # during movement. Radii are clamped to the physical minimum for the
+        # comparison: slant correction turns noisy near-readings into exact
+        # 0.0, and an untamed 0 <-> nonzero transition is an infinite relative
+        # jump that used to escape the gate entirely (r > 0 guard) and enter
+        # the fit fully trusted at maximum geometric weight.
+        weighted = []
+        for (x, y, r) in cords:
+            prev_r = last_r.get((floor_name, x, y))
+            if prev_r is not None:
+                r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
+                rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
+                w = 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
+            else:
+                w = 1.0  # first sighting on this floor: no basis to distrust it
+            weighted.append((x, y, r, w))
+
+        # The device cannot be outside the floor: bound the solver to the
+        # extent of the floor's receivers and zones (with some margin) so the
+        # fitted position is the best point WITHIN the map, not a runaway fix
+        # that would need clamping afterwards.
+        zone_polys = list(_floor_zone_polygons(new_global_data, entity, floor_name))
+        xs = [p[0] for p in weighted]
+        ys = [p[1] for p in weighted]
+        for _zone_id, polygon, _buffer_size in zone_polys:
+            minx, miny, maxx, maxy = polygon.bounds
+            xs.extend((minx, maxx))
+            ys.extend((miny, maxy))
+        margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+        floor_bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
+
+        fix = trilaterate(weighted, bounds=floor_bounds, min_weight_radius=min_wr)
+        if fix is None:
+            continue  # this floor's readings don't converge; not a contender
+        conf, rms_m, coverage = _score_floor_fit(fix, weighted, scale)
+        solved[floor_name] = {
+            "fix": fix,
+            "weighted": weighted,
+            "bounds": floor_bounds,
+            "zone_polys": zone_polys,
+            "scale": scale,
+            "conf": conf,
+        }
+
+    # Store current r-values for next time
+    update_trilateration_and_zone.last_r_values[entity] = new_last_r
+
+    if not solved:
+        # No candidate floor has three converging receivers (historical
+        # behavior: sensors keep their last value until pruned).
+        return
+
+    valid_floors = {
+        f["name"]
+        for e in new_global_data if e["entity"] == entity
+        for f in e["data"]["floor"]
+    }
+
+    # The elected floor was renamed or deleted in the data file: that is a
+    # change of world, not a dark blip — routing it into the grace below
+    # would freeze the ghost name for the grace period and then elect
+    # whichever OTHER floor inherited the stale probability mass. Reset the
+    # whole election state instead (exactly like a prune), so this cycle's
+    # fresh scores elect the renamed floor immediately.
+    if incumbent is not None and incumbent not in valid_floors:
+        _floor_probability.pop(entity, None)
+        _floor_challenge.pop(entity, None)
+        _floor_dark_cycles.pop(entity, None)
+        update_trilateration_and_zone.last_floor.pop(entity, None)
+        incumbent = None
+
+    # Dark-incumbent grace: the elected floor blipping below three receivers
+    # (or its solve failing) for a few cycles is a sensor hiccup, not
+    # evidence the tracker moved — hold everything frozen: last published
+    # values stand, probabilities are NOT updated (a competitor must not
+    # accumulate election lead from the incumbent's blind cycles), and no
+    # other floor inherits incumbency by forfeit. Only a disappearance
+    # longer than the grace lapses the incumbency, and then the best solved
+    # floor is adopted on its merits.
+    if incumbent is not None and incumbent not in solved \
+            and incumbent in _floor_probability.get(entity, {}):
+        dark = _floor_dark_cycles.get(entity, 0) + 1
+        if dark <= FLOOR_DARK_GRACE_CYCLES:
+            _floor_dark_cycles[entity] = dark
+            return
+        incumbent = None  # dark beyond grace: incumbency lapses
+    _floor_dark_cycles.pop(entity, None)
+    probs = _update_floor_probabilities(
+        entity, {f: s["conf"] for f, s in solved.items()}, valid_floors
+    )
+    lowest_floor_name, challenge = _elect_floor(
+        probs, incumbent, solved, _floor_challenge.get(entity)
+    )
+    if challenge is None:
+        _floor_challenge.pop(entity, None)
+    else:
+        _floor_challenge[entity] = challenge
+    if lowest_floor_name is None:
+        return  # nothing electable this cycle: keep last values
+
     if update_trilateration_and_zone.last_floor.get(entity) != lowest_floor_name:
         # The Kalman state holds pixel coordinates in the previously elected
         # floor's map space; it must not carry over to the newly elected floor.
         _kf_position_state.pop(entity, None)
         update_trilateration_and_zone.last_floor[entity] = lowest_floor_name
 
-    # Get previous r-values for this entity
-    last_r = update_trilateration_and_zone.last_r_values.get(entity, {})
+    elected = solved[lowest_floor_name]
+    weighted = elected["weighted"]
+    zone_polys = elected["zone_polys"]
+    floor_bounds = elected["bounds"]
+    scale = elected["scale"]
+    tricords = elected["fix"]
 
-    # Physical floor for the geometric weight and the jump comparison, in this
-    # floor's pixels. Slant correction (known mount heights) makes near-zero
-    # radii a normal reading, and 1/r^2 must not hand one such receiver the
-    # whole fit.
-    scale = _floor_scale(new_global_data, entity, lowest_floor_name)
-    min_wr = MIN_WEIGHT_RADIUS_M * scale if scale else 1e-3
-
-    # Soft radius-jump weighting (replaces the old hard 50% discard). A receiver
-    # whose radius jumped versus its previous update is DOWN-WEIGHTED rather than
-    # dropped, so the solver keeps enough points to fix a position even while
-    # every distance is legitimately changing during movement. The key includes
-    # the floor: radii are in per-floor pixel scales, so the same pixel coords on
-    # two floors must not be compared against each other. Radii are clamped to
-    # the physical minimum for the comparison: slant correction turns noisy
-    # near-readings into exact 0.0, and an untamed 0 <-> nonzero transition is
-    # an infinite relative jump that used to escape the gate entirely (r > 0
-    # guard) and enter the fit fully trusted at maximum geometric weight.
-    weighted = []
-    for (x, y, r) in filtered_cords:
-        prev_r = last_r.get((lowest_floor_name, x, y))
-        if prev_r is not None:
-            r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
-            rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
-            w = 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
-        else:
-            w = 1.0  # first sighting on this floor: no basis to distrust it
-        weighted.append((x, y, r, w))
-
-    # Store current r-values for next time
-    update_trilateration_and_zone.last_r_values[entity] = {(lowest_floor_name, x, y): r for (x, y, r) in filtered_cords}
-
-    if len(weighted) < 3:
-        # Too few receivers reporting for trilateration
-        return
-
-    # The device cannot be outside the floor: bound the solver to the extent
-    # of the floor's receivers and zones (with some margin) so the fitted
-    # position is the best point WITHIN the map, not a runaway fix that would
-    # need clamping afterwards.
-    zone_polys = list(_floor_zone_polygons(new_global_data, entity, lowest_floor_name))
-    xs = [p[0] for p in weighted]
-    ys = [p[1] for p in weighted]
-    for _zone_id, polygon, _buffer_size in zone_polys:
-        minx, miny, maxx, maxy = polygon.bounds
-        xs.extend((minx, maxx))
-        ys.extend((miny, maxy))
-    margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
-    floor_bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
-
-    tricords = trilaterate(weighted, bounds=floor_bounds, min_weight_radius=min_wr)
     if tricords is not None:
         # Constant-velocity Kalman smoothing of the published position. The RAW
         # trilaterated fix feeds the filter (so the estimate is never biased by
@@ -879,6 +1005,9 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
                 # The exact solver input (post-correction, post-filter), for
                 # the panel's trilateration circles.
                 "radii": [[float(px), float(py), float(pr)] for (px, py, pr, _w) in weighted],
+                # Smoothed floor-election probabilities, for debugging "why
+                # did it pick this floor" (issue #94).
+                "floors": {f: round(p, 3) for f, p in probs.items()},
                 "updated": time.time(),
             },
         )
@@ -895,6 +1024,7 @@ def update_or_add_entry(data, new_entry):
             item["zone"] = new_entry["zone"]  # Update "zone"
             item["floor"] = new_entry["floor"]  # Floor the fix belongs to
             item["radii"] = new_entry["radii"]  # Solver input, for circles
+            item["floors"] = new_entry["floors"]  # Election probabilities
             item["updated"] = new_entry["updated"]  # Freshness for pruning
             return data
 
@@ -924,8 +1054,19 @@ async def prune_stale_positions(hass):
     await update_apitricords(hass, apitricords)
     for ent in sorted(stale_ents):
         # Drop the Kalman state too: a returning tracker should re-seed fresh
-        # rather than predict velocity across the whole absence.
+        # rather than predict velocity across the whole absence. Same for the
+        # whole election state — probabilities, pending challenge, and the
+        # INCUMBENCY itself: it may well come back on another floor, and an
+        # hours-stale incumbent must not enjoy hysteresis against it (with
+        # freshly-reset probabilities the margin could pin the wrong floor
+        # indefinitely). Jump-gate radii from before the absence are equally
+        # meaningless.
         _kf_position_state.pop(ent, None)
+        _floor_probability.pop(ent, None)
+        _floor_challenge.pop(ent, None)
+        _floor_dark_cycles.pop(ent, None)
+        getattr(update_trilateration_and_zone, "last_floor", {}).pop(ent, None)
+        getattr(update_trilateration_and_zone, "last_r_values", {}).pop(ent, None)
         _LOGGER.info("Tracker %s not seen for %ss; clearing its position", ent, timeout)
         update_bps_sensor_state(hass, f"sensor.{ent}_bps_zone", "unknown")
         update_bps_sensor_state(hass, f"sensor.{ent}_bps_floor", "unknown")
@@ -961,38 +1102,132 @@ async def process_entities(hass, new_global_data):
     tasks = [process_single_entity(hass, new_global_data, eids) for eids in new_global_data]
     await asyncio.gather(*tasks)  # Run all entities in parallel, but maintain the correct internal order
 
-def extract_floor_and_receivers(new_global_data, tmpentity):
-    """Pick the floor of the physically closest receiver, then collect that floor's cords.
+def extract_candidate_floors(new_global_data, tmpentity):
+    """Every floor hearing the tracker, ranked by its nearest receiver.
 
-    The election compares raw distances (meters), not radii: radii are scaled
-    into each floor's own pixel space, so comparing them across floors would
-    let the floor with the smallest scale win regardless of where the tracker
-    actually is. Ties (the same receiver placed on several floors) go to the
-    floor listed first in the data file.
+    Returns a list of {"name", "cords": [(x, y, r), ...], "placed", "nearest_m"}
+    sorted by nearest_m. The ranking compares raw slant distances (meters),
+    not radii: radii are scaled into each floor's own pixel space, so
+    comparing them across floors would let the floor with the smallest scale
+    win regardless of where the tracker actually is. Ties (the same receiver
+    placed on several floors) keep the data file's floor order. Each floor's
+    cords feed that floor's own candidate solve — cords from different floors
+    live in different pixel coordinate systems and never mix.
     """
-    lowest_floor, lowest_distance = None, float("inf")
-
+    candidates = []
     for entity in new_global_data:
-        if entity["entity"] == tmpentity:
-            for floor in entity["data"]["floor"]:
-                for receiver in floor["receivers"]:
-                    distance = receiver.get("distance")
-                    if distance is None or "r" not in receiver.get("cords", {}):
-                        continue
-                    if distance < lowest_distance:
-                        lowest_distance, lowest_floor = distance, floor
+        if entity["entity"] != tmpentity:
+            continue
+        for floor in entity["data"]["floor"]:
+            nearest, cords = float("inf"), []
+            for receiver in floor["receivers"]:
+                distance = receiver.get("distance")
+                if distance is None or "r" not in receiver.get("cords", {}):
+                    continue
+                nearest = min(nearest, distance)
+                cords.append((receiver["cords"]["x"], receiver["cords"]["y"], receiver["cords"]["r"]))
+            if cords:
+                candidates.append({
+                    "name": floor["name"],
+                    "cords": cords,
+                    "nearest_m": nearest,
+                })
+    candidates.sort(key=lambda c: c["nearest_m"])  # stable: file order breaks ties
+    return candidates
 
-    if lowest_floor is None:
-        return None, []
 
-    # Only the winning floor's receivers feed the trilateration: cords from
-    # different floors live in different pixel coordinate systems.
-    filtered_cords = [
-        (receiver["cords"]["x"], receiver["cords"]["y"], receiver["cords"]["r"])
-        for receiver in lowest_floor["receivers"]
-        if "r" in receiver.get("cords", {})
-    ]
-    return lowest_floor["name"], filtered_cords
+def _score_floor_fit(fix, weighted, scale):
+    """Score one candidate floor's solve. Returns (confidence, rms_m, coverage).
+
+    Confidence blends how well the fix explains ALL of the floor's reporting
+    receivers (weighted RMS residual, converted to metres so floors with
+    different pixel scales compare fairly) with how many receivers corroborate
+    it. Modelled on ESPresense's scenario confidence (fit quality + node
+    coverage): the tracker's true floor tends to explain its whole receiver
+    ensemble, while a wrong floor fits one loud through-slab reading and
+    contradicts the rest.
+    """
+    x, y = fix
+    n = len(weighted)
+    num = den = 0.0
+    for (xi, yi, ri, wi) in weighted:
+        res = math.hypot(xi - x, yi - y) - ri
+        num += wi * res * res
+        den += wi
+    rms_px = math.sqrt(num / den) if den > 0 else float("inf")
+    # Reduced-chi-square-style correction: a 3-receiver floor fits the 2
+    # position unknowns almost perfectly no matter what (a single residual
+    # degree of freedom), which flatters exactly the floors with the least
+    # evidence. Inflate by sqrt(n / (n - 2)) so fits compete on evidence.
+    rms_px *= math.sqrt(n / max(n - 2.0, 1.0))
+    rms_m = rms_px / scale if scale else rms_px
+    quality = 1.0 / (1.0 + (rms_m / FLOOR_RESIDUAL_SCALE_M) ** 2)
+    # Corroboration: how many receivers hear the tracker on this floor,
+    # saturating at COVERAGE_TARGET_N. An absolute count, NOT a share of the
+    # floor's placed receivers: a dead or unmatched placement must not
+    # handicap its floor forever, and a tiny fully-reporting 3-receiver floor
+    # must not out-cover a floor with 6 of 8 receivers reporting.
+    coverage = min(1.0, n / COVERAGE_TARGET_N)
+    return 0.5 * coverage + 0.5 * quality, rms_m, coverage
+
+
+def _update_floor_probabilities(entity, scores, valid_floors=None):
+    """Fold this cycle's per-floor confidences into smoothed probabilities.
+
+    Each floor's probability moves 1-FLOOR_PROB_SMOOTHING of the way toward
+    its share of this cycle's total confidence; floors with no data this
+    cycle decay toward zero and are dropped once negligible, so the dict
+    cannot grow unbounded. Floors no longer present in the data file
+    (renamed/deleted) are dropped immediately — a ghost name must not hold
+    probability mass nor appear in the published election. Returns a
+    normalized copy.
+    """
+    probs = _floor_probability.setdefault(entity, {})
+    if valid_floors is not None:
+        for floor in [f for f in probs if f not in valid_floors]:
+            del probs[floor]
+    total = sum(scores.values())
+    for floor in set(probs) | set(scores):
+        target = (scores.get(floor, 0.0) / total) if total > 0 else 0.0
+        probs[floor] = FLOOR_PROB_SMOOTHING * probs.get(floor, 0.0) \
+            + (1.0 - FLOOR_PROB_SMOOTHING) * target
+    for floor in [f for f, p in probs.items() if p < 0.01]:
+        del probs[floor]
+    norm = sum(probs.values())
+    if norm > 0:
+        for floor in probs:
+            probs[floor] /= norm
+    return dict(probs)
+
+
+def _elect_floor(probs, incumbent, solved, challenge):
+    """Pick the floor to publish. Returns (floor, challenge_state).
+
+    The caller guarantees the incumbent is either solved this cycle or None
+    (a dark incumbent is handled by the grace hold upstream, and one dark
+    beyond the grace loses its standing entirely — incumbency is never
+    transferred by forfeit, it lapses).
+
+    A solved incumbent only loses to a challenger that leads its probability
+    by FLOOR_SWITCH_MARGIN for FLOOR_SWITCH_CYCLES consecutive cycles
+    (challenge_state carries the count between cycles). The small margin
+    filters share noise, the dwell filters single-cycle geometry flukes, and
+    together they cannot permanently dead-band a genuinely better floor the
+    way a large margin alone would — floor flapping was the disease
+    (issue #94), a stuck wrong floor must not be the cure.
+    """
+    contenders = {f: p for f, p in probs.items() if f in solved}
+    if not contenders:
+        return None, None
+    best = max(contenders, key=contenders.get)
+    if incumbent is None or incumbent not in contenders:
+        return best, None  # no standing incumbent: adopt the best immediately
+    if best == incumbent or contenders[best] - contenders[incumbent] < FLOOR_SWITCH_MARGIN:
+        return incumbent, None
+    count = challenge["count"] + 1 if challenge and challenge.get("floor") == best else 1
+    if count >= FLOOR_SWITCH_CYCLES:
+        return best, None
+    return incumbent, {"floor": best, "count": count}
 
 def _floor_zone_polygons(data, entity, floor_name):
     """Yield (zone entity_id, polygon, buffer_size) for the entity's floor."""

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -244,6 +244,7 @@ def _build_receiver_map(coords, floor_name=None) -> dict:
             cords = receiver.get("cords") or {}
             if receiver.get("entity_id") and cords.get("x") is not None and cords.get("y") is not None:
                 uid = receiver.get("scanner_uid")
+                height = receiver.get("height")
                 receivers[str(receiver["entity_id"])] = {
                     "x": float(cords["x"]),
                     "y": float(cords["y"]),
@@ -252,6 +253,13 @@ def _build_receiver_map(coords, floor_name=None) -> dict:
                     # Hardware identity stored by a panel re-link (issue #64);
                     # lets calibration match the scanner after a rename.
                     "uid": uid if isinstance(uid, str) and uid else None,
+                    # Mount height (m) set in the panel; makes the pair's
+                    # ground-truth distance 3D (see _true_distance_m). The
+                    # range guard also drops NaN/Infinity from a hand-edited
+                    # file (NaN fails both comparisons), which would poison
+                    # true_m and error out every solve on the floor.
+                    "height": float(height)
+                    if isinstance(height, (int, float)) and 0 <= height <= 10 else None,
                 }
     return receivers
 
@@ -396,7 +404,16 @@ def _true_distance_m(cal: dict, slug_a: str, slug_b: str):
     b = cal["receivers"].get(slug_b)
     if not a or not b or _normalize(a["floor"]) != _normalize(b["floor"]) or not a["scale"]:
         return None
-    return math.hypot(a["x"] - b["x"], a["y"] - b["y"]) / a["scale"]
+    horizontal = math.hypot(a["x"] - b["x"], a["y"] - b["y"]) / a["scale"]
+    # Known mount heights make the truth 3D: the probes' adverts travel the
+    # slant path, so judging them against the flat map distance reads pure
+    # geometry as RSSI bias — a 0.3 m vs 2.2 m pair 3 m apart on the map is
+    # really 3.55 m apart, an 18% phantom error the fit would otherwise bake
+    # into that receiver's correction. Applied only when BOTH heights are set;
+    # a lone height says nothing about the pair's geometry.
+    if a.get("height") is not None and b.get("height") is not None:
+        return math.hypot(horizontal, a["height"] - b["height"])
+    return horizontal
 
 
 def solve(cal: dict, floor_name: str):

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -105,6 +105,18 @@ canvas {
 }
 .bps-modal-msg { font-size: 14px; line-height: 1.5; margin-bottom: 18px; }
 .bps-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+/* Numeric input of bpsPromptNumber (receiver mount height). */
+.bps-modal-input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 18px;
+    padding: 8px 10px;
+    font-size: 14px;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+}
 .bps-btn-danger { background: #d32f2f; color: #ffffff; }
 .bps-btn-danger:hover { background: #b71c1c; }
 .bps-toast-host {
@@ -112,7 +124,9 @@ canvas {
     bottom: 24px;
     left: 50%;
     transform: translateX(-50%);
-    z-index: 2000;
+    /* Above .bps-modal-overlay (2000): modal validation toasts must not
+       render dimmed underneath the backdrop. */
+    z-index: 2100;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -3058,6 +3072,20 @@ select.bps-input { cursor: pointer; }
 .bps-zone-group li.bps-rec-focused:hover {
     background: hsl(var(--sidebar-accent));
     box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
+/* Mount-height badge on a receiver row (set via the ruler button). The border
+   keeps the pill legible on hovered/focused rows, whose background is the
+   same --sidebar-accent the badge fill uses. */
+.bps-rec-height {
+    flex: 0 0 auto;
+    padding: 0 6px;
+    font-size: 11px;
+    line-height: 16px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--sidebar-accent));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    white-space: nowrap;
 }
 .bps-icon-btn {
     flex: 0 0 auto;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -102,7 +102,7 @@
                                         <span>Receiver distances</span>
                                     </label>
                                     <span class="tooltip">❓
-                                        <span class="tooltip-text">Lines link receivers that measure each other. Colour = distance error (see legend); grey dashed = moved, recalibrate. Hover a line or receiver to read its detected (real) distance. The options below limit the count, filter by colour, and switch the detected distance between calibrated and raw. Click a line/pill to isolate, a receiver for its links.</span>
+                                        <span class="tooltip-text">Lines link receivers that measure each other. Colour = distance error (see legend); grey dashed = moved, recalibrate. Hover a line or receiver to read its detected (real) distance. The options below limit the count, filter by colour, and switch the detected distance between calibrated and raw. Click a line/pill to isolate, a receiver for its links. When both receivers have a mount height set (ruler button in the sidebar), the real distance is the true 3D distance between them.</span>
                                     </span>
                                 </span>
                                 <!-- Distance lines only make sense while tracking, so this control

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -231,6 +231,90 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
+    // A modal with one numeric input. Resolves to the entered number, to null
+    // when the value is cleared (empty Save), or to undefined on cancel/Esc.
+    // Used for the receiver mount height.
+    function bpsPromptNumber(message, opts = {}) {
+        const { initial = "", placeholder = "", min = 0, max = 10, confirmText = "Save" } = opts;
+        return new Promise(resolve => {
+            const overlay = document.createElement("div");
+            overlay.className = "bps-modal-overlay";
+            const dialog = document.createElement("div");
+            dialog.className = "bps-modal";
+            const msg = document.createElement("div");
+            msg.className = "bps-modal-msg";
+            msg.textContent = message;
+            const input = document.createElement("input");
+            input.type = "number";
+            input.className = "bps-modal-input";
+            input.step = "0.1";
+            input.min = String(min);
+            input.max = String(max);
+            input.placeholder = placeholder;
+            if (initial !== "" && Number.isFinite(initial)) input.value = String(initial);
+            const row = document.createElement("div");
+            row.className = "bps-modal-actions";
+            const cancelBtn = document.createElement("button");
+            cancelBtn.type = "button";
+            cancelBtn.className = "bps-btn bps-btn-outline";
+            cancelBtn.textContent = "Cancel";
+            const okBtn = document.createElement("button");
+            okBtn.type = "button";
+            okBtn.className = "bps-btn bps-btn-primary";
+            okBtn.textContent = confirmText;
+            row.appendChild(cancelBtn);
+            row.appendChild(okBtn);
+            dialog.appendChild(msg);
+            dialog.appendChild(input);
+            dialog.appendChild(row);
+            overlay.appendChild(dialog);
+            document.body.appendChild(overlay);
+            const openedAt = Date.now();
+            const close = (val) => {
+                overlay.remove();
+                document.removeEventListener("keydown", onKey);
+                resolve(val);
+            };
+            const commit = () => {
+                // Unparsable content in a number input reads back as "" but
+                // sets validity.badInput — it must fail validation, not be
+                // mistaken for "cleared" and silently unset the stored value.
+                if (input.validity.badInput) {
+                    bpsToast(`Enter a number between ${min} and ${max}.`);
+                    input.focus();
+                    return;                                 // keep the modal open
+                }
+                const raw = input.value.trim();
+                if (raw === "") { close(null); return; }   // cleared = unset
+                const v = parseFloat(raw);
+                if (!Number.isFinite(v) || v < min || v > max) {
+                    bpsToast(`Enter a number between ${min} and ${max}.`);
+                    input.focus();
+                    return;                                 // keep the modal open
+                }
+                close(v);
+            };
+            cancelBtn.addEventListener("click", () => close(undefined));
+            okBtn.addEventListener("click", commit);
+            // Backdrop click cancels — but not within the opening instant: the
+            // second click of a double-click on the launcher lands on the
+            // overlay and would open-and-instantly-cancel the dialog.
+            overlay.addEventListener("click", (e) => {
+                if (e.target === overlay && Date.now() - openedAt > 300) close(undefined);
+            });
+            function onKey(e) {
+                if (e.key === "Escape") close(undefined);
+                // Enter on the focused Cancel button must cancel, not save.
+                else if (e.key === "Enter") {
+                    if (document.activeElement === cancelBtn) close(undefined);
+                    else commit();
+                }
+            }
+            document.addEventListener("keydown", onKey);
+            input.focus();
+        });
+    }
+
     const createZoneId = () => `zone_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let isDrawing = false;
     let SelMapName = "";
@@ -949,6 +1033,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const bySlug = new Map((floor.receivers || [])
             .filter(r => r && r.cords && Number.isFinite(r.cords.x) && Number.isFinite(r.cords.y))
             .map(r => [r.entity_id, r.cords]));
+        // Mount heights (m), for the live 3D truth below. null = not set.
+        const heightBySlug = new Map((floor.receivers || [])
+            .filter(r => r && r.entity_id)
+            .map(r => [r.entity_id, Number.isFinite(r.height) ? r.height : null]));
         // Which detected distance the pill shows and the colour is judged on:
         // "calibrated" = the measured distance after the per-receiver correction
         // (residual error after calibration); "raw" = the uncorrected reading
@@ -987,8 +1075,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             // distance), the whole row is stale: judging the new geometry with
             // the old numbers would flag a placement change as a calibration
             // error. Such links are drawn neutral until the next solve.
-            const liveM = floor.scale
+            // Mount heights make the live truth 3D, matching the backend's
+            // true_m — so setting or changing a height after a solve flags the
+            // link stale (grey, "recalibrate") exactly like moving it would.
+            let liveM = floor.scale
                 ? Math.hypot(A.x - B.x, A.y - B.y) / floor.scale : null;
+            const hA = heightBySlug.get(link.a), hB = heightBySlug.get(link.b);
+            if (liveM !== null && Number.isFinite(hA) && Number.isFinite(hB)) {
+                liveM = Math.hypot(liveM, hA - hB);
+            }
             const stale = liveM !== null
                 && Math.abs(liveM - link.true_m) > Math.max(0.1, 0.02 * link.true_m);
             // Colour, and the filter category taken FROM that same hue so the
@@ -1655,6 +1750,31 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
             return;
         }
+        // Ruler button on a receiver row: set/clear its mount height (m above
+        // this floor). Checked before focusrec so editing never focuses.
+        if (event.target.closest('[data-type="recheight"]')) {
+            const recId = event.target.closest('[data-type="recheight"]').getAttribute('data-id');
+            // A stale sidebar (e.g. after Clear Canvas) must not fake a save.
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const rec = floor && (floor.receivers || []).find(r => r && r.entity_id === recId);
+            if (!rec) return;
+            bpsPromptNumber(
+                `Mount height of "${recId}" above this floor, in metres (empty = unknown). `
+                + `Used to remove the vertical leg from its distances and to judge calibration `
+                + `against the true 3D distance — recalibrate after changing it.`,
+                { initial: Number.isFinite(rec.height) ? rec.height : "", placeholder: "e.g. 2.2" }
+            ).then(val => {
+                if (val === undefined) return;                       // cancelled
+                if (val === null) delete rec.height; else rec.height = val;
+                savebuttondiv.appendChild(saveButton);               // reveal Save Floor Plan
+                clearCanvas();
+                drawElements();                                      // re-renders the sidebar badge
+                bpsToast(val === null
+                    ? `Height of "${recId}" cleared — Save Floor Plan to keep it, then recalibrate.`
+                    : `Height of "${recId}" set to ${val} m — Save Floor Plan to keep it, then recalibrate.`);
+            });
+            return;
+        }
         // Clicking a receiver row focuses it on the map (only that receiver and
         // its circle stay visible); clicking it again clears the focus. Mirrors
         // clicking the receiver's icon on the map. Checked after removerec so
@@ -2172,6 +2292,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
         const newReceiver = { entity_id: receiverName, cords: tmpcords };
+        // Optional mount height (m). Empty = unknown: distances stay slant
+        // ranges and calibration truth stays 2D, exactly as before.
+        // badInput = unparsable content reading back as "": reject it rather
+        // than silently placing the receiver without the height typed in.
+        if (receiverHeightInput && receiverHeightInput.validity.badInput) {
+            bpsToast("Mount height must be a number between 0 and 10 metres.");
+            return;
+        }
+        const heightRaw = receiverHeightInput ? receiverHeightInput.value.trim() : "";
+        if (heightRaw !== "") {
+            const h = parseFloat(heightRaw);
+            if (!Number.isFinite(h) || h < 0 || h > 10) {
+                bpsToast("Mount height must be a number between 0 and 10 metres.");
+                return;
+            }
+            newReceiver.height = h;
+        }
         // Committing: drop the placement click listener up front. On a duplicate
         // name addDataToFloor itself toasts + resets the UI and returns false, so
         // removing here (not only in the success branch) avoids stranding the
@@ -2566,6 +2703,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let receiverSelect = null;
     let receiverCustomInput = null;
     let receiverSearchInput = null;
+    let receiverHeightInput = null; // optional mount height (m) for the new receiver
     let receiverCancelBtn = null; // X that cancels receiver placement
     let availableReceiverNames = []; // unplaced receiver names, for the search filter
     const CUSTOM_RECEIVER_OPTION = "__custom__";
@@ -2637,6 +2775,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.value = "";
             receiverCustomInput.style.display = "none";
         }
+        if (receiverHeightInput) receiverHeightInput.value = "";
     }
 
     addDeviceButton.addEventListener('click', () => {
@@ -2699,6 +2838,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             receiverCustomInput.classList.add("rec-input");
             receiverCustomInput.style.display = "none";
 
+            // Optional mount height (m above this floor). Bermuda distances
+            // are slant ranges: with the height known, the backend removes the
+            // vertical leg before trilateration and calibration judges the
+            // pair against the true 3D distance. Editable later from the
+            // receiver's row in the Zones & Receivers sidebar.
+            receiverHeightInput = document.createElement("input");
+            receiverHeightInput.type = "number";
+            receiverHeightInput.id = "receiverHeight";
+            receiverHeightInput.placeholder = "Mount height m (optional)";
+            receiverHeightInput.min = "0";
+            receiverHeightInput.max = "10";
+            receiverHeightInput.step = "0.1";
+            receiverHeightInput.title = "Height above this floor the receiver is mounted at, in metres";
+            receiverHeightInput.classList.add("rec-input");
+
             receiverCancelBtn = document.createElement("button");
             receiverCancelBtn.type = "button";
             receiverCancelBtn.textContent = "✕";
@@ -2709,6 +2863,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             entityInput.appendChild(receiverSearchInput);
             entityInput.appendChild(receiverSelect);
             entityInput.appendChild(receiverCustomInput);
+            entityInput.appendChild(receiverHeightInput);
             entityInput.appendChild(receiverCancelBtn);
             document.body.appendChild(entityInput);
             // Populate only on creation; the session-start populate happens
@@ -3652,6 +3807,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         const trashSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>';
         const pencilSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>';
+        // Vertical double-arrow: the receiver mount-height editor.
+        const rulerSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"></path><path d="M8 7l4-4 4 4"></path><path d="M8 17l4 4 4-4"></path></svg>';
         const chevronSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>';
         // Toggle a zone's colour on/off: filled drop = add, slashed circle = remove.
         const colorOnSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor"></circle></svg>';
@@ -3694,8 +3851,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             // circle stay visible), mirroring a click on its icon. The trash
             // button's handler runs first, so removing never focuses.
             const cls = "bps-rec-row" + (r.entity_id === focusedReceiver ? " bps-rec-focused" : "");
+            // Mount height badge + editor. The ruler button prompts for the
+            // height (m above this floor); the badge shows the current value.
+            const hBadge = Number.isFinite(r.height)
+                ? `<span class="bps-rec-height" title="Mount height above this floor">${escHtml(String(r.height))} m</span>` : "";
             return `<li class="${cls}" data-type="focusrec" data-id="${escHtml(r.entity_id)}">`
                 + `<span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
+                + hBadge
+                + `<button class="bps-icon-btn" title="Set mount height (m)" data-type="recheight" data-id="${escHtml(r.entity_id)}">${rulerSvg}</button>`
                 + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
         };
 
@@ -4631,6 +4794,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     calibApply.addEventListener('click', async () => {
+        // Applying reloads bpsdata.txt from disk (below), which would silently
+        // discard any unsaved layout edit (moved receiver, height, zone colour)
+        // while the sidebar kept showing it — the badge and Save button would
+        // lie. Block instead of losing work; heights in particular route users
+        // here ("recalibrate after changing it").
+        if (savebuttondiv.contains(saveButton)) {
+            bpsToast("Save Floor Plan first — applying reloads the floor data and would discard your unsaved edits.");
+            return;
+        }
         try {
             const data = await calibRequest({ action: 'apply', floor: mapname.value });
             bpsToast(`Corrections applied to ${data.applied} receiver(s).`);
@@ -4645,6 +4817,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     calibReset.addEventListener('click', async () => {
         if (!mapname.value) {
             bpsToast('Select a floor first.');
+            return;
+        }
+        // Same reload-from-disk hazard as Apply: don't discard unsaved edits.
+        if (savebuttondiv.contains(saveButton)) {
+            bpsToast("Save Floor Plan first — resetting reloads the floor data and would discard your unsaved edits.");
             return;
         }
         const warning = calibAuto.checked

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.0"
+    "version": "1.8.0"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.6.0"
+    "version": "1.7.0"
 }


### PR DESCRIPTION
> **Merge order:** based on #99 (receiver heights) — merge that first; this PR then shows only its own diff.

## The problem (#94)

Which floor a tracker is on was decided by **one number**: the floor of the single receiver reporting the smallest distance, chosen *before any position existed*. BLE passes straight through ceilings, so one noisy reading from the floor above stole the tracker for a cycle — the kitchen ↔ bedroom flapping of #94. No hysteresis, no second opinion.

## The mechanism

Instead of trusting one loud reading, every plausible floor now **competes** (the idea behind ESPresense's per-floor scenarios — the part of their design that actually works, unlike solved-Z):

- **Candidates:** every floor hearing the tracker with ≥ 3 receivers, ranked by nearest receiver. The nearest few are each **solved**; the incumbent floor always defends its title when it can solve, even when ranked below the cut.
- **Scoring:** each fit is judged by how well the position explains **all** of that floor's reporting receivers — DOF-corrected weighted RMS residual (in metres, so different pixel scales compare fairly) — plus how many receivers corroborate it (an absolute count, so a dead or unmatched placement can't handicap its floor forever). A through-slab reading fits one receiver and contradicts the rest: it scores poorly.
- **Election:** scores feed smoothed per-floor probabilities. A challenger must lead the incumbent by a margin for **3 consecutive cycles** before the floor switches (~5 s on a genuine move). A cycle where the incumbent floor blips below three receivers **holds everything frozen** (up to 3 cycles) instead of handing the tracker to whoever else happened to solve that instant — incumbency is never transferred by forfeit, it lapses.
- **Visibility:** the per-floor probabilities are published per tracker (`floors` in `/api/bps/cords`), so "why did it pick this floor" is finally inspectable.
- **Bonus:** a tracker heard by only 2 receivers on the nearest floor but by 3+ on another now gets a position instead of none.

## Lifecycle correctness (from adversarial review)

Two review rounds produced **16 confirmed findings, all fixed** — the important ones:
- Pruning an absent tracker clears the **whole** election state including the incumbency and jump-gate radii (an hours-stale incumbent must not enjoy hysteresis against a fresh return — it could have pinned the wrong floor indefinitely).
- The switch threshold was redesigned from a large probability margin (mathematically unreachable in 2-floor homes → permanent wrong-floor lock-in) to small-margin + dwell.
- Unsolvable floors can't consume candidate slots; jump-gate memory survives candidate-rank churn in 4+ floor homes.
- Renaming the elected floor resets the election instead of masquerading as a sensor blip and electing the *other* floor from stale probability mass.

## Verification

31 stubbed-module regression tests drive the real `update_trilateration_and_zone` across cycles: the through-slab thief loses on cycle 1, single blips cause zero movement and zero Kalman resets, persistent moves switch and stay switched, rank churn / dead placements / rename / prune / out-of-range paths all covered. A scenario walk confirmed switch latency ~5 s on a real floor change and first-cycle correct election after an absence.

Groundwork for #60: a no-go zone hit can slot into this scoring as a per-floor penalty instead of an ad-hoc override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)