### PR TITLE
Move layout + calibration state to HA .storage (fixes #104, v1.7.2)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -25,8 +25,6 @@ import json
 import re
 import copy
 import difflib
-from watchdog.observers import Observer
-from watchdog.events import FileSystemEventHandler
 from shapely.geometry import Point, Polygon
 from shapely.ops import nearest_points, unary_union
 try:
@@ -36,12 +34,18 @@ except ImportError:  # very old shapely
 from asyncio import Lock, Queue, wait_for, TimeoutError
 
 from .calibration import (
-    BPS_FILE_LOCK,
     BPSCalibrationAPI,
     async_restore_calibration_state,
     async_shutdown_calibration,
     async_start_auto_if_enabled,
     refresh_receivers_from_coords,
+)
+from .storage import (
+    BPS_FILE_LOCK,
+    get_bps_data,
+    load_bps_data,
+    migrate_legacy,
+    save_bps_data,
 )
 from .zone_adjust import adjust_zones, adjust_subzones
 
@@ -52,8 +56,7 @@ OPTION_SHOW_SIDEBAR_PANEL = "show_sidebar_panel"
 FRONTEND_PATH = Path(__file__).parent / "frontend"
 LEGACY_BPS_ENTITY_PATTERN = re.compile(r"^sensor\.(.+)_\1_bps_(zone|floor)$")
 
-# Global data
-global_data = []
+# Global data (the layout now lives in the Store; see storage.get_bps_data)
 state_change_lock = Lock()
 state_change_counter = {}
 update_queue = Queue()
@@ -305,53 +308,9 @@ def cleanup_legacy_bps_registry_and_states(hass: HomeAssistant):
         _LOGGER.info("Removing legacy BPS state: %s", entity_id)
         hass.states.async_remove(entity_id)
 
-class FileWatcher(FileSystemEventHandler):
-    """A class to handle file changes"""
-    def __init__(self, file_path, callback, hass: HomeAssistant):
-        self.file_path = file_path
-        self.callback = callback
-        self.hass = hass  # Reference to the Home Assistant instance
-
-    def on_modified(self, event):
-        """Called when the file changes"""
-        if event.src_path == self.file_path:
-            asyncio.run_coroutine_threadsafe(self.callback(), self.hass.loop)
-
-async def read_file(file_path):
-    """Read data asynchronously from the file"""
-    try:
-        async with aiofiles.open(file_path, mode="r") as file:
-            content = await file.read()
-        return content
-    except FileNotFoundError:
-        _LOGGER.warning("File not found: %s", file_path)
-        return ""
-    except Exception as e:
-        _LOGGER.error("Error reading file %s: %s", file_path, e)
-        return ""
-
-def setup_file_watcher(file_path, update_callback, hass: HomeAssistant):
-    """Set up a file watcher to monitor changes"""
-    event_handler = FileWatcher(file_path, update_callback, hass)
-    observer = Observer()
-    observer.schedule(event_handler, os.path.dirname(file_path), recursive=False)
-    observer.start()
-    return observer
-
-async def update_global_data(file_path):
-    """Update global_data with the contents of the file"""
-    global global_data
-    new_data = await read_file(file_path) 
-    try:
-        global_data = json.loads(new_data) if new_data else []
-
-        _LOGGER.info("Updated global_data: %s", global_data)
-    except json.JSONDecodeError as e:
-        _LOGGER.error("Error parsing JSON data: %s", e)
-
 async def update_tracked_entities(hass, jinja_code):
     """Update tracked_entities with the result of the Jinja code once per second."""
-    global tracked_entities, tracked_listeners, global_data, new_global_data
+    global tracked_entities, tracked_listeners, new_global_data
     global secToUpdate
     template = Template(jinja_code, hass)  # compile once; async_render re-evaluates each tick
     while True:
@@ -379,7 +338,8 @@ async def update_tracked_entities(hass, jinja_code):
             cleaned = [item.split("_distance_to_")[0].replace("sensor.", "") for item in tracked_entities]
             unique_values = list(set(cleaned))
             # Use a separate copy per entity to avoid cross-entity mutation side effects.
-            new_global_data = [{"entity": ent, "data": copy.deepcopy(global_data)} for ent in unique_values]
+            layout = get_bps_data(hass)
+            new_global_data = [{"entity": ent, "data": copy.deepcopy(layout)} for ent in unique_values]
             
             await process_entities(hass, new_global_data)
 
@@ -1114,8 +1074,9 @@ async def prune_stale_positions(hass):
     """
     global apitricords
     timeout = STALE_POSITION_SECS
-    if isinstance(global_data, dict):
-        configured = global_data.get("position_timeout")
+    layout = get_bps_data(hass)
+    if isinstance(layout, dict):
+        configured = layout.get("position_timeout")
         if isinstance(configured, (int, float)) and configured > 0:
             timeout = configured
 
@@ -1542,7 +1503,6 @@ async def async_setup(hass, config):
         config_path = hass.config.path()
         target_dir = os.path.join(config_path, "www", "bps_maps")
         tracker_icons_dir = os.path.join(config_path, "www", "bps_icons")
-        target_file = os.path.join(target_dir, "bpsdata.txt")
 
         try:
             await aiofiles.os.makedirs(target_dir, exist_ok=True)
@@ -1593,26 +1553,11 @@ async def async_setup(hass, config):
         else:
             _LOGGER.info("BPS sidebar panel is disabled by integration options.")
 
-        try:
-            if not os.path.exists(target_file):
-                async with aiofiles.open(target_file, mode="w") as file:
-                    await file.write("")  # Skapa en tom fil
-                _LOGGER.info(f"File {target_file} has been created.")
-            else:
-                _LOGGER.info(f"File {target_file} already exist.")
-        except Exception as e:
-            _LOGGER.error(f"Could not create file {target_file}: {e}")
-
-        await update_global_data(target_file)
-
-        # Stop any previous watcher before creating a new one on reload.
-        old_observer = hass.data.get("bps_observer")
-        if old_observer:
-            old_observer.stop()
-            old_observer.join(timeout=2)
-
-        observer = setup_file_watcher(target_file, lambda: update_global_data(target_file), hass)
-        hass.data["bps_observer"] = observer
+        # Move any legacy www/bps_maps flat files into the Store (once), then
+        # load the layout into the in-memory cache. Store writes are atomic, so
+        # a crash can no longer leave a 0-byte layout (issue #104).
+        await migrate_legacy(hass)
+        await load_bps_data(hass)
 
         jinja_code = """
         {{
@@ -1632,7 +1577,6 @@ async def async_setup(hass, config):
         async def handle_homeassistant_stop(event):
             """Stop background work promptly so shutdown cannot drag or leave
             the unload half-done (which strands stale registry entries)."""
-            observer.stop()
             update_task = hass.data.pop("bps_update_task", None)
             if update_task:
                 update_task.cancel()
@@ -1694,11 +1638,6 @@ async def async_unload_entry(hass: HomeAssistant, entry):
     except Exception as e:
         _LOGGER.error(f"Error when removing frontend-panel for entry {entry.entry_id}: {e}")
         return False
-
-    observer = hass.data.pop("bps_observer", None)
-    if observer:
-        observer.stop()
-        observer.join(timeout=2)
 
     update_task = hass.data.pop("bps_update_task", None)
     if update_task:
@@ -1786,21 +1725,19 @@ class BPSSaveAPIText(HomeAssistantView):
 
         if not coordinates:
             return web.Response(status=400, text="Missing coordinates")
-        # Reject a non-JSON layout blob before it can truncate bpsdata.txt.
+        # Reject a non-JSON layout blob before it can reach the store.
         try:
-            json.loads(coordinates)
+            coords_obj = json.loads(coordinates)
         except (ValueError, TypeError):
             return web.Response(status=400, text="Coordinates must be valid JSON")
 
-        # Define the path to the bpsdata file
         maps_path = hass.config.path("www/bps_maps")
-        bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
-        
-        try: # Save coordinates to the bpsdata file
+
+        try: # Persist the layout to the store + handle map upload/removal
             # Serialized with the calibration writers so read-modify-write
-            # cycles on bpsdata.txt cannot interleave.
+            # cycles on the layout cannot interleave.
             async with BPS_FILE_LOCK:
-                error = await self._write_save(bpsdata_file_path, maps_path, data, coordinates)
+                error = await self._write_save(hass, maps_path, data, coords_obj)
             if error is not None:
                 return error
             # A calibration window may be sampling right now; hand it the
@@ -1814,15 +1751,16 @@ class BPSSaveAPIText(HomeAssistantView):
             _LOGGER.error(f"Failed to save coordinates: {e}")
             return web.Response(status=500, text="Failed to save coordinates")
 
-    async def _write_save(self, bpsdata_file_path, maps_path, data, coordinates):
-        """Validate all inputs, THEN write; returns an error Response or None.
+    async def _write_save(self, hass, maps_path, data, coords_obj):
+        """Validate all inputs, THEN persist; returns an error Response or None.
 
         Ordering matters: the new-floor map upload and the removal target are
-        validated (and the upload read + size-checked) BEFORE bpsdata.txt is
-        touched, so a rejected upload can no longer truncate the saved layout.
+        validated (and the upload read + size-checked) BEFORE the layout is
+        saved, so a rejected upload can no longer strand the saved layout.
         Every filesystem target derived from client input is constrained to
         maps_path via _safe_maps_child (audit #2: path traversal / arbitrary
-        write+delete on an unauthenticated endpoint).
+        write+delete). The layout goes to the Store (atomic); only the map
+        images live under maps_path.
         """
         # --- Validate the optional new-floor map upload ---
         map_target = None
@@ -1851,7 +1789,7 @@ class BPSSaveAPIText(HomeAssistantView):
                 return web.Response(status=400, text="Invalid remove target")
 
         # --- Inputs valid: persist. Map first (so the saved layout never names
-        # a map that failed to write), then bpsdata.txt, then delete the old map. ---
+        # a map that failed to write), then the layout, then delete the old map. ---
         if map_target is not None:
             try:
                 async with aiofiles.open(map_target, "wb") as f:
@@ -1860,8 +1798,7 @@ class BPSSaveAPIText(HomeAssistantView):
                 _LOGGER.error(f"Failed to save maps: {e}")
                 return web.Response(status=500, text="Failed to save maps")
 
-        async with aiofiles.open(bpsdata_file_path, "w") as f:
-            await f.write(coordinates)
+        await save_bps_data(hass, coords_obj)
 
         # Never delete the map we just wrote (a replace with the same filename).
         if remove_target is not None and remove_target != map_target and remove_target.exists():
@@ -1921,17 +1858,14 @@ class BPSAdjustZonesAPI(HomeAssistantView):
 
 
 class BPSReadAPIText(HomeAssistantView):
-    """Handle reading of BPS coordinates from a text file."""
+    """Return the stored BPS layout plus the tracked-device / receiver lists."""
 
     url = "/api/bps/read_text"
     name = "api:bps:read_text"
     requires_auth = True
 
     async def get(self, request):
-        """Handle reading coordinates from the text file."""
         hass = request.app["hass"]
-        maps_path = hass.config.path("www/bps_maps") # Define the path to the bpsdata file
-        bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
         # Both the tracked devices and their receivers come from the same
         # Bermuda "_distance_to_" sensors — the device is the part before
         # "_distance_to_", the receiver (scanner) the part after. Filtering to
@@ -1951,13 +1885,11 @@ class BPSReadAPIText(HomeAssistantView):
         offline_receivers = list(hass.data.get(DOMAIN, {}).get("rl_offline", []))
 
         try:
-            if not bpsdata_file_path.is_file(): # Check if the file exists
-                return web.Response(status=404, text="bpsdata.txt not found")
-
-            async with aiofiles.open(bpsdata_file_path, "r") as f: # Read the content of the file
-                content = await f.read()
-
-            _LOGGER.info(f"Read coordinates from bpsdata: {content}")
+            # The layout now lives in the Store; a fresh install has none, and
+            # the frontend's `if (data.coordinates)` guard expects "" (not "[]")
+            # in that case so it never JSON.parses an empty layout.
+            layout = get_bps_data(hass)
+            content = json.dumps(layout) if layout else ""
             return web.json_response({
                 "coordinates": content,
                 "entities": entities,
@@ -1968,7 +1900,7 @@ class BPSReadAPIText(HomeAssistantView):
                 # placed anywhere.
                 "scanner_diagnostics": _scanner_diagnostics(hass, content),
             })
-        
+
         except Exception as e:
             _LOGGER.error(f"Failed to read coordinates: {e}")
             return web.Response(status=500, text="Failed to read coordinates")
@@ -1996,17 +1928,9 @@ class BPSScannerLinkingAPI(HomeAssistantView):
 
     async def get(self, request):
         hass = request.app["hass"]
-        maps_path = hass.config.path("www/bps_maps")
-        bpsdata_file_path = Path(maps_path) / "bpsdata.txt"
-        content = ""
-        try:
-            if bpsdata_file_path.is_file():
-                async with aiofiles.open(bpsdata_file_path, "r") as f:
-                    content = await f.read()
-        except Exception as e:
-            # No placements to compare against is fine; still report the sensors.
-            _LOGGER.info(f"scanner_linking: could not read bpsdata: {e}")
-            content = ""
+        # No placements to compare against is fine; still report the sensors.
+        layout = get_bps_data(hass)
+        content = json.dumps(layout) if layout else ""
         try:
             data = _scanner_linking(hass, content)
         except Exception as e:

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -44,9 +44,16 @@ from scipy.optimize import least_squares
 
 _LOGGER = logging.getLogger(__name__)
 
-# Serializes every BPS writer of bpsdata.txt (panel saves, calibration
-# apply/reset, the auto loop) so read-modify-write cycles cannot interleave.
-BPS_FILE_LOCK = asyncio.Lock()
+# Layout + calibration state now live in HA's Store (see storage.py). The
+# shared write lock lives there too so both modules serialize on one lock
+# without an import cycle.
+from .storage import (
+    BPS_FILE_LOCK,
+    get_bps_data_for_edit,
+    save_bps_data,
+    load_calib_state,
+    save_calib_state,
+)
 
 DOMAIN = "bps"
 SAMPLE_INTERVAL = 10  # seconds between dump_devices calls (manual run)
@@ -125,14 +132,6 @@ def _token_matches_address(token, address):
         return False
 
 
-def _bpsdata_path(hass) -> Path:
-    return Path(hass.config.path("www/bps_maps")) / "bpsdata.txt"
-
-
-def _state_path(hass) -> Path:
-    return Path(hass.config.path("www/bps_maps")) / "bps_calibration_state.json"
-
-
 async def save_calibration_state(hass) -> None:
     """Persist the latest solves and the sample window across restarts.
 
@@ -151,10 +150,8 @@ async def save_calibration_state(hass) -> None:
         },
     }
     try:
