### PR TITLE
No-go zones: dead space a tracker can't occupy (v1.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,31 @@ per-floor scenarios) instead of on a single loudest reading:
 - Bonus: a tracker heard by too few receivers on the nearest floor but by
   three or more on another now gets a position instead of none.
 
+## No-go zones
+
+Some spots on an upper floor are physically impossible: the upper footprint
+of a **double-height foyer or great room open to the floor below**. Nothing
+can stand there — but the downstairs receivers hear a beacon in that shared
+air just fine, so the upper floor sometimes "wins" it and the tracker hovers
+in mid-air over the void
+([#60](https://github.com/maxi1134/BPS-improved/issues/60)).
+
+Mark such a zone **no-go** with the no-entry button on its row in the Zones &
+Receivers sidebar. It draws as **grey hatched dead space** on the map, and in
+tracking it:
+
+- **Down-weights the floor whose fit lands in it.** Because the floor
+  election is now a [competition](#floor-election-by-hypothesis-competition),
+  a no-go hit just makes that floor score poorly — so the floor where the
+  same spot is a real room (the one open below) wins on its merits. No
+  hard-coded override, and it rides the same anti-flap smoothing.
+- **Never strands a tracker.** If the no-go floor is the *only* one that can
+  solve (nobody downstairs hears the beacon), it still gets a position — the
+  point is just **snapped out** of the dead space to the nearest real room,
+  and the zone sensors never report the no-go zone.
+
+Marking a zone no-go changes only tracking; it doesn't need a recalibration.
+
 ---
 
 ## Receivers on the map card

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -127,6 +127,23 @@ FLOOR_DARK_GRACE_CYCLES = 3  # cycles a dark incumbent holds everything frozen
 FLOOR_RESIDUAL_SCALE_M = 2.0 # weighted RMS residual (m) at which fit quality = 0.5
 COVERAGE_TARGET_N = 5.0      # heard receivers at which the coverage term saturates
 
+# No-go zones (issue #60): areas a tracker can't physically be — the upper
+# footprint of a double-height foyer/great room open to the floor below.
+# When a floor's fit lands in one of its no-go zones the fit is impossible on
+# THAT floor, so its election confidence is multiplied down: the competition
+# then prefers the floor where the same spot is a real room (the open space
+# means that floor's receivers already hear the tracker and solve it as a
+# candidate). The penalty only DOWN-WEIGHTS — a no-go floor that is the sole
+# candidate still wins and its position is snapped out to the nearest allowed
+# zone — so a tracker is never left position-less.
+NO_GO_CONF_PENALTY = 0.15
+# When snapping a fix out of dead space, grow the no-go footprint by this many
+# pixels before subtracting it from the allowed region, so the snap target's
+# boundary sits clear of the (boundary-inclusive) no-go edge rather than
+# exactly on it — otherwise the snapped point still reads as "in the no-go
+# zone" to covers()-based tests.
+NO_GO_SNAP_MARGIN_PX = 3.0
+
 # Per-tracker election state, all reset when the tracker is pruned:
 # smoothed floor probabilities (entity -> {floor name: P}), the pending
 # challenge (a floor out-scoring the incumbent, counted per cycle: entity ->
@@ -881,7 +898,7 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
         zone_polys = list(_floor_zone_polygons(new_global_data, entity, floor_name))
         xs = [p[0] for p in weighted]
         ys = [p[1] for p in weighted]
-        for _zone_id, polygon, _buffer_size in zone_polys:
+        for _zone_id, polygon, _buffer_size, _no_go in zone_polys:
             minx, miny, maxx, maxy = polygon.bounds
             xs.extend((minx, maxx))
             ys.extend((miny, maxy))
@@ -892,6 +909,12 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
         if fix is None:
             continue  # this floor's readings don't converge; not a contender
         conf, rms_m, coverage = _score_floor_fit(fix, weighted, scale)
+        # A fit landing in this floor's no-go zone is physically impossible
+        # here (issue #60): down-weight it so the competition prefers the
+        # floor where that spot is a real room. Down-weight, not eliminate —
+        # a sole candidate still wins and is snapped out below.
+        if _point_in_no_go(fix, zone_polys):
+            conf *= NO_GO_CONF_PENALTY
         solved[floor_name] = {
             "fix": fix,
             "weighted": weighted,
@@ -1230,7 +1253,13 @@ def _elect_floor(probs, incumbent, solved, challenge):
     return incumbent, {"floor": best, "count": count}
 
 def _floor_zone_polygons(data, entity, floor_name):
-    """Yield (zone entity_id, polygon, buffer_size) for the entity's floor."""
+    """Yield (zone entity_id, polygon, buffer_size, no_go) for the floor.
+
+    no_go marks a zone a tracker can't be in (issue #60). Callers keep no-go
+    zones for the solver bounds (they still bound the floor) but exclude them
+    from zone assignment and snapping — a fix must never be reported as, or
+    snapped into, dead space.
+    """
     buffer_percent = 0.05  # set to 5%
 
     def order_zone_points(coords):
@@ -1283,13 +1312,34 @@ def _floor_zone_polygons(data, entity, floor_name):
                         width = max(xs) - min(xs)
                         height = max(ys) - min(ys)
                         buffer_size = ((width + height) / 2) * buffer_percent
-                        yield zone["entity_id"], polygon, buffer_size
+                        yield zone["entity_id"], polygon, buffer_size, bool(zone.get("no_go"))
+
+
+def _point_in_no_go(point, zone_polys):
+    """True if the point falls strictly inside any no-go zone in zone_polys.
+
+    zone_polys is the (zone_id, polygon, buffer_size, no_go) list from
+    _floor_zone_polygons. Accepts a shapely Point or an (x, y) pair. Uses
+    strict containment (not boundary-inclusive covers): a no-go zone's edge is
+    typically a physical railing, and a tracker genuinely ON the walkway there
+    sits on that boundary — it must not be penalised as if over the void.
+    """
+    if not isinstance(point, Point):
+        point = Point(float(point[0]), float(point[1]))
+    return any(no_go and polygon.contains(point)
+               for _zone_id, polygon, _buffer_size, no_go in zone_polys)
 
 
 def find_zone_for_point(data, entity, floor_name, point):
-    """Find zone for point, prioritize correct polygon, select nearest buffer if no correct zone matches."""
+    """Find zone for point, prioritize correct polygon, select nearest buffer if no correct zone matches.
+
+    No-go zones (issue #60) are skipped: a tracker can't be in one, so a fix
+    there is reported as belonging to the nearest real zone (or "unknown").
+    """
     buffer_candidates = []
-    for zone_id, polygon, buffer_size in _floor_zone_polygons(data, entity, floor_name):
+    for zone_id, polygon, buffer_size, no_go in _floor_zone_polygons(data, entity, floor_name):
+        if no_go:
+            continue
         # covers() also matches points on the polygon boundary.
         if polygon.covers(point):
             return zone_id  # Prioritize correct polygon
@@ -1305,19 +1355,43 @@ def find_zone_for_point(data, entity, floor_name, point):
 
 
 def snap_point_into_zones(zone_polys, point):
-    """Project a point outside every zone onto the nearest zone boundary.
+    """Project a point onto valid (allowed, non-no-go) space.
 
-    Returns the snapped Point, or None when the point is already inside a
-    zone (or the floor has no zones) and should be used as-is.
+    Returns the snapped Point, or None when the point is already in valid
+    space (or there is nowhere valid to put it). No-go zones (issue #60) are
+    subtracted from the allowed region — grown by NO_GO_SNAP_MARGIN_PX first —
+    so a fix in dead space is pushed to the nearest genuinely-allowed point,
+    clear of the boundary-inclusive no-go edge. This holds even when a no-go
+    zone is drawn overlapping or nested inside an allowed room (subtraction
+    carves the void out of the room), and when the floor's only zones are
+    no-go (the point is at least pushed off the dead-space footprint).
     """
-    polygons = [polygon for _zone_id, polygon, _buffer_size in zone_polys]
-    if not polygons:
-        return None
-    union = unary_union(polygons)
-    if union.is_empty or union.covers(point):
-        return None
-    snapped, _ = nearest_points(union, point)
-    return snapped
+    allowed = [polygon for _zone_id, polygon, _buffer_size, no_go in zone_polys if not no_go]
+    nogo = [polygon for _zone_id, polygon, _buffer_size, no_go in zone_polys if no_go]
+    nogo_union = unary_union(nogo) if nogo else None
+    nogo_blocks = nogo_union is not None and not nogo_union.is_empty
+
+    valid = None
+    if allowed:
+        valid = unary_union(allowed)
+        if nogo_blocks:
+            # Grow-and-subtract: the snap target's boundary ends up
+            # NO_GO_SNAP_MARGIN_PX outside the dead space, so the snapped point
+            # is not still read as inside it by the boundary-inclusive tests.
+            valid = valid.difference(nogo_union.buffer(NO_GO_SNAP_MARGIN_PX))
+
+    if valid is not None and not valid.is_empty:
+        if valid.covers(point):
+            return None  # already in valid space
+        snapped, _ = nearest_points(valid, point)
+        return snapped
+
+    # No allowed space to land in. If the point sits in declared dead space,
+    # at least push it just off the no-go footprint; otherwise leave it as-is.
+    if nogo_blocks and nogo_union.covers(point):
+        snapped, _ = nearest_points(nogo_union.buffer(NO_GO_SNAP_MARGIN_PX).boundary, point)
+        return snapped
+    return None
 
 
 def find_nearest_zone(data, entity, floor_name, point):
@@ -1330,7 +1404,9 @@ def find_nearest_zone(data, entity, floor_name, point):
     """
     nearest_id = "unknown"
     nearest_distance = None
-    for zone_id, polygon, _buffer_size in _floor_zone_polygons(data, entity, floor_name):
+    for zone_id, polygon, _buffer_size, no_go in _floor_zone_polygons(data, entity, floor_name):
+        if no_go:
+            continue  # dead space is never "the nearest zone" (issue #60)
         distance = polygon.distance(point)
         if nearest_distance is None or distance < nearest_distance:
             nearest_id, nearest_distance = zone_id, distance

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3098,6 +3098,24 @@ select.bps-input { cursor: pointer; }
     border-radius: 6px;
 }
 .bps-icon-btn:hover { color: hsl(0 84% 60%); background: hsl(var(--sidebar-accent)); }
+/* No-go toggle in its active state: the no-entry icon lit up so a dead-space
+   zone is obvious in the list (issue #60). Hover keeps the lit colour rather
+   than the shared red delete-hover. */
+.bps-icon-btn.bps-nogo-on,
+.bps-icon-btn.bps-nogo-on:hover { color: hsl(0 84% 60%); background: hsl(var(--sidebar-accent)); }
+/* "no-go" tag beside a dead-space zone's name in the sidebar. */
+.bps-nogo-tag {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    padding: 0 5px;
+    margin-left: 4px;
+    white-space: nowrap;
+}
 .bps-zone-actions { display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto; }
 /* Native colour picker shown as a small swatch beside a zone's name. */
 .bps-zone-swatch {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -863,6 +863,34 @@ document.addEventListener('DOMContentLoaded', async () => {
         ctx.closePath();
     }
 
+    // Fill a polygon with grey diagonal hatching — the "no-go zone" look
+    // (issue #60): dead space a tracker can't be in, distinct from a room's
+    // flat colour tint. Lines are clipped to the polygon so they never bleed.
+    function drawHatchedZone(pts) {
+        const xs = pts.map(p => p.x), ys = pts.map(p => p.y);
+        const minx = Math.min(...xs), maxx = Math.max(...xs);
+        const miny = Math.min(...ys), maxy = Math.max(...ys);
+        ctx.save();
+        tracePolygon(pts);
+        ctx.clip();
+        // Faint grey wash so the area still reads as filled at a glance.
+        ctx.globalAlpha = 0.15;
+        ctx.fillStyle = "#616161";
+        ctx.fill();
+        // Diagonal hatch lines across the bounding box (clip keeps them inside).
+        ctx.globalAlpha = 0.5;
+        ctx.strokeStyle = "#616161";
+        ctx.lineWidth = 2;
+        const step = 24;
+        ctx.beginPath();
+        for (let d = miny - (maxx - minx); d <= maxy; d += step) {
+            ctx.moveTo(minx, d);
+            ctx.lineTo(maxx, d + (maxx - minx));
+        }
+        ctx.stroke();
+        ctx.restore();
+    }
+
     // The radii filtered to finite, positive circles — and, when a receiver is
     // focused, just that receiver's. Shared by the circle (solo) and line (multi)
     // distance overlays.
@@ -1900,6 +1928,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             savebuttondiv.appendChild(saveButton);
             clearCanvas();
             drawElements();
+            return;
+        }
+        // Toggle a zone as no-go dead space (issue #60): the tracker can't be
+        // here, so the backend down-weights any floor whose fit lands inside
+        // it and snaps a position out to the nearest real zone.
+        if (event.target.closest('[data-type="zonetogglenogo"]')) {
+            const id = event.target.closest('[data-type="zonetogglenogo"]').getAttribute('data-id');
+            if (!finalcords.floor.some(f => sameFloorName(f.name, SelMapName))) return;
+            const floor = finalcords.floor.find(f => sameFloorName(f.name, SelMapName));
+            const zone = floor && (floor.zones || []).find(z => (z.zone_id || z.entity_id) === id);
+            if (!zone) return;
+            if (zone.no_go) delete zone.no_go; else zone.no_go = true;
+            savebuttondiv.appendChild(saveButton);
+            clearCanvas();
+            drawElements();
+            bpsToast(zone.no_go
+                ? `"${zone.entity_id}" marked no-go — Save Floor Plan to keep it.`
+                : `"${zone.entity_id}" is no longer no-go — Save Floor Plan to keep it.`);
             return;
         }
         if (event.target.closest('[data-type="editsubzone"]')) {
@@ -3408,6 +3454,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (item.type == "zone"){
                 const pts = zonePerimeterPoints(item);
                 if (pts.length < 3) return;
+                const cx = pts.reduce((s, p) => s + p.x, 0) / pts.length;
+                const cy = pts.reduce((s, p) => s + p.y, 0) / pts.length;
+                if (item.no_go) {
+                    // Dead space (issue #60): grey hatching instead of a room
+                    // tint. Deferred edge is drawn dashed-grey below.
+                    drawHatchedZone(pts);
+                    zoneStrokes.push({ pts, noGo: true });
+                    zonePills.push({ text: item.entity_id, cx, cy, color: "#bdbdbd" });
+                    return;
+                }
                 // null => the zone's colour was removed: no tint, neutral pill.
                 const zoneColor = zoneColorById.has(item.zone_id) ? zoneColorById.get(item.zone_id) : zoneDisplayColor(item, 0);
 
@@ -3422,8 +3478,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
                 // Defer the black edge + the name pill so both draw ABOVE sub-zones
                 // (zone lines on top of sub-zone lines; name readable over all).
-                const cx = pts.reduce((s, p) => s + p.x, 0) / pts.length;
-                const cy = pts.reduce((s, p) => s + p.y, 0) / pts.length;
                 zoneStrokes.push({ pts });
                 zonePills.push({ text: item.entity_id, cx, cy, color: zoneColor || "#e8e8e8" });
             }
@@ -3463,9 +3517,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         // meets the zone boundary the crisp black zone line is what shows.
         zoneStrokes.forEach(z => {
             tracePolygon(z.pts);
-            ctx.strokeStyle = "#000000";
-            ctx.lineWidth = 2;
-            ctx.stroke();
+            if (z.noGo) {
+                // Dashed grey edge so a no-go zone never reads as a normal room.
+                ctx.save();
+                ctx.strokeStyle = "#616161";
+                ctx.lineWidth = 2;
+                ctx.setLineDash([12, 8]);
+                ctx.stroke();
+                ctx.restore();
+            } else {
+                ctx.strokeStyle = "#000000";
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            }
         });
         // Name pills on top: sub-zones, then zones (a room name stays readable).
         subPills.forEach(s => drawColorPill(s.text, s.cx, s.cy, s.color, "#000000", 16));
@@ -3813,6 +3877,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Toggle a zone's colour on/off: filled drop = add, slashed circle = remove.
         const colorOnSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor"></circle></svg>';
         const colorOffSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="8"></circle><line x1="6" y1="18" x2="18" y2="6"></line></svg>';
+        // No-entry sign: toggle a zone as no-go dead space (issue #60).
+        const noGoSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"></circle><line x1="5.6" y1="5.6" x2="18.4" y2="18.4"></line></svg>';
         // Stable per-floor suffix so the two synthetic groups ("No zone" /
         // "Unlinked sub-zones") collapse independently on each floor, like real
         // zones do (those get globally-unique zone ids). Floor names don't churn,
@@ -3825,8 +3891,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         // optional edit/remove button block.
         const groupOpen = (key, titleHtml, countHtml, actionsHtml, headBg) => {
             const collapsed = !expandedZones.has(key);
-            // Overlay the zone's colour on its header (over the default accent).
-            const headStyle = headBg ? ` style="background: linear-gradient(${headBg}, ${headBg}), hsl(var(--sidebar-accent))"` : '';
+            // Overlay the zone's accent on its header (over the default accent).
+            // A solid colour is wrapped into a flat translucent layer; a value
+            // that is already an image/gradient (the no-go hatch) is layered
+            // as-is — nesting a gradient inside linear-gradient() is invalid CSS
+            // and the whole declaration would be dropped.
+            let headStyle = '';
+            if (headBg) {
+                const layer = /gradient\(/.test(headBg) ? headBg : `linear-gradient(${headBg}, ${headBg})`;
+                headStyle = ` style="background: ${layer}, hsl(var(--sidebar-accent))"`;
+            }
             return '<div class="bps-zone-group' + (collapsed ? ' bps-collapsed' : '') + '">'
                 + `<div class="bps-zone-head" data-type="togglezone" data-key="${escHtml(key)}"${headStyle}>`
                 + `<span class="bps-caret">${chevronSvg}</span>`
@@ -3875,17 +3949,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             const subs = subzones.filter(s => s.parent === zoneDomId);
             const zoneColor = zoneDisplayColor(zone, zi);
             const uncolored = !!zone.uncolored;
+            const noGo = !!zone.no_go;
             const zoneActions = '<span class="bps-zone-actions">'
                 + `<input type="color" class="bps-zone-swatch${uncolored ? ' bps-swatch-off' : ''}" data-type="zonecolor" data-id="${escHtml(zoneDomId)}" value="${colorToHex(zoneColor)}" title="Pick zone colour">`
                 + `<button class="bps-icon-btn" title="${uncolored ? 'Add colour' : 'Remove colour'}" data-type="zonetogglecolor" data-id="${escHtml(zoneDomId)}">${uncolored ? colorOnSvg : colorOffSvg}</button>`
+                + `<button class="bps-icon-btn${noGo ? ' bps-nogo-on' : ''}" title="${noGo ? 'Unmark no-go zone' : 'Mark as no-go (dead space — nothing can be here)'}" data-type="zonetogglenogo" data-id="${escHtml(zoneDomId)}">${noGoSvg}</button>`
                 + `<button class="bps-icon-btn" title="Edit zone" data-type="editzone" data-id="${escHtml(zoneDomId)}">${pencilSvg}</button>`
                 + `<button class="bps-icon-btn" title="Remove zone" data-type="removezone" data-id="${escHtml(zoneDomId)}">${trashSvg}</button>`
                 + '</span>';
+            // A no-go zone's header wears a grey hatched accent instead of its
+            // room colour, matching the map (issue #60).
+            const headBg = noGo
+                ? "repeating-linear-gradient(45deg, hsla(0,0%,45%,0.28) 0 6px, transparent 6px 12px)"
+                : (uncolored ? "" : colorToTranslucent(zoneColor, 0.35));
             html += groupOpen(zoneDomId,
-                `<span title="${escHtml(zone.entity_id)}">${escHtml(zone.entity_id)}</span>`,
+                `<span title="${escHtml(zone.entity_id)}">${escHtml(zone.entity_id)}${noGo ? ' <span class="bps-nogo-tag">no-go</span>' : ''}</span>`,
                 `<span class="bps-count"> · ${inside.length}</span>`,
                 zoneActions,
-                uncolored ? "" : colorToTranslucent(zoneColor, 0.35));
+                headBg);
             if (inside.length) {
                 html += "<ul>" + inside.map(receiverRow).join("") + "</ul>";
             }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.8.0"
+    "version": "1.9.0"
 }


### PR DESCRIPTION
Closes #60.

## The problem

The upper footprint of a **double-height foyer or great room open to the floor below** is physically impossible to stand in — but the downstairs receivers hear a beacon in that shared air perfectly well, so the upper floor sometimes won the election and the tracker hovered in mid-air over the void.

## What this adds

A zone can be flagged **no-go** with the no-entry button on its row in the Zones & Receivers sidebar. It renders as **grey hatched dead space** on the map (dashed grey edge, a `no-go` tag in the sidebar), and in tracking it:

- **Down-weights the floor whose fit lands in it.** This rides the floor [hypothesis competition](https://github.com/maxi1134/BPS-improved/pull/100) rather than hard-overriding it: a no-go hit multiplies that floor's confidence down (`NO_GO_CONF_PENALTY`), so the floor where the same spot is a real room — the one open below, whose receivers already solve the beacon as a candidate — wins on its merits, through the same anti-flap smoothing. Strict containment, so a tracker on the **railing edge** (the no-go boundary) isn't penalised as if it were over the void.
- **Never strands a tracker.** If the no-go floor is the *only* one that can solve, it still gets a position — the point is **snapped out** of the dead space to the nearest real room, and the zone sensors never report a no-go zone.

Marking a zone no-go changes only tracking — no recalibration needed. The Lovelace card draws only zone *labels* (not fills), so it needs no change.

## Why it's a clean fit

`#100` inverted floor election to *solve-then-score every candidate floor*, so a no-go zone drops in as a per-floor **score penalty** — no separate "re-solve the other floor" fallback, no new flap logic. The open-to-below space means the downstairs floor is already a scored candidate every cycle; the penalty just tips the competition to it.

## Hardening (4 adversarial-review findings, all fixed before this PR)

- **Snap-out no-op when the floor's only zones are no-go** — the allowed union was empty and the point was left in dead space. Now pushed off the footprint.
- **Snap-out failed for a no-go zone nested in / overlapping a room** — the enclosing room `covers()` the void point, so the naive union said "already valid". Now the snap target is `allowed − grown(no-go)`, carving the void out.
- **Railing-boundary false penalty** — boundary-inclusive `covers()` penalised a tracker standing at the void's edge. Switched to strict `contains()`.
- **Hatched sidebar header blanked** — the header builder nested the hatch gradient inside `linear-gradient(...)`, which is invalid CSS and dropped the whole background. Now a gradient value is layered as-is.

## Verification

41 stubbed-module tests against the real module (tuple tagging, `_point_in_no_go` strict-vs-boundary, zone/nearest/snap exclusion, penalty steers election, sole-candidate snap-out, nested/overlap snap-out, only-no-go footprint push-off), plus browser-harness pixel checks: hatched no-go region (160/161 grey) vs coloured room, toggle flips the render both ways, and the sidebar header now carries the hatch gradient. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)