### PR TITLE
Stop the BPS frontend self-banning HA's IP on expired tokens (v1.7.3)

### DIFF
--- a/custom_components/bps/frontend/bps-map-card.js
+++ b/custom_components/bps/frontend/bps-map-card.js
@@ -337,12 +337,49 @@ class BpsMapCard extends HTMLElement {
   }
 
   // GET a /api/bps/* endpoint with the logged-in user's token attached (those
-  // endpoints now require auth). The card always has `hass`, so this is direct.
+  // endpoints now require auth). Returns null (fires NO request) when there is
+  // no valid token, while rate-backing-off after a recent auth failure, or once
+  // a token has failed 5 times (a dead/revoked session must not keep feeding
+  // HA's http.ban and get the IP banned). A different token clears all of that.
+  // Callers treat a null / non-ok result as "no data this cycle".
   async _apiFetch(path) {
     const auth = this._hass && this._hass.auth;
-    const token = auth && (auth.accessToken || (auth.data && auth.data.access_token));
-    const headers = token ? { Authorization: "Bearer " + token } : {};
-    return fetch(path, { headers });
+    if (!auth) return null;
+    // HA does not proactively refresh the access token for manual fetches (its
+    // own use goes through fetchWithAuth); refresh it ourselves when expired so
+    // we don't send a dead Bearer. Feature-detected and de-duplicated so a
+    // burst of calls shares one refresh; on failure the guards below back off.
+    try {
+      if (auth.expired && typeof auth.refreshAccessToken === "function") {
+        this._authRefresh = this._authRefresh
+          || auth.refreshAccessToken().finally(() => { this._authRefresh = null; });
+        await this._authRefresh;
+      }
+    } catch (e) { /* refresh failed: fall through to the backoff/dead-token guards */ }
+    const token = auth.accessToken || (auth.data && auth.data.access_token);
+    if (!token) return null;
+    if (this._authDeadToken && token !== this._authDeadToken) {
+      // Fresh credentials: retry immediately, dropping any pending backoff.
+      this._authFails = 0; this._authBackoff = 0; this._authFailUntil = 0;
+      this._authDeadToken = null;
+    }
+    if (token === this._authDeadToken && (this._authFails || 0) >= 5) return null; // dead token: silent
+    if (Date.now() < (this._authFailUntil || 0)) return null;                      // rate backoff
+    const res = await fetch(path, { headers: { Authorization: "Bearer " + token } });
+    if (res.status === 401 || res.status === 403) {
+      // Bounded backoff (5s -> 5min) AND a hard cap of attempts per token, so
+      // failed auth can't keep hitting the ban tracker.
+      this._authFails = (this._authFails || 0) + 1;
+      this._authDeadToken = token;
+      this._authBackoff = this._authBackoff ? Math.min(this._authBackoff * 2, 300000) : 5000;
+      this._authFailUntil = Date.now() + this._authBackoff;
+    } else {
+      // Any non-401/403 response (incl. cords' normal "no fix yet" 404) proves
+      // the Bearer was accepted: clear all auth-failure state.
+      this._authFails = 0; this._authBackoff = 0; this._authFailUntil = 0;
+      this._authDeadToken = null;
+    }
+    return res;
   }
 
   async _refreshBermudaScanners() {
@@ -617,6 +654,7 @@ class BpsMapCard extends HTMLElement {
 
   async _loadFloorResources(expectedGen) {
     const res = await this._apiFetch("/api/bps/read_text");
+    if (!res) throw new Error("BPS auth not ready (no token / backing off)");
     if (!res.ok) throw new Error(`Could not read BPS data (${res.status})`);
     if (expectedGen !== this._runGeneration) {
       return;
@@ -667,6 +705,7 @@ class BpsMapCard extends HTMLElement {
 
     const floorName = String(resolvedFloorName || this._config.floor || "").trim();
     const mapsRes = await this._apiFetch("/api/bps/maps");
+    if (!mapsRes) throw new Error("BPS auth not ready (no token / backing off)");
     if (!mapsRes.ok) {
       throw new Error(
         `Could not list map files (${mapsRes.status}). Set map_file explicitly or check /api/bps/maps.`,
@@ -988,7 +1027,7 @@ class BpsMapCard extends HTMLElement {
       // A 404 here just means no tracker has position data yet; receivers
       // should still render, so this is not an early return.
       const res = await this._apiFetch("/api/bps/cords");
-      if (res.ok) {
+      if (res && res.ok) {
         const list = await res.json();
         if (Array.isArray(list)) {
           for (const ent of this._config.entities) {

--- a/custom_components/bps/frontend/bps-panel.js
+++ b/custom_components/bps/frontend/bps-panel.js
@@ -72,10 +72,27 @@ class BpsPanel extends HTMLElement {
     return auth.accessToken || (auth.data && auth.data.access_token) || null;
   }
 
-  _pushToken(force) {
+  async _pushToken(force) {
     if (!this._iframe) return;
     const cw = this._iframe.contentWindow;
     if (!cw) return;
+    // Refresh an expired token before couriering it: HA does not proactively
+    // refresh the access token for the manual /api/bps/* fetches the app makes,
+    // so without this the app keeps sending a dead Bearer and every poll 401s —
+    // which HA's http.ban counts toward banning the client's IP.
+    const auth = this._hass && this._hass.auth;
+    if (auth && auth.expired && typeof auth.refreshAccessToken === "function") {
+      // De-dupe: `set hass` fires many times a second, so cache the in-flight
+      // refresh and have concurrent ticks await the same one instead of each
+      // firing its own /auth/token request while the token is expired.
+      try {
+        this._refreshing = this._refreshing
+          || auth.refreshAccessToken().finally(() => { this._refreshing = null; });
+        await this._refreshing;
+      } catch (e) { /* send what we have */ }
+      // The element may have detached (and the iframe changed) during the await.
+      if (!this._iframe || this._iframe.contentWindow !== cw) return;
+    }
     const token = this._token();
     if (!token) return;
     if (!force && token === this._lastToken) return;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -13,10 +13,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     let _resolveToken = null;
     const _tokenReady = new Promise((resolve) => { _resolveToken = resolve; });
     const _settleToken = () => { if (_resolveToken) { _resolveToken(); _resolveToken = null; } };
+    // Auth-failure handling: after a 401/403 we back off (5s -> 5min) AND cap
+    // the number of attempts per token, so a stale/expired/revoked token can't
+    // keep racking up failed-auth hits and get our IP banned by HA's http.ban.
+    // A fresh token couriered in from the panel clears all of it immediately.
+    let _authFailUntil = 0;
+    let _authBackoff = 0;
+    let _authFails = 0;
+    let _authDeadToken = null;
     window.addEventListener("message", (e) => {
         if (e.origin !== window.location.origin) return;
         if (e.data && e.data.type === "bps-auth" && e.data.token) {
+            const isNew = e.data.token !== bpsAuthToken;
             bpsAuthToken = e.data.token;
+            if (isNew) { _authFailUntil = 0; _authBackoff = 0; _authFails = 0; _authDeadToken = null; } // fresh token: retry now
             _settleToken();
         }
     });
@@ -27,9 +37,38 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     async function bpsFetch(url, opts = {}) {
         if (bpsAuthToken === null) await _tokenReady;
+        // Dead token: after 5 failures on this exact token, send nothing more
+        // with it until a different one is couriered in. The 503 is treated by
+        // callers as "no data this cycle".
+        if (bpsAuthToken && bpsAuthToken === _authDeadToken && _authFails >= 5) {
+            return new Response(null, { status: 503, statusText: "BPS auth stuck" });
+        }
+        // Rate backoff between the allowed attempts.
+        if (Date.now() < _authFailUntil) {
+            return new Response(null, { status: 503, statusText: "BPS auth backoff" });
+        }
         const headers = Object.assign({}, opts.headers || {});
         if (bpsAuthToken) headers["Authorization"] = "Bearer " + bpsAuthToken;
-        return fetch(url, Object.assign({}, opts, { headers }));
+        const res = await fetch(url, Object.assign({}, opts, { headers }));
+        if (res.status === 401 || res.status === 403) {
+            _authFails += 1;
+            _authDeadToken = bpsAuthToken;
+            _authBackoff = _authBackoff ? Math.min(_authBackoff * 2, 300000) : 5000;
+            _authFailUntil = Date.now() + _authBackoff;
+            // Ask the panel for a fresh token: it refreshes an expired one and
+            // couriers it back, which clears this state (message handler above).
+            if (window.parent && window.parent !== window) {
+                window.parent.postMessage("bps-ready", window.location.origin);
+            }
+        } else {
+            // Any non-401/403 response (incl. cords' normal 404) proves the
+            // Bearer was accepted: clear all auth-failure state.
+            _authFails = 0;
+            _authBackoff = 0;
+            _authFailUntil = 0;
+            _authDeadToken = null;
+        }
+        return res;
     }
     const upload = document.getElementById('upload');
     const mapSelector = document.getElementById('mapSelector');

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.1"
+    "version": "1.7.2"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.2"
+    "version": "1.7.3"
 }


### PR DESCRIPTION
Fixes a regression from #103 (endpoint authentication). Reported symptom — the log fills with, and HA's ban tracker counts:
```
WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from 192.168.0.1. Requested URL: '/api/bps/cords'.
```

## Root cause
The card and panel poll the now `requires_auth=True` `/api/bps/*` endpoints, but:
1. **They never refreshed an expired token.** Both read `hass.auth.accessToken` directly. HA only auto-refreshes for its *own* fetches (via `fetchWithAuth`), not manual ones — so once a session's short-lived access token expired, every poll sent a dead Bearer → 401.
2. **No backoff.** The card polls every few seconds, the panel's tracking loop ~1 Hz, `receiver_status` every 10 s — all on fixed timers regardless of failures.

Every 401 increments HA's per-IP failed-auth counter, so the integration's own polling could get the client's IP — or, behind a reverse proxy without `trusted_proxies`, the **gateway** IP (`192.168.0.1`), i.e. the whole LAN — banned once `login_attempts_threshold` is configured. Frontend-only.

## Fix
- **Refresh on expiry** in the card (`_apiFetch`) and the panel courier (`_pushToken`), feature-detected (`auth.expired` / `auth.refreshAccessToken`); if the API differs it falls through to the guards below, so it degrades safely. Concurrent refreshes share one in-flight promise (no `/auth/token` stampede on rapid `set hass`).
- **Bound failed auth** so it can't feed the ban tracker: exponential backoff (5 s → 5 min) **and** a hard cap of **5 attempts per token** — once a token is dead, fire *no* further requests with it until a different token appears. A freshly refreshed/couriered token clears everything and retries at once.
- **Clear backoff on any non-401/403 response, not just 2xx.** `/api/bps/cords` returns **404 as its normal "no fix yet" state** with a perfectly valid token, so gating the reset on `res.ok` left the backoff stuck (review finding).
- **No token → no request** (return `null` / 503) instead of a headerless 401.

## Verification
- **Browser harness, 19/19** (real browser, no console errors): refresh-on-expiry sends a fresh Bearer; a 401 arms backoff and the next in-window call fires **no** request; a 404 clears state; the 5-attempt cap stops firing; a **new token clears the stuck state and retries**; concurrent refreshes dedupe to one call; degrades cleanly when `refreshAccessToken` is absent.
- Adversarial review (3 lenses → per-finding skeptic verify): all 5 findings confirmed, 0 refuted; the count-cap, 404-reset, and refresh-dedup came directly from it.

## If you're currently banned
Remove the `192.168.0.1` line from `config/ip_bans.yaml` and restart HA. If that IP is your gateway (HA behind a proxy), set `http.use_x_forwarded_for` + `trusted_proxies` so bans target real clients.

## ⚠️ Version collision
Tagged **v1.7.2**, same as the eval-harness [#109](https://github.com/maxi1134/BPS-improved/pull/109). This is the urgent one — merge it first; I'll rebump #109 to 1.7.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)