-        async with BPS_FILE_LOCK:
-            async with aiofiles.open(_state_path(hass), "w") as f:
-                await f.write(json.dumps(payload))
-    except OSError as e:
+        await save_calib_state(hass, payload)
+    except Exception as e:
         _LOGGER.warning("Could not persist calibration state: %s", e)
 
 
@@ -163,11 +160,9 @@ async def async_restore_calibration_state(hass) -> None:
     cal = get_calibration_state(hass)
     if cal["mode"] != "off":
         return
-    try:
-        async with aiofiles.open(_state_path(hass), "r") as f:
-            payload = json.loads(await f.read())
-    except (OSError, json.JSONDecodeError):
-        return  # first run, or an unreadable state file: start cold
+    payload = await load_calib_state(hass)
+    if not isinstance(payload, dict):
+        return  # first run, or nothing persisted: start cold
 
     if isinstance(payload.get("results"), dict):
         cal["results"] = payload["results"]
@@ -192,15 +187,13 @@ async def async_restore_calibration_state(hass) -> None:
 
 
 async def _read_coords(hass):
-    """Read and parse bpsdata.txt; returns the dict or None."""
-    path = _bpsdata_path(hass)
-    try:
-        async with aiofiles.open(path, "r") as f:
-            content = await f.read()
-        return json.loads(content) if content else None
-    except (OSError, json.JSONDecodeError) as e:
-        _LOGGER.error("Calibration could not read bpsdata: %s", e)
-        return None
+    """The current layout as a fresh dict to mutate, or None if there is none.
+
+    A deep copy from the store cache (never the live object) so the
+    read-modify-write below can't leak a half-mutated layout to the tracking
+    loop before the save lands.
+    """
+    return get_bps_data_for_edit(hass)
 
 
 def _find_floor(coords, floor_name):
