### PR TITLE
Harden HTTP endpoints, timeouts, dead code; add tests + CI (v1.8.1)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  python:
+    name: Python compile + unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Byte-compile the integration
+        run: python -m py_compile custom_components/bps/*.py
+      - name: Run unit tests
+        run: pytest tests/ -q
+
+  javascript:
+    name: JS syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: node --check the frontend
+        run: |
+          node --check custom_components/bps/frontend/script.js
+          node --check custom_components/bps/frontend/bps-map-card.js

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,6 +18,7 @@ jobs:
     name: HACS Action
     runs-on: "ubuntu-latest"
     steps:
+      - uses: "actions/checkout@v4"
       - name: HACS Action
         uses: "hacs/action@main"
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Github is used to host code, to track issues and feature requests, as well as ac
 
 Pull requests are the best way to propose changes to the codebase.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've changed something, update the documentation.
-3. Test you contribution.
+3. Test your contribution (see [Testing](#testing)).
 4. Issue that pull request!
 
 ## Any contributions you make will be under the MIT Software License
@@ -41,47 +41,29 @@ Report a bug by [opening a new issue](../../issues/new/choose); it's that easy!
 
 People _love_ thorough bug reports. I'm not even kidding.
 
-## Test your code modification
+## Testing
 
-Try [integration_blueprint template](https://github.com/custom-components/integration_blueprint).
+The backend has a unit-test suite under [`tests/`](./tests) that runs against
+the real integration modules with the Home Assistant runtime stubbed out (see
+`tests/conftest.py`), so it needs no HA install — only the numeric libraries
+the positioning/geometry code uses.
 
-It comes with development environment in a container, easy to launch
-if you use Visual Studio Code. With this container you will have a stand alone
-Home Assistant instance running and already configured with the included
-[`.devcontainer.json`](./.devcontainer.json)
-file.
-
-You can use the `pre-commit` settings implemented in this repository to have
-linting tool checking your contributions (see dedicated section below).
-
-You should also verify that existing [tests](./tests) are still working
-and you are encouraged to add new ones.
-You can run the tests using the following command from the root folder:
-
-`./scripts/test`
-
-If any of the tests fail, make the necessary changes to the tests as part of
-your changes to the integration.
-
-## Pre-commit
-
-You can use the [pre-commit](https://pre-commit.com/) settings included in the
-repostory to have code style and linting checks.
-
-With `pre-commit` tool already installed,
-activate the settings of the repository:
+From the repository root:
 
 ```console
-$ pre-commit install
+$ pip install -r requirements_test.txt
+$ pytest tests/ -q
 ```
 
-Now the pre-commit tests will be done every time you commit.
+CI runs the same suite plus a byte-compile of the integration and a
+`node --check` of the frontend on every push and pull request
+(`.github/workflows/test.yaml`), alongside Hassfest/HACS validation
+(`.github/workflows/validate.yaml`). Please keep the suite green and add tests
+for new positioning, calibration, or election logic.
 
-You can run the tests on all repository file with the command:
-
-```console
-$ pre-commit run --all-files
-```
+For end-to-end testing in a running Home Assistant, the
+[integration_blueprint template](https://github.com/custom-components/integration_blueprint)
+provides a VS Code dev-container with a standalone HA instance.
 
 ## License
 

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import async_register_built_in_panel, async_remove_panel
-from homeassistant.components.websocket_api import async_register_command, ActiveConnection, websocket_command
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.template import Template
 from homeassistant.core import HomeAssistant
@@ -95,6 +94,41 @@ KF_MAX_GAP_S = 30.0          # gap beyond which state is reset (tracker was away
 # points to fix a position even while every distance is legitimately changing
 # during movement.
 RADIUS_JUMP_TOL = 0.5
+
+# Uploaded floor-plan maps: accepted image extensions and a size cap. Client
+# filenames are never trusted for filesystem paths (see _safe_maps_child).
+_ALLOWED_MAP_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+MAX_MAP_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB
+# Longest to wait on Bermuda's dump_devices before treating it as unavailable,
+# so a hung/slow service can't stall the liveness or calibration loops.
+DUMP_DEVICES_TIMEOUT_S = 10.0
+
+
+def _safe_maps_child(maps_path, raw_name, allowed_exts=None):
+    """Resolve raw_name to a path guaranteed to sit directly inside maps_path.
+
+    Returns the resolved Path, or None if raw_name is unsafe. Path(name).name
+    strips any directory component (so '../x' and '/etc/x' both collapse to a
+    bare filename), and the resolved result is re-checked against maps_path as
+    belt-and-suspenders. Client-supplied filenames must never reach the
+    filesystem unfiltered (unauthenticated write endpoints, issue: audit #2).
+    """
+    if not raw_name:
+        return None
+    name = Path(str(raw_name)).name
+    if not name or name in (".", ".."):
+        return None
+    if allowed_exts is not None and Path(name).suffix.lower() not in allowed_exts:
+        return None
+    base = Path(maps_path).resolve()
+    target = (base / name).resolve()
+    try:
+        if not target.is_relative_to(base):
+            return None
+    except AttributeError:  # Python < 3.9 (HA is 3.12+; defensive only)
+        if base != target and base not in target.parents:
+            return None
+    return target
 
 # --- Receiver mount heights (optional per-receiver "height", metres) ---------
 # Bermuda's distance estimates are line-of-sight SLANT ranges, but the map
@@ -674,10 +708,19 @@ async def update_receiver_liveness(hass):
     """
     dom = hass.data.setdefault(DOMAIN, {})
     try:
-        devices = await hass.services.async_call(
-            "bermuda", "dump_devices", {"configured_devices": True},
-            blocking=True, return_response=True,
+        devices = await wait_for(
+            hass.services.async_call(
+                "bermuda", "dump_devices", {"configured_devices": True},
+                blocking=True, return_response=True,
+            ),
+            timeout=DUMP_DEVICES_TIMEOUT_S,
         ) or {}
+    except TimeoutError:
+        _LOGGER.warning(
+            "Receiver liveness: bermuda.dump_devices timed out after %ss; "
+            "skipping this refresh", DUMP_DEVICES_TIMEOUT_S,
+        )
+        devices = None
     except Exception as e:
         _LOGGER.info(f"Receiver liveness: dump_devices unavailable: {e}")
         devices = None
@@ -1413,11 +1456,6 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSCalibrationAPI())
             hass.data["bps_views_registered"] = True
 
-        if "bps_websocket" not in hass.data:
-            websocket = BPSEntityWebSocket(hass)
-            websocket.register()
-            hass.data["bps_websocket"] = websocket
-
         config_path = hass.config.path()
         target_dir = os.path.join(config_path, "www", "bps_maps")
         tracker_icons_dir = os.path.join(config_path, "www", "bps_icons")
@@ -1649,10 +1687,15 @@ class BPSSaveAPIText(HomeAssistantView):
         data = await request.post()
 
         coordinates = data.get("coordinates")
-        
+
         if not coordinates:
             return web.Response(status=400, text="Missing coordinates")
-        
+        # Reject a non-JSON layout blob before it can truncate bpsdata.txt.
+        try:
+            json.loads(coordinates)
+        except (ValueError, TypeError):
+            return web.Response(status=400, text="Coordinates must be valid JSON")
+
         # Define the path to the bpsdata file
         maps_path = hass.config.path("www/bps_maps")
         bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
@@ -1676,34 +1719,58 @@ class BPSSaveAPIText(HomeAssistantView):
             return web.Response(status=500, text="Failed to save coordinates")
 
     async def _write_save(self, bpsdata_file_path, maps_path, data, coordinates):
-        """Perform the writes; returns an error Response or None on success."""
-        async with aiofiles.open(bpsdata_file_path, "w") as f:
-            await f.write(coordinates)
-        _LOGGER.warning(f"New file: {data.get("new_floor")}")
-        if data.get("new_floor") == "true": # If it is a new floor then save the file
+        """Validate all inputs, THEN write; returns an error Response or None.
+
+        Ordering matters: the new-floor map upload and the removal target are
+        validated (and the upload read + size-checked) BEFORE bpsdata.txt is
+        touched, so a rejected upload can no longer truncate the saved layout.
+        Every filesystem target derived from client input is constrained to
+        maps_path via _safe_maps_child (audit #2: path traversal / arbitrary
+        write+delete on an unauthenticated endpoint).
+        """
+        # --- Validate the optional new-floor map upload ---
+        map_target = None
+        map_bytes = None
+        if data.get("new_floor") == "true":
             map_file = data.get("file")
             if not map_file:
                 return web.Response(status=400, text="Missing file")
-            map_file_path = Path(maps_path) / map_file.filename
+            map_target = _safe_maps_child(maps_path, map_file.filename, _ALLOWED_MAP_EXTS)
+            if map_target is None:
+                return web.Response(status=400, text="Invalid map filename")
+            map_bytes = map_file.file.read()
+            if len(map_bytes) > MAX_MAP_UPLOAD_BYTES:
+                return web.Response(status=413, text="Map file too large")
+
+        # --- Validate the optional removal target ---
+        remove_target = None
+        remove_file = data.get("remove")
+        if remove_file:
+            remove_target = _safe_maps_child(maps_path, remove_file, _ALLOWED_MAP_EXTS)
+            if remove_target is None:
+                return web.Response(status=400, text="Invalid remove target")
+
+        # --- Inputs valid: persist. Map first (so the saved layout never names
+        # a map that failed to write), then bpsdata.txt, then delete the old map. ---
+        if map_target is not None:
             try:
-                async with aiofiles.open(map_file_path, "wb") as f:
-                    await f.write(map_file.file.read())
+                async with aiofiles.open(map_target, "wb") as f:
+                    await f.write(map_bytes)
             except Exception as e:
                 _LOGGER.error(f"Failed to save maps: {e}")
                 return web.Response(status=500, text="Failed to save maps")
 
-        # Check if "remove" key exists and delete the specified file
-        remove_file = data.get("remove")
-        if remove_file:
-            remove_file_path = Path(maps_path) / remove_file
-            if remove_file_path.exists():
-                _LOGGER.warning(f"File exist: {remove_file_path}")
-                try:
-                    remove_file_path.unlink()  # Delete the file
-                    _LOGGER.info(f"Removed file: {remove_file_path}")
-                except Exception as e:
-                    _LOGGER.error(f"Failed to remove file {remove_file_path}: {e}")
-                    return web.Response(status=500, text="Failed to remove file")
+        async with aiofiles.open(bpsdata_file_path, "w") as f:
+            await f.write(coordinates)
+
+        # Never delete the map we just wrote (a replace with the same filename).
+        if remove_target is not None and remove_target != map_target and remove_target.exists():
+            try:
+                remove_target.unlink()
+                _LOGGER.info(f"Removed file: {remove_target.name}")
+            except Exception as e:
+                _LOGGER.error(f"Failed to remove file {remove_target.name}: {e}")
+                return web.Response(status=500, text="Failed to remove file")
         return None
 
 
@@ -1969,188 +2036,6 @@ class BPSCordsAPI(HomeAssistantView):
 
         return web.json_response(apitricords)
 
-class BPSEntityWebSocket:
-    def __init__(self, hass):
-        self.hass = hass
-        self.tracked_entities = {}
-        self.connections = []
-
-    async def handle_subscribe(self, hass, connection: ActiveConnection, msg: dict):
-        """Managing subscription for entities"""
-        _LOGGER.debug(f"Received subscription request: {msg}")
-        entity_ids = msg["entities"]
-        if not entity_ids:
-            connection.send_message({
-                "id": msg["id"],
-                "type": "result",
-                "success": False,
-                "error": {"code": "invalid_request", "message": "No entities provided."},
-            })
-            return
-
-        self.connections.append(connection) # Add a connection to subscribed entities
-        for entity_id in entity_ids:
-            if entity_id not in self.tracked_entities:
-                self.tracked_entities[entity_id] = []
-            self.tracked_entities[entity_id].append(connection)
-
-        current_states = [] # Send the current state for all subscribed entities
-        for entity_id in entity_ids:
-            state = hass.states.get(entity_id)
-            if state:
-                current_states.append({
-                    "entity_id": entity_id,
-                    "state": state.state,
-                    "attributes": state.attributes,
-                })
-
-        connection.send_message({
-            "id": msg["id"],
-            "type": "result",
-            "success": True,
-            "message": f"Subscribed to entities: {entity_ids}",
-            "current_states": current_states,  
-        })
-        async_track_state_change_event(hass, entity_ids, self.state_change_listener) # Listen for state_change
-
-
-    async def handle_unsubscribe(self, hass, connection: ActiveConnection, msg: dict):
-        """Managing unsubscription"""
-        _LOGGER.debug(f"Received unsubscribe request: {msg}")
-        entity_ids = msg.get("entities", [])
-        for entity_id in entity_ids:
-            if entity_id in self.tracked_entities:
-                if connection in self.tracked_entities[entity_id]:
-                    self.tracked_entities[entity_id].remove(connection)
-                if not self.tracked_entities[entity_id]:
-                    del self.tracked_entities[entity_id]
-
-        connection.send_message({
-            "id": msg["id"],
-            "type": "result",
-            "success": True,
-            "message": f"Unsubscribed from entities: {entity_ids}",
-        })
-
-    async def handle_known_points(self, hass, connection: ActiveConnection, msg: dict):
-        try:
-            known_points = msg.get("knownPoints") # Read knownPoints from the message
-            if not known_points:
-                connection.send_message({
-                    "id": msg["id"],
-                    "type": "tri_result",
-                    "success": False,
-                    "error": {"code": "invalid_request", "message": "No knownPoints provided."}
-                })
-                return
-
-            result = trilaterate(known_points) # Perform trilateration
-
-            if result is None: # If the result is None, return an error
-                connection.send_message({
-                    "id": msg["id"],
-                    "type": "tri_result",
-                    "success": False,
-                    "error": {"code": "calculation_error", "message": "Trilateration failed."}
-                })
-                return
-
-            tracker_key = msg.get("tracker")
-            result_payload = {
-                "x": result[0],
-                "y": result[1],
-            }
-            if tracker_key:
-                result_payload["ent"] = tracker_key
-
-            connection.send_message({ # Send back the result
-                "id": msg["id"],
-                "type": "tri_result",
-                "success": True,
-                "result": result_payload
-            })
-
-        except Exception as e:
-            _LOGGER.error(f"Error processing knownPoints: {e}")
-            connection.send_message({
-                "id": msg["id"],
-                "type": "tri_result",
-                "success": False,
-                "error": {"code": "server_error", "message": str(e)}
-            })
-
-    async def state_change_listener(self, event):
-        """Listens for status changes and sends them to connections."""
-        entity_id = event.data.get("entity_id")
-        old_state = event.data.get("old_state")
-        new_state = event.data.get("new_state")
-
-        _LOGGER.debug(f"State change for {entity_id}: {old_state} -> {new_state}")
-
-        # Create the message to send to subscribing clients
-        message = {
-            "type": "state_changed",
-            "entity_id": entity_id,
-            "old_state": old_state.state if old_state else None,
-            "new_state": new_state.state if new_state else None,
-        }
-
-        # Send to all connected clients who are subscribed to this entity
-        for connection in self.tracked_entities.get(entity_id, []):
-            connection.send_message(message)
-
-
-    def register(self):
-        """Registers WebSocket commands"""
-        _LOGGER.debug("Registering WebSocket commands")
-
-        def subscribe_wrapper(hass, connection, msg):
-            """Wrapper to invoke handle_subscribe."""
-            hass.async_create_task(self.handle_subscribe(hass, connection, msg))
-        def unsubscribe_wrapper(hass, connection, msg):
-            """Wrapper to invoke handle_unsubscribe."""
-            hass.async_create_task(self.handle_unsubscribe(hass, connection, msg))
-        def known_points_wrapper(hass, connection, msg):
-            """Wrapper to invoke handle_known_points."""
-            hass.async_create_task(self.handle_known_points(hass, connection, msg))
-
-        async_register_command(
-            self.hass,
-            "bps/subscribe",
-            subscribe_wrapper,  # The wrapper handles async
-            schema=vol.Schema({
-                vol.Required("type"): "bps/subscribe", # Type for API
-                vol.Required("entities"): [str],
-                vol.Optional("id"): int,
-            }),
-        )
-        async_register_command(
-            self.hass,
-            "bps/unsubscribe",
-            unsubscribe_wrapper,  # The wrapper handles async
-            schema=vol.Schema({
-                vol.Required("type"): "bps/unsubscribe", # Type for API
-                vol.Required("entities"): [str],
-                vol.Optional("id"): int,
-            }),
-        )
-        async_register_command(
-            self.hass,
-            "bps/known_points",
-            known_points_wrapper,  # The wrapper handles async
-            schema=vol.Schema({
-                vol.Required("type"): "bps/known_points",  # Type for API
-                vol.Required("knownPoints"): vol.All(
-                    list,
-                    [vol.All([float, float, float])]  
-                ),
-                vol.Optional("tracker"): str,
-                vol.Optional("id"): int,  
-                }),
-        )
-
-        _LOGGER.info("All WebSocket commands registered successfully.")
-    
 # Trilateration function
 def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     """Weighted least-squares position fit.

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -97,8 +97,14 @@ RADIUS_JUMP_TOL = 0.5
 
 # Uploaded floor-plan maps: accepted image extensions and a size cap. Client
 # filenames are never trusted for filesystem paths (see _safe_maps_child).
-_ALLOWED_MAP_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+# .jfif/.jpe are ordinary JPEG variants a browser's image/jpeg picker yields.
+_ALLOWED_MAP_EXTS = {
+    ".png", ".jpg", ".jpeg", ".jfif", ".jpe", ".gif", ".webp", ".bmp", ".svg", ".avif",
+}
 MAX_MAP_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB
+# Non-map files that live in www/bps_maps and must never be deletable via the
+# save_text "remove" field (that field is only meant to drop an old map image).
+_PROTECTED_MAPS_FILES = {"bpsdata.txt", "bps_calibration_state.json"}
 # Longest to wait on Bermuda's dump_devices before treating it as unavailable,
 # so a hung/slow service can't stall the liveness or calibration loops.
 DUMP_DEVICES_TIMEOUT_S = 10.0
@@ -1743,11 +1749,15 @@ class BPSSaveAPIText(HomeAssistantView):
                 return web.Response(status=413, text="Map file too large")
 
         # --- Validate the optional removal target ---
+        # No extension allowlist here: a map stored under any earlier-accepted
+        # extension must stay deletable (the allowlist is an UPLOAD guard, not a
+        # reason to strand an existing floor). Containment still applies, and
+        # the layout/calibration files are explicitly protected.
         remove_target = None
         remove_file = data.get("remove")
         if remove_file:
-            remove_target = _safe_maps_child(maps_path, remove_file, _ALLOWED_MAP_EXTS)
-            if remove_target is None:
+            remove_target = _safe_maps_child(maps_path, remove_file, None)
+            if remove_target is None or remove_target.name in _PROTECTED_MAPS_FILES:
                 return web.Response(status=400, text="Invalid remove target")
 
         # --- Inputs valid: persist. Map first (so the saved layout never names

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -58,6 +58,7 @@ AUTO_SAMPLE_INTERVAL = 30  # seconds between dumps in continuous mode
 AUTO_SOLVE_INTERVAL = 900  # seconds between re-solves in continuous mode
 AUTO_MIN_WINDOW = 300  # seconds of data before the first auto solve
 APPLY_EPSILON = 0.01  # relative correction change worth persisting
+DUMP_DEVICES_TIMEOUT_S = 10  # cap on a single bermuda.dump_devices call
 SAMPLES_MAXLEN = 720  # rolling window per pair (6 h at the auto interval)
 STATE_SAMPLES_PER_PAIR = 200  # samples persisted per pair (enough for a solve)
 STATE_MAX_AGE = SAMPLES_MAXLEN * AUTO_SAMPLE_INTERVAL  # drop older windows
@@ -598,12 +599,17 @@ def solve(cal: dict, floor_name: str):
 
 
 async def _dump_devices(hass) -> dict:
-    response = await hass.services.async_call(
-        "bermuda",
-        "dump_devices",
-        {"configured_devices": True},
-        blocking=True,
-        return_response=True,
+    # Bounded so a hung/slow Bermuda service can't stall the sampling loop
+    # indefinitely; the caller counts a timeout as a normal sampling failure.
+    response = await asyncio.wait_for(
+        hass.services.async_call(
+            "bermuda",
+            "dump_devices",
+            {"configured_devices": True},
+            blocking=True,
+            return_response=True,
+        ),
+        timeout=DUMP_DEVICES_TIMEOUT_S,
     )
     return response or {}
 

--- a/custom_components/bps/config_flow.py
+++ b/custom_components/bps/config_flow.py
@@ -2,7 +2,10 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 import logging
 import voluptuous as vol
-from . import DOMAIN
+# Import DOMAIN from the lightweight const module, NOT from the package root:
+# `from . import DOMAIN` executes __init__.py (scipy/shapely/numpy/watchdog) just
+# to load the config flow, and couples config-flow loading to those heavy deps.
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 OPTION_SHOW_SIDEBAR_PANEL = "show_sidebar_panel"

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -8,6 +8,6 @@
     "integration_type": "device",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
-    "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.8.0"
+    "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2", "watchdog>=2.1.0"],
+    "version": "1.8.1"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,7 @@
+# Test-only dependencies. The HA runtime is stubbed in tests/conftest.py, so
+# only the genuinely numeric libs the positioning/geometry code runs against
+# are needed, plus the test runner.
+pytest>=7.4
+numpy>=1.26.4
+scipy>=1.10.1
+shapely>=2.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+"""Test bootstrap: stub the Home Assistant runtime so the real `bps` package
+imports without a full HA install.
+
+The BPS backend pulls in a handful of `homeassistant.*` modules (plus aiofiles,
+aiohttp, voluptuous, watchdog) purely for type/registration plumbing that the
+unit tests never exercise. We install lightweight fakes for those in
+`sys.modules` BEFORE anything imports `bps`, then let the genuinely numeric
+dependencies (numpy, scipy, shapely) load for real — the positioning and
+geometry maths under test run against the actual libraries.
+"""
+import sys
+import types
+from pathlib import Path
+
+
+def _module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+class _FakeDistanceConverter:
+    VALID_UNITS = {"m", "ft"}
+
+    @staticmethod
+    def convert(value, from_unit, to_unit):
+        # Only feet->metres is exercised by the tests.
+        return value * 0.3048 if from_unit == "ft" else value
+
+
+# --- Functional-enough aiofiles / aiohttp.web fakes -------------------------- #
+# The save/read handlers do real file I/O and build aiohttp responses; back
+# those with a tiny synchronous-under-the-hood async shim so tests can exercise
+# the actual handler flow (e.g. the write-after-validate ordering, audit #2).
+class _AsyncFile:
+    def __init__(self, path, mode):
+        self._f = open(path, mode)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self._f.close()
+
+    async def read(self):
+        return self._f.read()
+
+    async def write(self, data):
+        return self._f.write(data)
+
+
+def _aiofiles_open(path, mode="r", *a, **k):
+    return _AsyncFile(path, mode)
+
+
+async def _aiofiles_makedirs(*a, **k):
+    return None
+
+
+class _Response:
+    def __init__(self, status=200, text="", **k):
+        self.status = status
+        self.body_text = text
+
+
+def _json_response(data=None, status=200):
+    r = _Response(status=status)
+    r.json_body = data
+    return r
+
+
+def _install_homeassistant_stubs():
+    _module("aiofiles", open=_aiofiles_open)
+    _module("aiofiles.os", makedirs=_aiofiles_makedirs)
+    _module("aiohttp", web=types.SimpleNamespace(
+        Response=_Response, json_response=_json_response, FileResponse=object,
+    ))
+    _module("homeassistant")
+    _module("homeassistant.components")
+    _module("homeassistant.components.http", HomeAssistantView=object)
+    _module(
+        "homeassistant.components.frontend",
+        async_register_built_in_panel=lambda *a, **k: None,
+        async_remove_panel=lambda *a, **k: None,
+    )
+    _module("homeassistant.helpers")
+    _module("homeassistant.helpers.event", async_track_state_change_event=lambda *a, **k: None)
+    _module("homeassistant.helpers.template", Template=object)
+    _module("homeassistant.core", HomeAssistant=object, callback=lambda f: f)
+    _module("homeassistant.helpers.entity_registry")
+    _module("homeassistant.helpers.device_registry")
+    _module("homeassistant.const", UnitOfLength=types.SimpleNamespace(METERS="m"))
+    _module("homeassistant.util", slugify=lambda s: s)
+    _module("homeassistant.util.unit_conversion", DistanceConverter=_FakeDistanceConverter)
+    _module(
+        "voluptuous",
+        Schema=lambda *a, **k: None, Required=lambda *a, **k: None,
+        Optional=lambda *a, **k: None, Coerce=lambda *a, **k: None,
+        All=lambda *a, **k: None, Length=lambda *a, **k: None, Range=lambda *a, **k: None,
+    )
+    _module("watchdog")
+    _module("watchdog.observers", Observer=object)
+    _module("watchdog.events", FileSystemEventHandler=object)
+
+
+_install_homeassistant_stubs()
+# custom_components/ on the path so `import bps` resolves to the integration.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -112,13 +112,55 @@ def test_valid_new_floor_writes_map_and_layout(tmp_path):
     assert (maps / "ground.png").read_bytes() == b"PNGDATA"
 
 
-def test_traversal_removal_target_rejected_before_any_write(tmp_path):
+def test_protected_files_not_deletable(tmp_path):
+    maps = tmp_path
+    bpsdata = maps / "bpsdata.txt"
+    bpsdata.write_text('{"floor":[]}')
+    (maps / "bps_calibration_state.json").write_text("{}")
+    view = bps.BPSSaveAPIText()
+    for name in ("bpsdata.txt", "../../bpsdata.txt", "bps_calibration_state.json"):
+        err = run(view._write_save(bpsdata, str(maps), _Dict(remove=name), "{}"))
+        assert err is not None and err.status == 400, name
+    # Neither protected file was touched.
+    assert bpsdata.read_text() == '{"floor":[]}'
+    assert (maps / "bps_calibration_state.json").exists()
+
+
+def test_existing_map_deletable_regardless_of_extension(tmp_path):
+    # A map stored under any earlier-accepted extension must stay deletable —
+    # the upload allowlist must not strand an existing floor (regression guard).
     maps = tmp_path
     bpsdata = maps / "bpsdata.txt"
     bpsdata.write_text("{}")
-    view = bps.BPSSaveAPIText()
-    data = _Dict(remove="../../bpsdata.txt")
-    # '../../bpsdata.txt' collapses to bpsdata.txt (allowed ext? .txt is NOT in
-    # the image allowlist) -> rejected as an invalid remove target.
-    err = run(view._write_save(bpsdata, str(maps), data, "{}"))
-    assert err is not None and err.status == 400
+    for ext in (".jfif", ".tiff", ".png"):
+        target = maps / f"ground{ext}"
+        target.write_bytes(b"img")
+        err = run(view_delete(maps, bpsdata, f"ground{ext}"))
+        assert err is None, ext
+        assert not target.exists(), ext
+
+
+def view_delete(maps, bpsdata, name):
+    return bps.BPSSaveAPIText()._write_save(bpsdata, str(maps), _Dict(remove=name), "{}")
+
+
+def test_jfif_upload_accepted(tmp_path):
+    maps = tmp_path
+    bpsdata = maps / "bpsdata.txt"
+    bpsdata.write_text("{}")
+    data = _Dict(new_floor="true", file=_Upload("attic.jfif", b"JPEG"))
+    err = run(bps.BPSSaveAPIText()._write_save(bpsdata, str(maps), data, '{"floor":[1]}'))
+    assert err is None
+    assert (maps / "attic.jfif").read_bytes() == b"JPEG"
+
+
+def test_delete_traversal_still_blocked(tmp_path):
+    # Containment must still reject an attempt to escape the maps dir.
+    maps = tmp_path / "bps_maps"
+    maps.mkdir()
+    outside = tmp_path / "secret.png"
+    outside.write_bytes(b"x")
+    bpsdata = maps / "bpsdata.txt"
+    bpsdata.write_text("{}")
+    run(view_delete(maps, bpsdata, "../secret.png"))
+    assert outside.exists()  # '../' collapsed to basename; the real file survives

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -1,0 +1,124 @@
+"""Path-safety of the (unauthenticated) save_text file handling — audit #2.
+
+_safe_maps_child is the single choke point that keeps client-supplied
+filenames from escaping www/bps_maps; these lock its behaviour down, plus the
+_write_save write-after-validate ordering.
+"""
+import asyncio
+import io
+
+import bps
+
+
+MAPS = "/config/www/bps_maps"
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class _Dict(dict):
+    """Stand-in for aiohttp's multidict form data (only .get is used)."""
+
+
+class _Upload:
+    def __init__(self, filename, data=b"img"):
+        self.filename = filename
+        self.file = io.BytesIO(data)
+
+
+def child(name, exts=bps._ALLOWED_MAP_EXTS):
+    return bps._safe_maps_child(MAPS, name, exts)
+
+
+def test_plain_filename_is_contained():
+    got = child("first_floor.png")
+    assert got is not None
+    assert got.name == "first_floor.png"
+    assert str(got).replace("\\", "/").endswith("www/bps_maps/first_floor.png")
+
+
+def test_parent_traversal_is_stripped_to_basename():
+    # '../' components are removed by Path(...).name, never escaping the dir.
+    got = child("../../secret.png")
+    assert got is not None and got.name == "secret.png"
+    base = bps.Path(MAPS).resolve()
+    assert got.parent == base
+
+
+def test_absolute_path_is_neutralised():
+    got = child("/etc/passwd.png")
+    assert got is not None and got.name == "passwd.png"
+    assert got.parent == bps.Path(MAPS).resolve()
+
+
+def test_windows_absolute_path_is_neutralised():
+    # Backslash form must not survive as a directory component either.
+    got = child(r"C:\windows\system32\evil.png")
+    assert got is None or got.parent == bps.Path(MAPS).resolve()
+
+
+def test_disallowed_extension_rejected():
+    assert child("payload.exe") is None
+    assert child("script.html") is None
+    assert child("bpsdata.txt") is None  # can't target the layout file
+
+
+def test_allowed_image_extensions_accepted():
+    for name in ("a.png", "b.jpg", "c.jpeg", "d.gif", "e.webp", "f.bmp", "g.svg"):
+        assert child(name) is not None, name
+
+
+def test_extension_check_is_case_insensitive():
+    assert child("FLOOR.PNG") is not None
+
+
+def test_empty_and_dot_names_rejected():
+    assert child("") is None
+    assert child(".") is None
+    assert child("..") is None
+    assert child(None) is None
+
+
+def test_no_extension_filter_still_contains():
+    # Without an extension allowlist the containment guarantee must still hold.
+    got = bps._safe_maps_child(MAPS, "../../../x", None)
+    assert got is not None and got.parent == bps.Path(MAPS).resolve()
+
+
+# --- _write_save ordering: a rejected upload must not truncate bpsdata.txt --- #
+def test_bad_upload_does_not_truncate_bpsdata(tmp_path):
+    maps = tmp_path
+    bpsdata = maps / "bpsdata.txt"
+    original = '{"floor":[{"name":"F"}]}'
+    bpsdata.write_text(original)
+    view = bps.BPSSaveAPIText()
+    data = _Dict(new_floor="true", file=_Upload("evil.exe"))
+    err = run(view._write_save(bpsdata, str(maps), data, '{"floor":[]}'))
+    assert err is not None and err.status == 400
+    # The layout on disk is untouched — no partial-write corruption.
+    assert bpsdata.read_text() == original
+
+
+def test_valid_new_floor_writes_map_and_layout(tmp_path):
+    maps = tmp_path
+    bpsdata = maps / "bpsdata.txt"
+    bpsdata.write_text("{}")
+    view = bps.BPSSaveAPIText()
+    data = _Dict(new_floor="true", file=_Upload("ground.png", b"PNGDATA"))
+    err = run(view._write_save(bpsdata, str(maps), data, '{"floor":[1]}'))
+    assert err is None
+    assert bpsdata.read_text() == '{"floor":[1]}'
+    assert (maps / "ground.png").read_bytes() == b"PNGDATA"
+
+
+def test_traversal_removal_target_rejected_before_any_write(tmp_path):
+    maps = tmp_path
+    bpsdata = maps / "bpsdata.txt"
+    bpsdata.write_text("{}")
+    view = bps.BPSSaveAPIText()
+    data = _Dict(remove="../../bpsdata.txt")
+    # '../../bpsdata.txt' collapses to bpsdata.txt (allowed ext? .txt is NOT in
+    # the image allowlist) -> rejected as an invalid remove target.
+    err = run(view._write_save(bpsdata, str(maps), data, "{}"))
+    assert err is not None and err.status == 400

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -1,0 +1,160 @@
+"""Regression tests for the positioning maths, run against the real `bps`
+module (Home Assistant stubbed by conftest). Covers the pieces most likely to
+regress silently: the trilateration solver, receiver mount-height slant
+correction, 3D calibration ground truth, and the floor hypothesis-competition
+election helpers.
+"""
+import asyncio
+import math
+
+import bps
+from bps import calibration as cal_mod
+
+SCALE = 40.0  # px per metre
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# --------------------------------------------------------------------------- #
+# Trilateration solver
+# --------------------------------------------------------------------------- #
+def test_trilaterate_recovers_known_point():
+    d = math.hypot(5, 5)
+    pts = [(0, 0, d), (10, 0, d), (0, 10, d)]
+    x, y = bps.trilaterate(pts)
+    assert abs(x - 5) < 0.05 and abs(y - 5) < 0.05
+
+
+def test_trilaterate_zero_radius_survives():
+    # Regression: a 0 radius must not divide-by-zero and abort the solve.
+    res = bps.trilaterate([(0, 0, 0.0), (10, 0, 10.0), (0, 10, 10.0)])
+    assert res is not None
+
+
+def test_min_weight_radius_tames_a_spuriously_short_reading():
+    truth = (140.0, 140.0)
+    far = [
+        (400.0, 140.0, 260.0),
+        (140.0, 400.0, 260.0),
+        (400.0, 400.0, math.hypot(260, 260)),
+    ]
+    liar = (100.0, 100.0, 0.01)          # claims the tracker is basically on it
+    honest = (140.0, 140.0, 20.0)        # 0.5 m at 40 px/m, corroborated
+    pts = far + [liar, honest]
+    d_unclamped = math.dist(bps.trilaterate(pts), truth)
+    d_clamped = math.dist(bps.trilaterate(pts, min_weight_radius=20.0), truth)
+    assert d_clamped < d_unclamped - 15.0  # the clamp pulls the fit off the liar
+
+
+# --------------------------------------------------------------------------- #
+# Tracker height + slant correction
+# --------------------------------------------------------------------------- #
+def test_tracker_height_default_and_override():
+    assert bps._tracker_height({}) == bps.TRACKER_HEIGHT_M
+    assert bps._tracker_height({"tracker_height": 0.3}) == 0.3
+    assert bps._tracker_height({"tracker_height": 99}) == bps.TRACKER_HEIGHT_M  # out of range
+
+
+def _run_radii(state, unit="m", height=None, tracker_height=None):
+    class St:
+        def __init__(self):
+            self.state = state
+            self.attributes = {"unit_of_measurement": unit}
+
+    class Hass:
+        states = type("S", (), {"get": staticmethod(lambda _eid: St())})()
+
+    rec = {"entity_id": "probe", "cords": {"x": 0, "y": 0}}
+    if height is not None:
+        rec["height"] = height
+    data = {"floor": [{"name": "F", "scale": SCALE, "receivers": [rec]}]}
+    if tracker_height is not None:
+        data["tracker_height"] = tracker_height
+    run(bps.update_receiver_radii(Hass(), {"entity": "phone", "data": data}))
+    return rec
+
+
+def test_no_height_leaves_distance_alone():
+    r = _run_radii("2.3")
+    assert abs(r["distance"] - 2.3) < 1e-9
+    assert abs(r["cords"]["r"] - 92.0) < 1e-6
+
+
+def test_height_removes_vertical_leg_from_radius_only():
+    # dz = 1.2 -> horizontal sqrt(2.3^2 - 1.2^2) = 1.962 m into the radius;
+    # the election "distance" stays the calibrated slant (cross-floor safe).
+    r = _run_radii("2.3", height=2.2)
+    assert abs(r["cords"]["r"] - 1.9621 * SCALE) < 0.1
+    assert abs(r["distance"] - 2.3) < 1e-9
+
+
+def test_height_underneath_clamps_radius_to_zero():
+    r = _run_radii("1.0", height=2.2)  # slant < vertical leg
+    assert r["cords"]["r"] == 0.0
+
+
+def test_nan_and_out_of_range_height_ignored():
+    assert abs(_run_radii("2.3", height=float("nan"))["cords"]["r"] - 92.0) < 1e-6
+    assert abs(_run_radii("2.3", height=float("inf"))["cords"]["r"] - 92.0) < 1e-6
+    assert abs(_run_radii("2.3", height=25)["cords"]["r"] - 92.0) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Calibration ground truth (2D vs 3D)
+# --------------------------------------------------------------------------- #
+def _cal(ha=None, hb=None):
+    return {"receivers": {
+        "a": {"x": 0.0, "y": 0.0, "scale": SCALE, "floor": "F", "height": ha},
+        "b": {"x": 120.0, "y": 0.0, "scale": SCALE, "floor": "F", "height": hb},
+    }}
+
+
+def test_true_distance_2d_when_heights_absent_or_partial():
+    assert abs(cal_mod._true_distance_m(_cal(), "a", "b") - 3.0) < 1e-9
+    assert abs(cal_mod._true_distance_m(_cal(ha=2.2), "a", "b") - 3.0) < 1e-9
+
+
+def test_true_distance_3d_when_both_heights_present():
+    # 3 m apart on the map, 0.3 m vs 2.2 m high -> sqrt(9 + 1.9^2) = 3.551 m.
+    assert abs(cal_mod._true_distance_m(_cal(ha=0.3, hb=2.2), "a", "b") - 3.5511) < 1e-3
+
+
+# --------------------------------------------------------------------------- #
+# Floor election helpers
+# --------------------------------------------------------------------------- #
+def test_score_rewards_agreement_and_coverage():
+    good = [(x, y, math.hypot(x - 400, y - 400), 1.0)
+            for (x, y) in [(0, 0), (800, 0), (0, 800), (800, 800), (400, 0)]]
+    conf, rms, cov = bps._score_floor_fit((400.0, 400.0), good, SCALE)
+    assert rms < 1e-6 and cov == 1.0 and conf > 0.99
+
+    bad = [(0, 0, 40.0, 1.0), (800, 0, 40.0, 1.0), (0, 800, 40.0, 1.0)]
+    conf_bad, rms_bad, _ = bps._score_floor_fit((400.0, 400.0), bad, SCALE)
+    assert rms_bad > 5.0 and conf_bad < conf
+
+
+def test_probabilities_converge_and_drop_renamed():
+    bps._floor_probability.clear()
+    for _ in range(30):
+        probs = bps._update_floor_probabilities("e", {"a": 0.8, "b": 0.2})
+    assert abs(probs["a"] - 0.8) < 0.02
+    probs = bps._update_floor_probabilities("e", {"c": 1.0}, valid_floors={"c"})
+    assert "a" not in probs and "b" not in probs
+
+
+def test_elect_hysteresis_and_dwell():
+    # No incumbent: adopt the best immediately.
+    floor, ch = bps._elect_floor({"a": 0.6, "b": 0.4}, None, {"a", "b"}, None)
+    assert floor == "a" and ch is None
+    # Incumbent holds within the margin.
+    floor, _ = bps._elect_floor({"a": 0.52, "b": 0.48}, "b", {"a", "b"}, None)
+    assert floor == "b"
+    # A leading challenger must persist FLOOR_SWITCH_CYCLES before switching.
+    ch = None
+    seen = []
+    for _ in range(4):
+        floor, ch = bps._elect_floor({"a": 0.7, "b": 0.3}, "b", {"a", "b"}, ch)
+        seen.append(floor)
+    assert seen[:bps.FLOOR_SWITCH_CYCLES] == ["b"] * (bps.FLOOR_SWITCH_CYCLES - 1) + ["a"]


### PR DESCRIPTION
Addresses the external audit findings that don't need an auth-model change. **The unauthenticated-endpoint fix (#1) is deliberately excluded** — it requires converting the iframe panel to an authenticated custom panel and ships on its own branch so it can be smoke-tested on a real HA.

## Fixes

**#2 — `save_text` path traversal (was Critical).** Client filenames and delete targets were joined onto `www/bps_maps` unsanitized, so `../` traversal or an absolute path could write/delete arbitrary files; `bpsdata.txt` was also truncated *before* the upload validated (partial-write corruption on error). Now:
- `_safe_maps_child` = `Path.name` + image-extension allowlist + `resolve()`/`is_relative_to` containment.
- `_write_save` validates the upload (extension + size cap) and the remove target **first**, writes the map, **then** `bpsdata.txt`, then deletes the old map — so a rejected input can't corrupt the layout.
- Non-JSON `coordinates` rejected before it can truncate the file.
- Delete path keeps containment but no extension gate (so any existing map stays deletable) and **protects `bpsdata.txt` + `bps_calibration_state.json`**.

**#3 — `watchdog` missing from manifest (was High).** The top-level `from watchdog...` import breaks a clean HA install that doesn't already have it. Added to `requirements`; `config_flow` now imports `DOMAIN` from `.const` instead of executing the heavy package root.

**#9 — `bermuda.dump_devices` had no timeout.** Both the liveness loop and the calibration sampler now use `asyncio.wait_for` so a hung service can't stall them.

**#10 — dead WebSocket API removed.** `BPSEntityWebSocket` (subscribe/unsubscribe/known_points) was never called by the frontend and leaked a state-change listener (dropped unsub callback). Deleted the class, its registration, and the now-unused `websocket_api` import.

**#5 — real tests + CI.** Committed a `tests/` suite that runs against the actual modules with HA stubbed (`conftest.py`): path-safety + write-after-validate, trilateration, slant/height correction, 3D calibration truth, floor-election scoring/probability/hysteresis. Added `.github/workflows/test.yaml` (py_compile + pytest + `node --check`), gave the HACS validate job its missing `actions/checkout`, and refreshed CONTRIBUTING (`master`→`main`, real test instructions).

## Verification

28 tests pass locally. Two adversarial-review rounds on the diff; the second caught the delete-path regression above, now fixed and regression-tested.

## Notes
- Version bumped to **1.8.1** (patch). Merge before #101 (no-go, 1.9.0) or rebase #101's bump. Neither #101 nor this touch the other's files.
- Follow-up incoming: the #1 authenticated-panel conversion (you chose the full custom-panel + Bearer-token approach) as a separate PR you'll want to smoke-test before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)