### PR TITLE
Fix zone editing while tracking: handles vanishing + name field off-map (v1.7.1)

### DIFF
--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2610,20 +2610,44 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        const cx = zonePoints.reduce((s, p) => s + p.x, 0) / zonePoints.length;
-        const topY = Math.min(...zonePoints.map(p => p.y));
-        const css = cssFromWorld(cx, topY);
-
-        zoneInputElement.style.left = `${css.left - 40}px`;
-        zoneInputElement.style.top = `${css.top - 40}px`;
-        zoneInputElement.style.display = "block";
+        // Show first so offsetWidth/Height are measurable, then position.
         zoneInputElement.style.position = "absolute";
-
-        // X button hugging the name field's top-right corner.
+        zoneInputElement.style.display = "block";
         zoneCancelBtn.style.position = "absolute";
         zoneCancelBtn.style.display = "block";
-        zoneCancelBtn.style.left = `${css.left - 40 + zoneInputElement.offsetWidth + 4}px`;
-        zoneCancelBtn.style.top = `${css.top - 40}px`;
+
+        const cx = zonePoints.reduce((s, p) => s + p.x, 0) / zonePoints.length;
+        const topY = Math.min(...zonePoints.map(p => p.y));
+        const botY = Math.max(...zonePoints.map(p => p.y));
+
+        // Keep the name field (+ its ✕) ON the map. Prefer just above the zone;
+        // if that would clip off the top of the map, drop it just below the
+        // zone instead; and if the zone spans the whole map height, clamp it
+        // inside as a last resort. Also clamp horizontally so an edge zone's
+        // field never spills off the side (issue: name field shown off-map).
+        const rect = canvas.getBoundingClientRect();
+        const mapLeft = rect.left + window.scrollX;
+        const mapTop = rect.top + window.scrollY;
+        const M = 6; // margin from the map edges
+        const groupW = zoneInputElement.offsetWidth + 4 + zoneCancelBtn.offsetWidth;
+        const groupH = Math.max(zoneInputElement.offsetHeight, zoneCancelBtn.offsetHeight);
+        const minTop = mapTop + M;
+        const maxTop = mapTop + rect.height - groupH - M;
+        const aboveTop = cssFromWorld(cx, topY).top - groupH - M;
+        const belowTop = cssFromWorld(cx, botY).top + M;
+        let top;
+        if (aboveTop >= minTop) top = aboveTop;            // room above the zone
+        else if (belowTop <= maxTop) top = belowTop;       // else below the zone
+        else top = Math.min(Math.max(aboveTop, minTop), maxTop); // clamp inside
+
+        let left = cssFromWorld(cx, topY).left - 40;
+        left = Math.min(Math.max(left, mapLeft + M), mapLeft + rect.width - groupW - M);
+
+        zoneInputElement.style.left = `${left}px`;
+        zoneInputElement.style.top = `${top}px`;
+        // X button hugging the name field's top-right corner.
+        zoneCancelBtn.style.left = `${left + zoneInputElement.offsetWidth + 4}px`;
+        zoneCancelBtn.style.top = `${top}px`;
 
         // Draw the polygon so far
         ctx.beginPath();

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -193,6 +193,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function redrawAll() {
+        // While a zone/sub-zone is being drawn or edited, repaint through
+        // drawZonePreview so the corner handles (and the shape-in-progress)
+        // survive. Otherwise a tracking-poll redraw every tick would wipe the
+        // handles mid-edit — they'd flash in on "Edit" and vanish on the next
+        // poll. drawZonePreview repaints the elements too; the tracker overlay
+        // then goes on top so the live fix still updates while editing.
+        if (drawAreaButton.dataset.active === 'true' || drawSubZoneButton.dataset.active === 'true') {
+            drawZonePreview();
+            drawTrackOverlay();
+            return;
+        }
         clearCanvas();
         drawElements();
         drawTrackOverlay();

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2", "watchdog>=2.1.0"],
-    "version": "1.7.0"
+    "version": "1.7.1"
 }


### PR DESCRIPTION
Two zone-editing fixes (the second surfaced while testing the first).

## 1. Corner handles vanish while tracking
Clicking **Edit** on a zone shows draggable corner handles, but if a beacon is being tracked they disappear immediately — the zone is effectively uneditable during a session.

**Cause:** the handles are painted by `drawZonePreview()`, but `redrawAll()` (which the tracking poll calls every tick) never redrew them, so each poll wiped them.

**Fix:** `redrawAll()` now repaints through `drawZonePreview()` whenever a zone/sub-zone draw or edit is in progress, then draws the tracker overlay on top — handles persist across poll redraws while the live fix keeps updating.

Verified: a "living" zone corner stayed solid-red `(255,0,0)` across a `redrawAll` fired mid-edit (reverted to the faint background before the fix).

## 2. Name field shown off the map for edge zones
The floating name field was pinned at `zone-top − 40px`, so editing a zone near the **top edge** pushed the field above the map (as in the report), and a right-edge zone could spill past the side.

**Fix:** position it defensively — prefer just above the zone, flip to just below when there's no room above, clamp inside as a last resort, plus a horizontal clamp. The field (and its ✕) now always stay on the map and, where possible, off the zone being edited.

Verified: a top-right edge zone's field lands fully inside the map (flipped below the zone, right edge clamped); a mid-map zone still shows the field just above it. Zero console errors.

Frontend-only (`script.js`).

> Note: #105 (sidebar UX) also bumps to 1.7.1. Merge both together into a single 1.7.1 (they touch different parts of `script.js`; only the manifest version line collides), or rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)