@@ -761,9 +754,7 @@ async def _auto_solve_and_apply_locked(hass, cal: dict) -> None:
         changed = True
 
     if changed:
-        path = _bpsdata_path(hass)
-        async with aiofiles.open(path, "w") as f:
-            await f.write(json.dumps(coords))
+        await save_bps_data(hass, coords)
         _LOGGER.info("Auto-calibration updated receiver corrections")
 
 
@@ -834,9 +825,7 @@ async def set_auto_calibration(hass, enabled: bool) -> None:
             # Re-read inside the lock so a concurrent writer is not clobbered.
             coords = await _read_coords(hass) or coords
             coords["auto_calibration"] = bool(enabled)
-            path = _bpsdata_path(hass)
-            async with aiofiles.open(path, "w") as f:
-                await f.write(json.dumps(coords))
+            await save_bps_data(hass, coords)
 
     await _stop_task(cal)
     if enabled:
@@ -951,9 +940,7 @@ async def _apply_result_locked(hass, cal: dict, result: dict) -> int:
     }
     cal["applied"][floor.get("name")] = dict(result["receivers"])
 
-    path = _bpsdata_path(hass)
-    async with aiofiles.open(path, "w") as f:
-        await f.write(json.dumps(coords))
+    await save_bps_data(hass, coords)
     return updated
 
 
@@ -973,9 +960,7 @@ async def reset_corrections(hass, cal: dict, floor_name: str) -> int:
         floor.pop("calibration", None)
         cal["applied"].pop(floor.get("name"), None)
 
-        path = _bpsdata_path(hass)
-        async with aiofiles.open(path, "w") as f:
-            await f.write(json.dumps(coords))
+        await save_bps_data(hass, coords)
         return removed
 
 

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -8,6 +8,6 @@
     "integration_type": "device",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
-    "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2", "watchdog>=2.1.0"],
-    "version": "1.7.1"
+    "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
+    "version": "1.7.2"
 }

--- a/custom_components/bps/storage.py
+++ b/custom_components/bps/storage.py
@@ -86,27 +86,41 @@ def get_bps_data_for_edit(hass):
 
 
 async def load_bps_data(hass):
-    """Load the layout from the store into the in-memory cache (at setup)."""
-    data = await _layout_store(hass).async_load()
+    """Load the layout from the store into the in-memory cache (at setup).
+
+    A corrupt/unreadable store must not abort setup — the old flat-file reader
+    tolerated bad JSON and ran with an empty layout, so keep that resilience.
+    """
+    try:
+        data = await _layout_store(hass).async_load()
+    except Exception as e:
+        _LOGGER.error("Could not load layout from storage; starting empty: %s", e)
+        data = None
     _bucket(hass)["layout"] = data if data is not None else []
     return _bucket(hass)["layout"]
 
 
 async def save_bps_data(hass, data) -> None:
