### PR TITLE
Sidebar UX: consistent receiver actions + distinct no-go icon (v1.7.1)

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3066,6 +3066,18 @@ select.bps-input { cursor: pointer; }
 .bps-zone-head .bps-zone-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .bps-zone-group li:hover { background: hsl(var(--sidebar-accent)); }
 .bps-zone-group li.bps-rec-row { cursor: pointer; }
+/* Let the receiver name grow so its actions group (height + delete) is pinned
+   to a fixed right-hand column — consistent across rows regardless of name
+   length or the mount-height badge. */
+.bps-rec-row > span:first-child { flex: 1 1 auto; min-width: 0; }
+/* Divider before the no-go toggle: separates the two colour controls (swatch
+   + colour on/off) from the structural actions so they don't read as a pair. */
+.bps-zone-actions .bps-nogo-btn {
+    margin-left: 5px;
+    padding-left: 7px;
+    border-left: 1px solid hsl(var(--border));
+    border-radius: 0;
+}
 /* The receiver currently focused on the map: accent bar + tint, held on hover
    so the active row stays distinguishable from a plain hover. */
 .bps-zone-group li.bps-rec-focused,

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -3908,7 +3908,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const colorOnSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="currentColor"></circle></svg>';
         const colorOffSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="8"></circle><line x1="6" y1="18" x2="18" y2="6"></line></svg>';
         // No-entry sign: toggle a zone as no-go dead space (issue #60).
-        const noGoSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"></circle><line x1="5.6" y1="5.6" x2="18.4" y2="18.4"></line></svg>';
+        // Hatched square — mirrors the grey diagonal hatching a no-go zone gets
+        // on the map, and is unmistakably different from the colour-toggle's
+        // slashed circle (they used to be two near-identical circles).
+        const noGoSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><line x1="3" y1="14" x2="14" y2="3"></line><line x1="9" y1="21" x2="21" y2="9"></line></svg>';
         // Stable per-floor suffix so the two synthetic groups ("No zone" /
         // "Unlinked sub-zones") collapse independently on each floor, like real
         // zones do (those get globally-unique zone ids). Floor names don't churn,
@@ -3959,11 +3962,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             // height (m above this floor); the badge shows the current value.
             const hBadge = Number.isFinite(r.height)
                 ? `<span class="bps-rec-height" title="Mount height above this floor">${escHtml(String(r.height))} m</span>` : "";
+            // Badge + buttons live in an actions group (like zone rows) so the
+            // height and delete buttons sit in a fixed right-hand column, no
+            // matter the receiver name's length or whether a badge is shown.
             return `<li class="${cls}" data-type="focusrec" data-id="${escHtml(r.entity_id)}">`
                 + `<span title="${escHtml(r.entity_id)}"${off ? ' style="color:#d32f2f"' : ''}>${escHtml(label)}</span>`
+                + `<span class="bps-zone-actions">`
                 + hBadge
                 + `<button class="bps-icon-btn" title="Set mount height (m)" data-type="recheight" data-id="${escHtml(r.entity_id)}">${rulerSvg}</button>`
-                + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button></li>`;
+                + `<button class="bps-icon-btn" title="Remove receiver" data-type="removerec" data-id="${escHtml(r.entity_id)}">${trashSvg}</button>`
+                + `</span></li>`;
         };
 
         const receivers = (floor.receivers || []).filter(r => r && r.entity_id && r.cords);
@@ -3983,7 +3991,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const zoneActions = '<span class="bps-zone-actions">'
                 + `<input type="color" class="bps-zone-swatch${uncolored ? ' bps-swatch-off' : ''}" data-type="zonecolor" data-id="${escHtml(zoneDomId)}" value="${colorToHex(zoneColor)}" title="Pick zone colour">`
                 + `<button class="bps-icon-btn" title="${uncolored ? 'Add colour' : 'Remove colour'}" data-type="zonetogglecolor" data-id="${escHtml(zoneDomId)}">${uncolored ? colorOnSvg : colorOffSvg}</button>`
-                + `<button class="bps-icon-btn${noGo ? ' bps-nogo-on' : ''}" title="${noGo ? 'Unmark no-go zone' : 'Mark as no-go (dead space — nothing can be here)'}" data-type="zonetogglenogo" data-id="${escHtml(zoneDomId)}">${noGoSvg}</button>`
+                + `<button class="bps-icon-btn bps-nogo-btn${noGo ? ' bps-nogo-on' : ''}" title="${noGo ? 'Unmark no-go zone' : 'Mark as no-go (dead space — nothing can be here)'}" data-type="zonetogglenogo" data-id="${escHtml(zoneDomId)}">${noGoSvg}</button>`
                 + `<button class="bps-icon-btn" title="Edit zone" data-type="editzone" data-id="${escHtml(zoneDomId)}">${pencilSvg}</button>`
                 + `<button class="bps-icon-btn" title="Remove zone" data-type="removezone" data-id="${escHtml(zoneDomId)}">${trashSvg}</button>`
                 + '</span>';

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2", "watchdog>=2.1.0"],
-    "version": "1.7.0"
+    "version": "1.7.1"
 }


### PR DESCRIPTION
Two small sidebar fixes from testing feedback.

## Height button drifts across receiver rows
Receiver rows rendered `[name] [badge] [↕ height] [🗑]` as bare children of a `space-between` row, so `justify-content` spread them by name length — the ↕ button landed in a different spot on every row. Now the badge + buttons live in an actions group (like zone rows) and the name flex-grows, so **↕ and 🗑 sit in a fixed right-hand column**, consistent regardless of name length or whether a height badge is shown. Verified in-harness: the ↕ button is at the same x on all rows, badge or not.

## The two round buttons look identical
The **no-go** toggle was a circle with a `\` slash, right next to the **remove-colour** toggle — a circle with a `/` slash. Near-indistinguishable at 14px. The no-go button is now a **hatched square**, matching the grey diagonal hatching a no-go zone gets on the map, with a thin divider separating the two colour controls (swatch + colour on/off) from the structural actions. Circle = colour, hatched square = no-go.

Frontend-only (`script.js` + `bpsstyle.css`); no behaviour change — the same click handlers, just regrouped markup and a new icon. Zero console errors in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)