### PR TITLE
Authenticate BPS endpoints via a custom panel (audit #1, v1.8.2)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -1686,6 +1686,12 @@ class BPSFrontendView(HomeAssistantView):
         # copy but forces revalidation (a cheap 304 when unchanged, the new file
         # when it changed), so updates show up on a normal reload.
         response.headers["Cache-Control"] = "no-cache"
+        # bps-panel.js is loaded as an ES module (panel_custom), and browsers
+        # refuse a module served with a non-JS MIME type. Force it rather than
+        # trust the host's mimetypes registry (a Windows HA host can map .js to
+        # text/plain, which would silently blank the panel).
+        if file_name.endswith(".js"):
+            response.headers["Content-Type"] = "text/javascript"
         return response
 
 class BPSSaveAPIText(HomeAssistantView):

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -4,7 +4,8 @@ import time
 from pathlib import Path
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.frontend import async_register_built_in_panel, async_remove_panel
+from homeassistant.components.frontend import async_remove_panel
+from homeassistant.components import panel_custom
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.template import Template
 from homeassistant.core import HomeAssistant
@@ -1494,14 +1495,21 @@ async def async_setup(hass, config):
 
         if show_sidebar_panel:
             try:
-                _LOGGER.debug("Registering the built-in panel for BPS...")
-                async_register_built_in_panel(
-                    hass=hass,
-                    component_name="iframe",
+                _LOGGER.debug("Registering the custom panel for BPS...")
+                # A custom panel (not a bare iframe) so the panel element
+                # receives `hass` and can hand the app an HA access token to
+                # authenticate its /api/bps/* calls (those views now require
+                # auth). The element (bps-panel.js) still hosts the existing
+                # app in an inner iframe and only couriers the token in.
+                await panel_custom.async_register_panel(
+                    hass,
+                    frontend_url_path="bps",
+                    webcomponent_name="bps-panel",
+                    module_url="/bps/bps-panel.js",
                     sidebar_title="BPS",
                     sidebar_icon="mdi:map",
-                    frontend_url_path="bps",
-                    config={"url": "/bps/index.html"},
+                    require_admin=False,
+                    embed_iframe=False,
                 )
                 _LOGGER.info("Panel registered successfully.")
             except Exception as e:
@@ -1685,7 +1693,7 @@ class BPSSaveAPIText(HomeAssistantView):
 
     url = "/api/bps/save_text"
     name = "api:bps:save_text"
-    requires_auth = False
+    requires_auth = True
 
     async def post(self, request):
         """Handle saving coordinates to a text file."""
@@ -1795,7 +1803,7 @@ class BPSAdjustZonesAPI(HomeAssistantView):
 
     url = "/api/bps/adjust_zones"
     name = "api:bps:adjust_zones"
-    requires_auth = False
+    requires_auth = True
 
     async def post(self, request):
         hass = request.app["hass"]
@@ -1835,7 +1843,7 @@ class BPSReadAPIText(HomeAssistantView):
 
     url = "/api/bps/read_text"
     name = "api:bps:read_text"
-    requires_auth = False
+    requires_auth = True
 
     async def get(self, request):
         """Handle reading coordinates from the text file."""
@@ -1887,7 +1895,7 @@ class BPSReceiverStatusAPI(HomeAssistantView):
     """Current offline receivers (Bermuda liveness), polled live by the panel."""
     url = "/api/bps/receiver_status"
     name = "api:bps:receiver_status"
-    requires_auth = False
+    requires_auth = True
 
     async def get(self, request):
         hass = request.app["hass"]
@@ -1902,7 +1910,7 @@ class BPSScannerLinkingAPI(HomeAssistantView):
     never adds cost to a normal panel load or the tracking loop."""
     url = "/api/bps/scanner_linking"
     name = "api:bps:scanner_linking"
-    requires_auth = False
+    requires_auth = True
 
     async def get(self, request):
         hass = request.app["hass"]
@@ -1934,7 +1942,7 @@ class BPSMapsListAPI(HomeAssistantView):
     """API to list map files in /www/bps_maps."""
     url = "/api/bps/maps"
     name = "api:bps:maps"
-    requires_auth = False
+    requires_auth = True
 
     @staticmethod
     def _list_map_files(maps_path):
@@ -1964,7 +1972,7 @@ class BPSTrackerIconsListAPI(HomeAssistantView):
 
     url = "/api/bps/tracker_icons"
     name = "api:bps:tracker_icons"
-    requires_auth = False
+    requires_auth = True
 
     @staticmethod
     def _list_tracker_icons(icons_path):
@@ -1997,7 +2005,7 @@ class BPSUploadTrackerIconAPI(HomeAssistantView):
 
     url = "/api/bps/upload_tracker_icon"
     name = "api:bps:upload_tracker_icon"
-    requires_auth = False
+    requires_auth = True
 
     async def post(self, request):
         hass = request.app["hass"]
@@ -2031,7 +2039,7 @@ class BPSCordsAPI(HomeAssistantView):
 
     url = "/api/bps/cords"
     name = "api:bps:cords"
-    requires_auth = False
+    requires_auth = True
 
     def __init__(self, hass):
         """Spara referens till hass"""

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -1002,7 +1002,7 @@ class BPSCalibrationAPI(HomeAssistantView):
 
     url = "/api/bps/calibration"
     name = "api:bps:calibration"
-    requires_auth = False
+    requires_auth = True
 
     async def get(self, request):
         hass = request.app["hass"]

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -336,6 +336,15 @@ class BpsMapCard extends HTMLElement {
       .replace(/-/g, "_");
   }
 
+  // GET a /api/bps/* endpoint with the logged-in user's token attached (those
+  // endpoints now require auth). The card always has `hass`, so this is direct.
+  async _apiFetch(path) {
+    const auth = this._hass && this._hass.auth;
+    const token = auth && (auth.accessToken || (auth.data && auth.data.access_token));
+    const headers = token ? { Authorization: "Bearer " + token } : {};
+    return fetch(path, { headers });
+  }
+
   async _refreshBermudaScanners() {
     const hass = this._hass;
     if (!hass?.callWS || !this._config?.show_receivers) return;
@@ -601,7 +610,7 @@ class BpsMapCard extends HTMLElement {
   }
 
   async _loadFloorResources(expectedGen) {
-    const res = await fetch("/api/bps/read_text");
+    const res = await this._apiFetch("/api/bps/read_text");
     if (!res.ok) throw new Error(`Could not read BPS data (${res.status})`);
     if (expectedGen !== this._runGeneration) {
       return;
@@ -651,7 +660,7 @@ class BpsMapCard extends HTMLElement {
     }
 
     const floorName = String(resolvedFloorName || this._config.floor || "").trim();
-    const mapsRes = await fetch("/api/bps/maps");
+    const mapsRes = await this._apiFetch("/api/bps/maps");
     if (!mapsRes.ok) {
       throw new Error(
         `Could not list map files (${mapsRes.status}). Set map_file explicitly or check /api/bps/maps.`,
@@ -972,7 +981,7 @@ class BpsMapCard extends HTMLElement {
     try {
       // A 404 here just means no tracker has position data yet; receivers
       // should still render, so this is not an early return.
-      const res = await fetch("/api/bps/cords");
+      const res = await this._apiFetch("/api/bps/cords");
       if (res.ok) {
         const list = await res.json();
         if (Array.isArray(list)) {

--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -597,6 +597,12 @@ class BpsMapCard extends HTMLElement {
     } catch (e) {
       console.error(e);
       this._setStatus(e.message || String(e));
+      // The one-shot bootstrap otherwise never retries (set hass only
+      // re-bootstraps when _bootstrapPromise is falsy). Now that read_text /
+      // maps require auth, a transient 401/network blip here would leave the
+      // card permanently broken. Re-arm after a delay so a later hass update
+      // retries — throttled so a persistent failure can't hammer the endpoint.
+      setTimeout(() => { this._bootstrapPromise = null; }, 15000);
     }
   }
 

--- a/custom_components/bps/frontend/bps-panel.js
+++ b/custom_components/bps/frontend/bps-panel.js
@@ -14,6 +14,13 @@ class BpsPanel extends HTMLElement {
     this._iframe = null;
     this._lastToken = null;
     this._onMessage = this._onMessage.bind(this);
+    // Register on the constructor, not connectedCallback: HA may detach and
+    // re-attach the SAME element instance (e.g. after the tab is backgrounded),
+    // and the inner iframe reloads on re-attach. A listener added in
+    // connectedCallback would be removed on detach and — because the reconnect
+    // path early-returns on the existing iframe — never re-added, so the
+    // reloaded app's "bps-ready" would go unheard and every API call would 401.
+    window.addEventListener("message", this._onMessage);
   }
 
   set hass(hass) {
@@ -26,7 +33,13 @@ class BpsPanel extends HTMLElement {
   set panel(_v) {}
 
   connectedCallback() {
-    if (this._iframe) return;
+    if (this._iframe) {
+      // Reconnect (same instance re-attached): the iframe reloads, so re-arm
+      // the token once its app comes back up.
+      this._lastToken = null;
+      this._pushToken(true);
+      return;
+    }
     this.style.display = "block";
     this.style.height = "100%";
     this.style.width = "100%";
@@ -40,14 +53,7 @@ class BpsPanel extends HTMLElement {
     iframe.style.display = "block";
     this._iframe = iframe;
 
-    // The app announces itself once its message listener is live; answer with
-    // the token regardless of whether it changed (the app may have (re)loaded).
-    window.addEventListener("message", this._onMessage);
     this.appendChild(iframe);
-  }
-
-  disconnectedCallback() {
-    window.removeEventListener("message", this._onMessage);
   }
 
   _onMessage(event) {

--- a/custom_components/bps/frontend/bps-panel.js
+++ b/custom_components/bps/frontend/bps-panel.js
@@ -1,0 +1,81 @@
+// BPS custom panel — a thin courier.
+//
+// The BPS setup app is a standalone page served at /bps/index.html. It used to
+// be shown as a bare Home Assistant `iframe` panel, which has no access to the
+// logged-in user's token — so the /api/bps/* endpoints had to be left
+// unauthenticated. This element is registered as a `panel_custom` instead, so
+// Home Assistant sets `hass` on it; it keeps hosting the app in an inner iframe
+// (no rewrite of the app) and simply forwards the current access token in via
+// postMessage. The app attaches that token as a Bearer header on every API
+// call, and the endpoints now require auth.
+class BpsPanel extends HTMLElement {
+  constructor() {
+    super();
+    this._iframe = null;
+    this._lastToken = null;
+    this._onMessage = this._onMessage.bind(this);
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._pushToken(); // fires on every hass update -> covers token refresh
+  }
+
+  set narrow(_v) {}
+  set route(_v) {}
+  set panel(_v) {}
+
+  connectedCallback() {
+    if (this._iframe) return;
+    this.style.display = "block";
+    this.style.height = "100%";
+    this.style.width = "100%";
+
+    const iframe = document.createElement("iframe");
+    iframe.src = "/bps/index.html";
+    iframe.setAttribute("title", "BPS");
+    iframe.style.border = "0";
+    iframe.style.width = "100%";
+    iframe.style.height = "100%";
+    iframe.style.display = "block";
+    this._iframe = iframe;
+
+    // The app announces itself once its message listener is live; answer with
+    // the token regardless of whether it changed (the app may have (re)loaded).
+    window.addEventListener("message", this._onMessage);
+    this.appendChild(iframe);
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener("message", this._onMessage);
+  }
+
+  _onMessage(event) {
+    if (event.origin !== window.location.origin) return;
+    if (!this._iframe || event.source !== this._iframe.contentWindow) return;
+    if (event.data === "bps-ready") {
+      this._pushToken(true); // force: a freshly (re)loaded app has no token yet
+    }
+  }
+
+  _token() {
+    const auth = this._hass && this._hass.auth;
+    if (!auth) return null;
+    // home-assistant-js-websocket exposes `accessToken`; older builds only had
+    // `data.access_token`. Accept either.
+    return auth.accessToken || (auth.data && auth.data.access_token) || null;
+  }
+
+  _pushToken(force) {
+    if (!this._iframe) return;
+    const cw = this._iframe.contentWindow;
+    if (!cw) return;
+    const token = this._token();
+    if (!token) return;
+    if (!force && token === this._lastToken) return;
+    cw.postMessage({ type: "bps-auth", token }, window.location.origin);
+    this._lastToken = token;
+  }
+}
+
+customElements.define("bps-panel", BpsPanel);

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1,6 +1,36 @@
 document.addEventListener('DOMContentLoaded', async () => {
     const canvas = document.getElementById('canvas');
     const ctx = canvas.getContext('2d');
+
+    // --- API auth token (see bps-panel.js) ---------------------------------
+    // The BPS panel element couriers the HA access token in via postMessage;
+    // every /api/bps/* call goes through bpsFetch(), which attaches it as a
+    // Bearer header (those endpoints now require auth). API calls hold until
+    // the first token arrives so none fire unauthenticated — but never block
+    // forever: if the app is opened outside the panel, calls proceed after a
+    // short wait and 401 visibly rather than hanging.
+    let bpsAuthToken = null;
+    let _resolveToken = null;
+    const _tokenReady = new Promise((resolve) => { _resolveToken = resolve; });
+    const _settleToken = () => { if (_resolveToken) { _resolveToken(); _resolveToken = null; } };
+    window.addEventListener("message", (e) => {
+        if (e.origin !== window.location.origin) return;
+        if (e.data && e.data.type === "bps-auth" && e.data.token) {
+            bpsAuthToken = e.data.token;
+            _settleToken();
+        }
+    });
+    if (window.parent && window.parent !== window) {
+        window.parent.postMessage("bps-ready", window.location.origin);
+    }
+    setTimeout(_settleToken, 5000);
+
+    async function bpsFetch(url, opts = {}) {
+        if (bpsAuthToken === null) await _tokenReady;
+        const headers = Object.assign({}, opts.headers || {});
+        if (bpsAuthToken) headers["Authorization"] = "Bearer " + bpsAuthToken;
+        return fetch(url, Object.assign({}, opts, { headers }));
+    }
     const upload = document.getElementById('upload');
     const mapSelector = document.getElementById('mapSelector');
     const entSelector = document.getElementById('entSelector');
@@ -83,7 +113,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // picks up the new set on its own).
     async function fetchReceiverStatus() {
         try {
-            const res = await fetch('/api/bps/receiver_status');
+            const res = await bpsFetch('/api/bps/receiver_status');
             if (!res.ok) return;
             const data = await res.json();
             const next = Array.isArray(data.offline) ? data.offline : [];
@@ -381,7 +411,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ensureIconOption("/bps/person.svg", "Person (default)");
         ensureIconOption("/bps/beacon.svg", "Beacon");
         try {
-            const response = await fetch("/api/bps/tracker_icons");
+            const response = await bpsFetch("/api/bps/tracker_icons");
             if (!response.ok) {
                 return;
             }
@@ -410,7 +440,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         async function getSavedMaps(){
-            const mapsResponse = await fetch('/api/bps/maps');
+            const mapsResponse = await bpsFetch('/api/bps/maps');
             if (!mapsResponse.ok) {
                 console.error('Failed to fetch maps:', mapsResponse.statusText);
                 bpsToast('Could not load maps.');
@@ -1446,7 +1476,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const apiUrl = "/api/bps/read_text"; // API endpoint to read the file
         
             try {
-                const response = await fetch(apiUrl); // Make a GET request to the API
+                const response = await bpsFetch(apiUrl); // Make a GET request to the API
         
             if (!response.ok) {
                 console.error("Failed to fetch BPS data:", response.statusText); // Handle error status
@@ -1496,7 +1526,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const apiUrl = "/api/bps/cords"; 
         
             try {
-                const response = await fetch(apiUrl); // Make a GET request to the API
+                const response = await bpsFetch(apiUrl); // Make a GET request to the API
         
             if (!response.ok) {
                 console.error("Failed to fetch BPS data:", response.statusText); // Handle error status
@@ -1635,7 +1665,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const uploadData = new FormData();
                 uploadData.append("icon", iconFile);
                 try {
-                    const response = await fetch("/api/bps/upload_tracker_icon", {
+                    const response = await bpsFetch("/api/bps/upload_tracker_icon", {
                         method: "POST",
                         body: uploadData,
                     });
@@ -3572,7 +3602,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         renderDebugView();
         let data = { placed: [], unplaced: [], beacons: [] };
         try {
-            const res = await fetch('/api/bps/scanner_linking');
+            const res = await bpsFetch('/api/bps/scanner_linking');
             if (res.ok) {
                 const parsed = await res.json();
                 if (parsed && typeof parsed === 'object') {
@@ -4305,7 +4335,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const square = squareEl.checked;
         summary.textContent = 'Computing…';
         try {
-            const res = await fetch('/api/bps/adjust_zones', {
+            const res = await bpsFetch('/api/bps/adjust_zones', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -4516,7 +4546,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         try {
-            const response = await fetch('/api/bps/save_text', {
+            const response = await bpsFetch('/api/bps/save_text', {
                 method: 'POST',
                 body: data,
             });
@@ -4564,7 +4594,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     async function calibRequest(body) {
-        const res = await fetch('/api/bps/calibration', {
+        const res = await bpsFetch('/api/bps/calibration', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
@@ -4731,7 +4761,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     async function pollCalibration() {
         try {
-            const res = await fetch('/api/bps/calibration');
+            const res = await bpsFetch('/api/bps/calibration');
             if (!res.ok) return;
             const status = await res.json();
             renderCalibration(status);

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -3,11 +3,11 @@
     "name": "BLE Positioning System",
     "codeowners": ["@maxi1134"],
     "config_flow": true,
-    "dependencies": ["http"],
+    "dependencies": ["http", "panel_custom"],
     "documentation": "https://github.com/maxi1134/BPS-improved",
     "integration_type": "device",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2", "watchdog>=2.1.0"],
-    "version": "1.8.1"
+    "version": "1.8.2"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,8 +78,17 @@ def _install_homeassistant_stubs():
         Response=_Response, json_response=_json_response, FileResponse=object,
     ))
     _module("homeassistant")
-    _module("homeassistant.components")
+    components = _module("homeassistant.components")
     _module("homeassistant.components.http", HomeAssistantView=object)
+
+    async def _async_register_panel(*a, **k):
+        return None
+
+    panel_custom = _module("homeassistant.components.panel_custom",
+                           async_register_panel=_async_register_panel)
+    # `from homeassistant.components import panel_custom` reads the attribute
+    # off the parent package, so expose it there too.
+    components.panel_custom = panel_custom
     _module(
         "homeassistant.components.frontend",
         async_register_built_in_panel=lambda *a, **k: None,

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -154,6 +154,25 @@ def test_jfif_upload_accepted(tmp_path):
     assert (maps / "attic.jfif").read_bytes() == b"JPEG"
 
 
+def test_all_api_views_require_auth_static_stays_public():
+    # Every /api/bps/* data/mutation view must require auth; the static
+    # /bps/{file} view stays public so the custom panel can load (audit #1).
+    import inspect
+    api_views, static_views = [], []
+    for obj in vars(bps).values():
+        if inspect.isclass(obj) and isinstance(getattr(obj, "url", None), str):
+            if obj.url.startswith("/api/bps/"):
+                api_views.append(obj)
+            elif obj.url.startswith("/bps/"):
+                static_views.append(obj)
+    assert len(api_views) >= 9, [v.__name__ for v in api_views]
+    for v in api_views:
+        assert getattr(v, "requires_auth", None) is True, f"{v.__name__} ({v.url})"
+    assert static_views, "expected the static frontend view"
+    for v in static_views:
+        assert getattr(v, "requires_auth", None) is False, f"{v.__name__} must stay public"
+
+
 def test_delete_traversal_still_blocked(tmp_path):
     # Containment must still reject an attempt to escape the maps dir.
     maps = tmp_path / "bps_maps"


### PR DESCRIPTION
Closes audit finding #1 (unauthenticated endpoints). **Stacked on #102** (hardening) — merge that first.

> ⚠️ **Needs a real-HA smoke test before release.** Panel registration and token delivery can't be exercised in my test harness. Please confirm the BPS sidebar panel loads and can save a floor on a live HA.

## The problem

The BPS panel was a bare iframe with no access to the user's token, so every `/api/bps/*` view was `requires_auth=False`. Anyone able to reach the HA HTTP server could read **live occupant coordinates** and the floor plan, and mutate calibration/layout — no login.

## The fix (custom-panel courier, no app rewrite)

- Register the panel as a **`panel_custom`** element instead of an iframe, so the panel element gets `hass`. A thin courier (`frontend/bps-panel.js`) still hosts the existing app in an inner iframe and `postMessage`s the HA access token in (re-sent on token refresh and on reconnect).
- The app routes all 11 `/api/bps/*` calls through **`bpsFetch()`**, which waits for the first token then attaches `Authorization: Bearer` (5 s fallback so it degrades to visible 401s rather than hanging).
- The Lovelace card already has `hass`; its 3 API GETs attach the token via `_apiFetch()`.
- **`requires_auth=True`** on all 10 `/api/bps/*` views; the static `/bps/{file}` view stays public so the panel/module/app can load. Forced `text/javascript` on the served module so a host mimetype quirk can't blank the panel.

## Verified

Browser harness: the app receives the token via postMessage and **all 6 on-load API calls carry the Bearer header** (zero unauthenticated). A committed test asserts every `/api/bps` view requires auth while the static view stays public. Two adversarial-review rounds; the second caught a background-tab reconnect token-loss regression, a module-MIME hazard, and a card no-retry issue — all fixed here.

## Known remaining items (deliberately not in this PR)

1. **Static layout still readable via `/local/` (medium).** `bpsdata.txt` and `bps_calibration_state.json` live under `www/`, which HA serves publicly at `/local/` regardless of this change — so the *static* layout/calibration data is still fetchable unauthenticated. The **live** position data (`/api/bps/cords`, in-memory) **is** now protected. Closing this fully means relocating those two files out of `www/` (map images must stay, since `<img>` can't carry a token) plus a migration — I'd do it as a focused follow-up.
2. **Any authenticated user, not admin-only (low).** Endpoints accept any HA user's token, matching the panel's `require_admin=False` (the app is meant for all household users). Add `is_admin` checks on the mutating POSTs if you want config changes admin-restricted.

Version 1.8.2 (stacks after #102's 1.8.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)