-    """Persist the layout dict atomically and refresh the cache.
+    """Persist the layout dict atomically, THEN refresh the cache.
 
     Uses ``async_save`` (immediate atomic write), never ``async_delay_save`` —
     a debounced write could still be lost on a crash inside the delay window.
+    Persist first so a raising write leaves the cache matching what survives a
+    restart rather than running ahead of disk.
     """
-    _bucket(hass)["layout"] = data
     await _layout_store(hass).async_save(data)
+    _bucket(hass)["layout"] = data
 
 
 # --- Calibration state -------------------------------------------------------
 
 async def load_calib_state(hass):
-    """The persisted calibration state, or None on first run."""
-    return await _calib_store(hass).async_load()
+    """The persisted calibration state, or None on first run / if unreadable."""
+    try:
+        return await _calib_store(hass).async_load()
+    except Exception as e:
+        _LOGGER.warning("Could not load calibration state; starting cold: %s", e)
+        return None
 
 
 async def save_calib_state(hass, payload) -> None:
@@ -128,11 +142,15 @@ async def _read_legacy(path: Path):
 
 
 async def _remove_legacy(path: Path) -> None:
+    if not path.exists():
+        return
     try:
         await aiofiles.os.remove(path)
-        _LOGGER.info("Removed migrated legacy file %s", path.name)
+        _LOGGER.info("Removed legacy file %s (data now lives in .storage)", path.name)
     except OSError as e:
-        _LOGGER.warning("Could not remove legacy file %s: %s", path.name, e)
+        _LOGGER.error(
+            "Could not remove legacy %s — it stays readable via /local until "
+            "removed by hand: %s", path.name, e)
 
 
 async def migrate_legacy(hass) -> None:
@@ -156,8 +174,19 @@ async def migrate_legacy(hass) -> None:
 
 
 async def _migrate_one(store: Store, legacy: Path, label: str, is_valid) -> None:
-    if await store.async_load() is not None:
-        return  # already migrated / store owns the data now
+    try:
+        existing = await store.async_load()
+    except Exception as e:
+        # Corrupt/unreadable store: don't migrate over it (may be recoverable)
+        # and don't touch the legacy file — just don't crash setup.
+        _LOGGER.warning("Could not read %s store; leaving legacy file: %s", label, e)
+        return
+    if existing is not None:
+        # Store already owns the data. Retry the cleanup every boot so a
+        # previously-failed delete (or a legacy file restored from a backup)
+        # can't linger /local-exposed forever.
+        await _remove_legacy(legacy)
+        return
     content, existed = await _read_legacy(legacy)
     if not existed or content is None:
         return  # fresh install, or unreadable — leave it

--- a/custom_components/bps/storage.py
+++ b/custom_components/bps/storage.py
@@ -1,0 +1,183 @@
+"""Persistent storage for BPS layout + calibration state.
+
+The floor/zone/receiver layout and the calibration state used to live as flat
+files in ``www/bps_maps`` (``bpsdata.txt`` / ``bps_calibration_state.json``),
+written with ``open(path, "w")`` — which truncates to zero *before* writing, so
+an interrupted write left a 0-byte file and wiped the config (issue #104).
+Being under ``www/`` also made them readable unauthenticated via ``/local/``.
+
+Both now live in Home Assistant's ``Store`` (``config/.storage/``):
+``Store.async_save`` writes atomically (temp file + ``os.replace`` — the live
+file is never truncated), and ``.storage`` is not web-served. This module is
+the single owner of that data and imports nothing from the rest of the package
+(so both ``__init__`` and ``calibration`` can import it without a cycle).
+"""
+import asyncio
+import copy
+import json
+import logging
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+from homeassistant.helpers.storage import Store
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "bps"
+STORAGE_VERSION = 1
+STORAGE_KEY_LAYOUT = "bps"                       # -> config/.storage/bps
+STORAGE_KEY_CALIB = "bps_calibration_state"      # -> config/.storage/bps_calibration_state
+
+# Serializes read-modify-write sequences on the layout across every writer
+# (panel save + calibration). Lives here so both importers share one lock
+# without an import cycle (was previously defined in calibration.py).
+BPS_FILE_LOCK = asyncio.Lock()
+
+
+def _legacy_layout_path(hass) -> Path:
+    return Path(hass.config.path("www/bps_maps")) / "bpsdata.txt"
+
+
+def _legacy_calib_path(hass) -> Path:
+    return Path(hass.config.path("www/bps_maps")) / "bps_calibration_state.json"
+
+
+def _bucket(hass) -> dict:
+    return hass.data.setdefault(DOMAIN, {})
+
+
+def _layout_store(hass) -> Store:
+    bucket = _bucket(hass)
+    store = bucket.get("_layout_store")
+    if store is None:
+        store = bucket["_layout_store"] = Store(hass, STORAGE_VERSION, STORAGE_KEY_LAYOUT)
+    return store
+
+
+def _calib_store(hass) -> Store:
+    bucket = _bucket(hass)
+    store = bucket.get("_calib_store")
+    if store is None:
+        store = bucket["_calib_store"] = Store(hass, STORAGE_VERSION, STORAGE_KEY_CALIB)
+    return store
+
+
+# --- Layout (bpsdata) --------------------------------------------------------
+
+def get_bps_data(hass):
+    """The cached layout for READ-ONLY consumers.
+
+    Defaults to ``[]`` on a fresh install, matching the old empty-file
+    behaviour (a populated layout is a dict; consumers guard with isinstance).
+    """
+    return _bucket(hass).get("layout", [])
+
+
+def get_bps_data_for_edit(hass):
+    """A deep copy of the layout for read-modify-write callers (calibration).
+
+    Returns ``None`` when there is no layout yet — matching the old
+    ``_read_coords`` contract — so callers must never mutate the live cache
+    the tracking loop reads.
+    """
+    data = get_bps_data(hass)
+    return copy.deepcopy(data) if isinstance(data, dict) else None
+
+
+async def load_bps_data(hass):
+    """Load the layout from the store into the in-memory cache (at setup)."""
+    data = await _layout_store(hass).async_load()
+    _bucket(hass)["layout"] = data if data is not None else []
+    return _bucket(hass)["layout"]
+
+
+async def save_bps_data(hass, data) -> None:
+    """Persist the layout dict atomically and refresh the cache.
+
+    Uses ``async_save`` (immediate atomic write), never ``async_delay_save`` —
+    a debounced write could still be lost on a crash inside the delay window.
+    """
+    _bucket(hass)["layout"] = data
+    await _layout_store(hass).async_save(data)
+
+
+# --- Calibration state -------------------------------------------------------
+
+async def load_calib_state(hass):
+    """The persisted calibration state, or None on first run."""
+    return await _calib_store(hass).async_load()
+
+
+async def save_calib_state(hass, payload) -> None:
+    await _calib_store(hass).async_save(payload)
+
+
+# --- One-time migration of the old flat files -------------------------------
+
+async def _read_legacy(path: Path):
+    """Read a legacy file. Returns (content, existed)."""
+    try:
+        async with aiofiles.open(path, "r") as f:
+            return await f.read(), True
+    except FileNotFoundError:
+        return None, False
+    except OSError as e:
+        _LOGGER.warning("Could not read legacy file %s: %s", path, e)
+        return None, True  # exists but unreadable — don't delete it
+
+
+async def _remove_legacy(path: Path) -> None:
+    try:
+        await aiofiles.os.remove(path)
+        _LOGGER.info("Removed migrated legacy file %s", path.name)
+    except OSError as e:
+        _LOGGER.warning("Could not remove legacy file %s: %s", path.name, e)
+
+
+async def migrate_legacy(hass) -> None:
+    """Move the old ``www/bps_maps`` files into the store, once.
+
+    Idempotent: only runs while the store is still empty. For each file:
+    a blank/whitespace file (the issue-#104 artifact — no recoverable data) is
+    deleted; a corrupt-but-non-empty file is LEFT in place (may be
+    hand-recoverable); a valid file is saved to the store, verified, and only
+    then deleted — closing the ``/local/`` exposure. Map images stay in
+    ``www/bps_maps`` (served via ``/local/``) and are untouched.
+    """
+    await _migrate_one(
+        _layout_store(hass), _legacy_layout_path(hass), "layout",
+        lambda parsed: isinstance(parsed, (dict, list)),
+    )
+    await _migrate_one(
+        _calib_store(hass), _legacy_calib_path(hass), "calibration state",
+        lambda parsed: isinstance(parsed, dict),
+    )
+
+
+async def _migrate_one(store: Store, legacy: Path, label: str, is_valid) -> None:
+    if await store.async_load() is not None:
+        return  # already migrated / store owns the data now
+    content, existed = await _read_legacy(legacy)
+    if not existed or content is None:
+        return  # fresh install, or unreadable — leave it
+    if not content.strip():
+        # 0-byte / whitespace: the data-loss artifact, nothing to recover.
+        await _remove_legacy(legacy)
+        return
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        _LOGGER.warning(
+            "Legacy %s file %s is not valid JSON; leaving it in place for "
+            "manual recovery and starting empty", label, legacy.name)
+        return
+    if not is_valid(parsed):
+        _LOGGER.warning("Legacy %s file %s has unexpected shape; leaving it", label, legacy.name)
+        return
+    await store.async_save(parsed)
+    if await store.async_load() is None:
+        _LOGGER.error("Migrating %s to storage failed to verify; keeping %s", label, legacy.name)
+        return
+    _LOGGER.info("Migrated %s from %s into .storage", label, legacy.name)
+    await _remove_legacy(legacy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,12 @@ unit tests never exercise. We install lightweight fakes for those in
 dependencies (numpy, scipy, shapely) load for real — the positioning and
 geometry maths under test run against the actual libraries.
 """
+import os
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 
 def _module(name, **attrs):
@@ -59,6 +62,36 @@ async def _aiofiles_makedirs(*a, **k):
     return None
 
 
+async def _aiofiles_remove(path):
+    os.remove(path)
+
+
+# --- Fake homeassistant.helpers.storage.Store -------------------------------
+# Backed by a per-`hass` dict so a "restart" (fresh cache, same hass) still
+# loads what was saved. Records save calls so tests can assert async_save is
+# used (never async_delay_save) and that only complete dicts are persisted.
+class _FakeStore:
+    def __init__(self, hass, version, key):
+        self._hass = hass
+        self._key = key
+        if not hasattr(hass, "_store_backing"):
+            hass._store_backing = {}
+            hass._store_saves = []
+            hass._store_delay_saves = []
+
+    async def async_load(self):
+        import copy as _copy
+        return _copy.deepcopy(self._hass._store_backing.get(self._key))
+
+    async def async_save(self, data):
+        import copy as _copy
+        self._hass._store_saves.append((self._key, data))
+        self._hass._store_backing[self._key] = _copy.deepcopy(data)
+
+    async def async_delay_save(self, data_func, delay=None):
+        self._hass._store_delay_saves.append(self._key)
+
+
 class _Response:
     def __init__(self, status=200, text="", **k):
         self.status = status
@@ -72,8 +105,10 @@ def _json_response(data=None, status=200):
 
 
 def _install_homeassistant_stubs():
-    _module("aiofiles", open=_aiofiles_open)
-    _module("aiofiles.os", makedirs=_aiofiles_makedirs)
+    aiofiles_mod = _module("aiofiles", open=_aiofiles_open)
+    # `import aiofiles.os` reads `.os` off the parent; attach it explicitly.
+    aiofiles_mod.os = _module("aiofiles.os", makedirs=_aiofiles_makedirs, remove=_aiofiles_remove)
+    _module("homeassistant.helpers.storage", Store=_FakeStore)
     _module("aiohttp", web=types.SimpleNamespace(
         Response=_Response, json_response=_json_response, FileResponse=object,
     ))
@@ -94,7 +129,10 @@ def _install_homeassistant_stubs():
         async_register_built_in_panel=lambda *a, **k: None,
         async_remove_panel=lambda *a, **k: None,
     )
-    _module("homeassistant.helpers")
+    helpers = _module("homeassistant.helpers")
+    # `from homeassistant.helpers.storage import Store` — expose the submodule
+    # on its parent (as done for panel_custom above).
+    helpers.storage = sys.modules["homeassistant.helpers.storage"]
     _module("homeassistant.helpers.event", async_track_state_change_event=lambda *a, **k: None)
     _module("homeassistant.helpers.template", Template=object)
     _module("homeassistant.core", HomeAssistant=object, callback=lambda f: f)
@@ -109,11 +147,32 @@ def _install_homeassistant_stubs():
         Optional=lambda *a, **k: None, Coerce=lambda *a, **k: None,
         All=lambda *a, **k: None, Length=lambda *a, **k: None, Range=lambda *a, **k: None,
     )
-    _module("watchdog")
-    _module("watchdog.observers", Observer=object)
-    _module("watchdog.events", FileSystemEventHandler=object)
+    # NOTE: no watchdog stub — the integration no longer imports it (the file
+    # watcher was removed when the layout moved to the Store). If a stray import
+    # comes back, the suite will fail loudly here.
 
 
 _install_homeassistant_stubs()
 # custom_components/ on the path so `import bps` resolves to the integration.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+
+
+def make_hass(config_dir=None):
+    """A minimal fake Home Assistant for storage/handler tests.
+
+    Carries `.data`, a `.config.path()` rooted at config_dir (or cwd), and the
+    per-hass Store backing the fake Store reads/writes.
+    """
+    root = Path(config_dir) if config_dir else Path(".")
+    hass = types.SimpleNamespace()
+    hass.data = {}
+    hass.config = types.SimpleNamespace(path=lambda *p: str(root.joinpath(*p)))
+    hass._store_backing = {}
+    hass._store_saves = []
+    hass._store_delay_saves = []
+    return hass
+
+
+@pytest.fixture
+def hass(tmp_path):
+    return make_hass(tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ unit tests never exercise. We install lightweight fakes for those in
 dependencies (numpy, scipy, shapely) load for real — the positioning and
 geometry maths under test run against the actual libraries.
 """
+import json
 import os
 import sys
 import types
@@ -81,12 +82,16 @@ class _FakeStore:
 
     async def async_load(self):
         import copy as _copy
+        # Simulate a corrupt/unreadable store file (HA raises HomeAssistantError).
+        if self._key in getattr(self._hass, "_store_raise_on_load", ()):
+            raise ValueError(f"corrupt store {self._key}")
         return _copy.deepcopy(self._hass._store_backing.get(self._key))
 
     async def async_save(self, data):
-        import copy as _copy
+        # Round-trip through JSON like real HA Store, so a non-JSON-serializable
+        # value (e.g. a numpy scalar or set) fails the test as it would in prod.
         self._hass._store_saves.append((self._key, data))
-        self._hass._store_backing[self._key] = _copy.deepcopy(data)
+        self._hass._store_backing[self._key] = json.loads(json.dumps(data))
 
     async def async_delay_save(self, data_func, delay=None):
         self._hass._store_delay_saves.append(self._key)
@@ -170,6 +175,7 @@ def make_hass(config_dir=None):
     hass._store_backing = {}
     hass._store_saves = []
     hass._store_delay_saves = []
+    hass._store_raise_on_load = set()   # store keys whose async_load should raise
     return hass
 
 

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -8,6 +8,7 @@ import asyncio
 import io
 
 import bps
+from conftest import make_hass
 
 
 MAPS = "/config/www/bps_maps"
@@ -86,72 +87,61 @@ def test_no_extension_filter_still_contains():
     assert got is not None and got.parent == bps.Path(MAPS).resolve()
 
 
-# --- _write_save ordering: a rejected upload must not truncate bpsdata.txt --- #
-def test_bad_upload_does_not_truncate_bpsdata(tmp_path):
-    maps = tmp_path
-    bpsdata = maps / "bpsdata.txt"
-    original = '{"floor":[{"name":"F"}]}'
-    bpsdata.write_text(original)
-    view = bps.BPSSaveAPIText()
+# --- _write_save: map-image handling + layout goes to the store, not a file --- #
+def _write(hass, maps, data, coords):
+    return bps.BPSSaveAPIText()._write_save(hass, str(maps), data, coords)
+
+
+def _layout(hass):
+    return hass._store_backing.get("bps")
+
+
+def test_bad_upload_leaves_layout_untouched(tmp_path):
+    hass = make_hass(tmp_path)
+    run(bps.save_bps_data(hass, {"floor": [{"name": "F"}]}))  # existing saved layout
     data = _Dict(new_floor="true", file=_Upload("evil.exe"))
-    err = run(view._write_save(bpsdata, str(maps), data, '{"floor":[]}'))
+    err = run(_write(hass, tmp_path, data, {"floor": []}))
     assert err is not None and err.status == 400
-    # The layout on disk is untouched — no partial-write corruption.
-    assert bpsdata.read_text() == original
+    # A rejected upload must not have replaced the stored layout.
+    assert _layout(hass) == {"floor": [{"name": "F"}]}
 
 
-def test_valid_new_floor_writes_map_and_layout(tmp_path):
-    maps = tmp_path
-    bpsdata = maps / "bpsdata.txt"
-    bpsdata.write_text("{}")
-    view = bps.BPSSaveAPIText()
+def test_valid_new_floor_writes_map_and_stores_layout(tmp_path):
+    hass = make_hass(tmp_path)
     data = _Dict(new_floor="true", file=_Upload("ground.png", b"PNGDATA"))
-    err = run(view._write_save(bpsdata, str(maps), data, '{"floor":[1]}'))
+    err = run(_write(hass, tmp_path, data, {"floor": [1]}))
     assert err is None
-    assert bpsdata.read_text() == '{"floor":[1]}'
-    assert (maps / "ground.png").read_bytes() == b"PNGDATA"
+    assert _layout(hass) == {"floor": [1]}                    # layout -> store
+    assert (tmp_path / "ground.png").read_bytes() == b"PNGDATA"  # image -> www/
 
 
 def test_protected_files_not_deletable(tmp_path):
-    maps = tmp_path
-    bpsdata = maps / "bpsdata.txt"
-    bpsdata.write_text('{"floor":[]}')
-    (maps / "bps_calibration_state.json").write_text("{}")
-    view = bps.BPSSaveAPIText()
+    hass = make_hass(tmp_path)
+    (tmp_path / "bps_calibration_state.json").write_text("{}")
     for name in ("bpsdata.txt", "../../bpsdata.txt", "bps_calibration_state.json"):
-        err = run(view._write_save(bpsdata, str(maps), _Dict(remove=name), "{}"))
+        err = run(_write(hass, tmp_path, _Dict(remove=name), {}))
         assert err is not None and err.status == 400, name
-    # Neither protected file was touched.
-    assert bpsdata.read_text() == '{"floor":[]}'
-    assert (maps / "bps_calibration_state.json").exists()
+    assert (tmp_path / "bps_calibration_state.json").exists()
 
 
 def test_existing_map_deletable_regardless_of_extension(tmp_path):
     # A map stored under any earlier-accepted extension must stay deletable —
     # the upload allowlist must not strand an existing floor (regression guard).
-    maps = tmp_path
-    bpsdata = maps / "bpsdata.txt"
-    bpsdata.write_text("{}")
+    hass = make_hass(tmp_path)
     for ext in (".jfif", ".tiff", ".png"):
-        target = maps / f"ground{ext}"
+        target = tmp_path / f"ground{ext}"
         target.write_bytes(b"img")
-        err = run(view_delete(maps, bpsdata, f"ground{ext}"))
+        err = run(_write(hass, tmp_path, _Dict(remove=f"ground{ext}"), {}))
         assert err is None, ext
         assert not target.exists(), ext
 
 
-def view_delete(maps, bpsdata, name):
-    return bps.BPSSaveAPIText()._write_save(bpsdata, str(maps), _Dict(remove=name), "{}")
-
-
 def test_jfif_upload_accepted(tmp_path):
-    maps = tmp_path
-    bpsdata = maps / "bpsdata.txt"
-    bpsdata.write_text("{}")
+    hass = make_hass(tmp_path)
     data = _Dict(new_floor="true", file=_Upload("attic.jfif", b"JPEG"))
-    err = run(bps.BPSSaveAPIText()._write_save(bpsdata, str(maps), data, '{"floor":[1]}'))
+    err = run(_write(hass, tmp_path, data, {"floor": [1]}))
     assert err is None
-    assert (maps / "attic.jfif").read_bytes() == b"JPEG"
+    assert (tmp_path / "attic.jfif").read_bytes() == b"JPEG"
 
 
 def test_all_api_views_require_auth_static_stays_public():
@@ -175,11 +165,10 @@ def test_all_api_views_require_auth_static_stays_public():
 
 def test_delete_traversal_still_blocked(tmp_path):
     # Containment must still reject an attempt to escape the maps dir.
+    hass = make_hass(tmp_path)
     maps = tmp_path / "bps_maps"
     maps.mkdir()
     outside = tmp_path / "secret.png"
     outside.write_bytes(b"x")
-    bpsdata = maps / "bpsdata.txt"
-    bpsdata.write_text("{}")
-    run(view_delete(maps, bpsdata, "../secret.png"))
+    run(_write(hass, maps, _Dict(remove="../secret.png"), {}))
     assert outside.exists()  # '../' collapsed to basename; the real file survives

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -68,15 +68,15 @@ def test_migrate_corrupt_layout_is_preserved(tmp_path):
     assert legacy.exists()                        # ...but keep the file for manual recovery
 
 
-def test_migrate_is_idempotent(tmp_path):
+def test_migrate_does_not_overwrite_populated_store(tmp_path):
     hass = make_hass(tmp_path)
     run(st.save_bps_data(hass, {"floor": [{"name": "Already"}]}))   # store already owns data
     legacy = _legacy_layout(hass)
     legacy.write_text('{"floor":[{"name":"Stale"}]}')
-    run(st.migrate_legacy(hass))                  # no-op: store non-empty
+    run(st.migrate_legacy(hass))                  # store non-empty: don't re-import
     run(st.load_bps_data(hass))
-    assert st.get_bps_data(hass) == {"floor": [{"name": "Already"}]}
-    assert legacy.exists()                        # left untouched
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Already"}]}  # store data wins
+    assert not legacy.exists()                    # stale exposed copy cleaned up
 
 
 # --- save / load round-trip -------------------------------------------------
@@ -123,3 +123,30 @@ def test_calib_state_migrates_and_removes_legacy(tmp_path):
     run(st.migrate_legacy(hass))
     assert run(st.load_calib_state(hass)) == {"results": {"F": 2}}
     assert not legacy.exists()
+
+
+# --- resilience -------------------------------------------------------------
+def test_corrupt_store_starts_empty_not_crash(tmp_path):
+    # A corrupt/unreadable .storage file must degrade (start empty), not abort
+    # setup the way an unguarded Store.async_load() would.
+    hass = make_hass(tmp_path)
+    hass._store_raise_on_load = {"bps", "bps_calibration_state"}
+    _legacy_layout(hass).write_text('{"floor":[{"name":"Home"}]}')
+    run(st.migrate_legacy(hass))                 # must not raise
+    run(st.load_bps_data(hass))                  # must not raise
+    assert st.get_bps_data(hass) == []
+    assert run(st.load_calib_state(hass)) is None
+    # Corrupt store: don't touch the possibly-recoverable legacy file.
+    assert _legacy_layout(hass).exists()
+
+
+def test_legacy_cleanup_retries_when_store_already_populated(tmp_path):
+    # A leftover www copy (failed prior delete, or restored from backup) must
+    # be cleaned up on a later boot even though the store already has the data.
+    hass = make_hass(tmp_path)
+    run(st.save_bps_data(hass, {"floor": [{"name": "Home"}]}))
+    stale = _legacy_layout(hass)
+    stale.write_text('{"floor":[{"name":"Home"}]}')   # reappeared /local-exposed copy
+    run(st.migrate_legacy(hass))
+    assert not stale.exists()                          # removed despite store non-empty
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Home"}]}  # data untouched

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,125 @@
+"""Storage layer: crash-safe atomic writes + one-time legacy migration.
+
+Runs against the fake in-memory Store in conftest. The real atomicity lives in
+HA's Store; these lock down our migration/round-trip logic and, crucially,
+that the truncate-then-write path that caused issue #104 is gone (we only ever
+hand the store a complete dict, via async_save, never async_delay_save).
+"""
+import asyncio
+from pathlib import Path
+
+import bps.storage as st
+from conftest import make_hass
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _legacy_layout(hass):
+    d = Path(hass.config.path("www", "bps_maps"))
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "bpsdata.txt"
+
+
+def _legacy_calib(hass):
+    d = Path(hass.config.path("www", "bps_maps"))
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "bps_calibration_state.json"
+
+
+# --- fresh install ----------------------------------------------------------
+def test_fresh_install_is_empty(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.migrate_legacy(hass))   # nothing to migrate
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == []           # matches old empty-file behaviour
+    assert st.get_bps_data_for_edit(hass) is None
+
+
+# --- migration --------------------------------------------------------------
+def test_migrate_valid_layout(tmp_path):
+    hass = make_hass(tmp_path)
+    legacy = _legacy_layout(hass)
+    legacy.write_text('{"floor":[{"name":"Home"}]}')
+    run(st.migrate_legacy(hass))
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Home"}]}
+    assert not legacy.exists()                    # old www copy removed (closes /local exposure)
+
+
+def test_migrate_zero_byte_is_the_issue_104_guard(tmp_path):
+    hass = make_hass(tmp_path)
+    legacy = _legacy_layout(hass)
+    legacy.write_text("")                         # the 0-byte artifact
+    run(st.migrate_legacy(hass))                  # must not raise
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == []
+    assert not legacy.exists()                    # unrecoverable blank file cleaned up
+
+
+def test_migrate_corrupt_layout_is_preserved(tmp_path):
+    hass = make_hass(tmp_path)
+    legacy = _legacy_layout(hass)
+    legacy.write_text('{"floor": [ this is not json')
+    run(st.migrate_legacy(hass))
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == []            # start empty...
+    assert legacy.exists()                        # ...but keep the file for manual recovery
+
+
+def test_migrate_is_idempotent(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.save_bps_data(hass, {"floor": [{"name": "Already"}]}))   # store already owns data
+    legacy = _legacy_layout(hass)
+    legacy.write_text('{"floor":[{"name":"Stale"}]}')
+    run(st.migrate_legacy(hass))                  # no-op: store non-empty
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Already"}]}
+    assert legacy.exists()                        # left untouched
+
+
+# --- save / load round-trip -------------------------------------------------
+def test_save_survives_restart(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.save_bps_data(hass, {"floor": [{"name": "Home"}]}))
+    # Simulate a restart: fresh in-memory cache, same .storage backing.
+    hass.data.get(st.DOMAIN, {}).pop("layout", None)
+    run(st.load_bps_data(hass))
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Home"}]}
+
+
+def test_save_is_immediate_and_never_truncates(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.save_bps_data(hass, {"floor": []}))
+    # async_save (atomic), never the debounced async_delay_save.
+    assert hass._store_delay_saves == []
+    assert [k for k, _ in hass._store_saves] == ["bps"]
+    # The store is only ever handed a complete object — never "" — so the old
+    # truncate-then-write 0-byte path (issue #104) cannot recur.
+    assert all(isinstance(v, (dict, list)) for _, v in hass._store_saves)
+
+
+def test_get_for_edit_returns_a_copy(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.save_bps_data(hass, {"floor": [{"name": "Home"}]}))
+    editable = st.get_bps_data_for_edit(hass)
+    editable["floor"].append({"name": "Injected"})
+    # Mutating the editable copy must not touch the live cache the loop reads.
+    assert st.get_bps_data(hass) == {"floor": [{"name": "Home"}]}
+
+
+# --- calibration state ------------------------------------------------------
+def test_calib_state_roundtrip(tmp_path):
+    hass = make_hass(tmp_path)
+    run(st.save_calib_state(hass, {"results": {"F": 1}, "saved_at": 123}))
+    assert run(st.load_calib_state(hass)) == {"results": {"F": 1}, "saved_at": 123}
+
+
+def test_calib_state_migrates_and_removes_legacy(tmp_path):
+    hass = make_hass(tmp_path)
+    legacy = _legacy_calib(hass)
+    legacy.write_text('{"results": {"F": 2}}')
+    run(st.migrate_legacy(hass))
+    assert run(st.load_calib_state(hass)) == {"results": {"F": 2}}
+    assert not legacy.exists()


### PR DESCRIPTION
Fixes #104 (0-byte `bpsdata.txt` wiped a user's whole config), and closes the residual `/local` read exposure from #103.

## Root cause
Every writer of `bpsdata.txt` / `bps_calibration_state.json` opened the file with mode `"w"`, which **truncates to 0 bytes before writing**. An interrupted write — an HA restart mid auto-calibration, or an exception after open — left a **0-byte file and wiped the layout**. Living under `www/` also left both readable unauthenticated via `/local/`.

## Fix — move both to HA's `Store` (`config/.storage/`)
`Store.async_save` writes atomically (temp file + `os.replace`; the live file is never truncated), and `.storage` isn't web-served — so this kills the data-loss bug **and** the read exposure in one change.

- **New `storage.py`** — single owner of the layout + calib-state Stores and the write lock (imported by both `__init__` and `calibration`, no cycle). Per-`hass` in-memory cache; `get_bps_data` (read-only) / `get_bps_data_for_edit` (deep copy for calibration's read-modify-write); `save_bps_data` persists **then** caches, using `async_save` (immediate atomic), never `async_delay_save`.
- **`migrate_legacy`** — one-time, idempotent: valid legacy content is saved to the store, **verified**, then the old `www` file is deleted; a 0-byte artifact is cleaned up; a corrupt-but-non-empty file is **left for manual recovery**; the cleanup is **retried every boot** so a failed delete or a backup-restored copy can't stay exposed; a corrupt store never aborts setup (starts empty/degraded, like the old reader).
- Removed the `watchdog` file watcher entirely (writers keep the cache in sync now) and **dropped the `watchdog` manifest requirement**.
- `read_text` / `scanner_linking` / `save_text` now go through the store; map **images** stay in `www/bps_maps` (served via `/local/`, unchanged).

**Frontend is unaffected** — it only ever used `/api/bps/read_text` + `/api/bps/save_text`, which keep the same JSON-string contract (fresh install returns `200` + `""`).

## Verification
- **41 unit tests** against a fake in-memory Store (now JSON-round-tripping, so a non-serializable payload fails like prod): fresh install, valid migrate, **0-byte guard (#104)**, corrupt-file preserved, populated-store no-overwrite + stale-copy cleanup, corrupt-store-degrades, restart round-trip, and `async_save`-not-`async_delay_save`.
- Two adversarial-review rounds; the four low-severity findings (persist-order, corrupt-store resilience, cleanup retry, test JSON fidelity) are fixed here.

## ⚠️ Needs a real-HA smoke test before merge/release
The real `Store` + migration can't run in my harness. Please confirm on a live HA:
1. **Existing install:** on restart, `bpsdata.txt` + `bps_calibration_state.json` disappear from `www/bps_maps` and appear in `config/.storage/`; the panel shows the same floors/zones; `/local/bps_maps/bpsdata.txt` now 404s.
2. **Fresh install:** panel opens empty; saving a floor persists across a restart.
3. Save a floor / run calibration, restart HA — config + corrections survive.
4. A crash mid-activity can no longer 0-byte the layout.

Version **1.7.2**. Note: once on this version, a downgrade would keep data only in `.storage` (the old file is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)