### PR TITLE
Receiver leave-one-out self-localization benchmark (v1.7.3)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -38,6 +38,7 @@ from .calibration import (
     async_restore_calibration_state,
     async_shutdown_calibration,
     async_start_auto_if_enabled,
+    get_calibration_state,
     refresh_receivers_from_coords,
 )
 from .storage import (
@@ -1511,6 +1512,7 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSScannerLinkingAPI())
             hass.http.register_view(BPSCordsAPI(hass))
             hass.http.register_view(BPSCalibrationAPI())
+            hass.http.register_view(BPSSelfTestAPI(hass))
             hass.data["bps_views_registered"] = True
 
         config_path = hass.config.path()
@@ -2132,3 +2134,118 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
         return None
     x, y = result.x # Extract the calculated coordinates
     return x, y # return the result
+
+
+# --- Receiver self-localization: a zero-setup, ground-truthed accuracy bench --
+# Every receiver's true position is known (it is placed on the map) and Bermuda
+# measures the distance between scanners, so each receiver's position can be
+# solved from the OTHERS' measured distances -- through the SAME trilaterate() +
+# per-receiver correction + slant the live tracker uses -- and compared to where
+# it actually is (leave-one-out). This measures the SOLVER, per-receiver
+# calibration, and geometry with no parked beacon and no hand-measured truth.
+# It does NOT exercise the temporal filtering (a static, always-fresh anchor has
+# no motion to smooth or stale readings to reject), and it is an OPTIMISTIC
+# bound on real tracker accuracy: calibration is fit on these very inter-receiver
+# links, and receiver-to-receiver paths (ceiling height, clean line of sight)
+# are easier than a body-worn beacon's. Consumed by tools/bps_eval.py `selftest`.
+SELFTEST_MIN_SAMPLES = 3  # need a median over at least this many raw distances
+
+
+def _selftest_receivers(coords):
+    """slug -> {entity, x, y, scale, floor, height, correction} for every placement."""
+    out = {}
+    if not isinstance(coords, dict):
+        return out
+    for floor in coords.get("floor", []):
+        scale = floor.get("scale")
+        if not scale:
+            continue
+        for rec in floor.get("receivers", []):
+            cords = rec.get("cords") or {}
+            eid = rec.get("entity_id")
+            if not eid or cords.get("x") is None or cords.get("y") is None:
+                continue
+            height = rec.get("height")
+            corr = rec.get("correction")
+            out[str(eid)] = {
+                "entity": str(eid),
+                "x": float(cords["x"]),
+                "y": float(cords["y"]),
+                "scale": float(scale),
+                "floor": floor.get("name"),
+                "height": float(height) if isinstance(height, (int, float)) and 0 <= height <= 10 else None,
+                "correction": float(corr) if isinstance(corr, (int, float)) and corr > 0 else 1.0,
+            }
+    return out
+
+
+def run_selftest(hass):
+    """Leave-one-out receiver self-localization accuracy against known positions."""
+    receivers = _selftest_receivers(get_bps_data(hass))
+    samples = get_calibration_state(hass).get("samples", {})
+
+    def _measured_m(target, rx):
+        # The live tracker sees the beacon (target) transmit and a receiver hear
+        # it, so use exactly that direction ("target|rx") and the receiver's gain.
+        vals = [float(v) for v in samples.get(f"{target}|{rx}", [])
+                if isinstance(v, (int, float)) and v > 0]
+        if len(vals) < SELFTEST_MIN_SAMPLES:
+            return None
+        return float(np.median(vals))
+
+    solved, unsolved = [], []
+    for slug, tgt in receivers.items():
+        pts = []
+        for oslug, o in receivers.items():
+            if oslug == slug or o["floor"] != tgt["floor"]:
+                continue
+            raw = _measured_m(slug, oslug)
+            if raw is None:
+                continue
+            d = raw * o["correction"]  # receiving scanner's correction (live path)
+            horizontal = d
+            if tgt["height"] is not None and o["height"] is not None:
+                dz = o["height"] - tgt["height"]
+                horizontal = math.sqrt(max(d * d - dz * dz, 0.0))
+            pts.append((o["x"], o["y"], horizontal * tgt["scale"]))  # radius in pixels
+        if len(pts) < 3:
+            unsolved.append({"entity": slug, "floor": tgt["floor"], "heard_by": len(pts)})
+            continue
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+        bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
+        fix = trilaterate(
+            [(px, py, pr, 1.0) for (px, py, pr) in pts],
+            bounds=bounds, min_weight_radius=MIN_WEIGHT_RADIUS_M * tgt["scale"],
+        )
+        if fix is None:
+            unsolved.append({"entity": slug, "floor": tgt["floor"], "heard_by": len(pts), "reason": "no convergence"})
+            continue
+        err_px = math.hypot(fix[0] - tgt["x"], fix[1] - tgt["y"])
+        solved.append({
+            "entity": slug, "floor": tgt["floor"],
+            "known": [round(tgt["x"], 1), round(tgt["y"], 1)],
+            "est": [round(float(fix[0]), 1), round(float(fix[1]), 1)],
+            "error_m": round(err_px / tgt["scale"], 3),
+            "heard_by": len(pts),
+        })
+    return {
+        "receivers": solved,
+        "unsolved": unsolved,
+        "counts": {"placed": len(receivers), "solved": len(solved), "unsolved": len(unsolved)},
+    }
+
+
+class BPSSelfTestAPI(HomeAssistantView):
+    """Read-only receiver leave-one-out self-localization accuracy (see run_selftest)."""
+
+    url = "/api/bps/selftest"
+    name = "api:bps:selftest"
+    requires_auth = True
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    async def get(self, request):
+        return web.json_response(run_selftest(self.hass))

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -2179,9 +2179,44 @@ def _selftest_receivers(coords):
     return out
 
 
+def _selftest_floor_bounds(coords, receivers):
+    """Per-floor solver bounds = extent of ALL placed receivers + zone polygons
+    (+10% margin), mirroring the live solve (update_trilateration_and_zone).
+
+    Keyed on the floor so a left-out perimeter receiver's own known position
+    still lies inside the feasible box — bounding only to the OTHER receivers
+    would clamp it and inflate its error.
+    """
+    xs_by, ys_by = {}, {}
+    for r in receivers.values():
+        xs_by.setdefault(r["floor"], []).append(r["x"])
+        ys_by.setdefault(r["floor"], []).append(r["y"])
+    if isinstance(coords, dict):
+        for floor in coords.get("floor", []):
+            name = floor.get("name")
+            for zone in floor.get("zones", []) or []:  # no-go zones still bound the floor
+                for c in (zone.get("cords") or []):
+                    if isinstance(c, dict) and c.get("x") is not None and c.get("y") is not None:
+                        xs_by.setdefault(name, []).append(float(c["x"]))
+                        ys_by.setdefault(name, []).append(float(c["y"]))
+    out = {}
+    for name, xs in xs_by.items():
+        ys = ys_by[name]
+        margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+        out[name] = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
+    return out
+
+
 def run_selftest(hass):
-    """Leave-one-out receiver self-localization accuracy against known positions."""
-    receivers = _selftest_receivers(get_bps_data(hass))
+    """Leave-one-out receiver self-localization accuracy against known positions.
+
+    Solves on the RAW inter-receiver distances BPS collects for calibration
+    (median per link), not the Bermuda-filtered distance sensor the live tracker
+    reads — so the numbers also exclude Bermuda's own smoothing.
+    """
+    coords = get_bps_data(hass)
+    receivers = _selftest_receivers(coords)
+    floor_bounds = _selftest_floor_bounds(coords, receivers)
     samples = get_calibration_state(hass).get("samples", {})
 
     def _measured_m(target, rx):
@@ -2211,13 +2246,10 @@ def run_selftest(hass):
         if len(pts) < 3:
             unsolved.append({"entity": slug, "floor": tgt["floor"], "heard_by": len(pts)})
             continue
-        xs = [p[0] for p in pts]
-        ys = [p[1] for p in pts]
-        margin = 0.1 * max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
-        bounds = (min(xs) - margin, min(ys) - margin, max(xs) + margin, max(ys) + margin)
         fix = trilaterate(
             [(px, py, pr, 1.0) for (px, py, pr) in pts],
-            bounds=bounds, min_weight_radius=MIN_WEIGHT_RADIUS_M * tgt["scale"],
+            bounds=floor_bounds.get(tgt["floor"]),
+            min_weight_radius=MIN_WEIGHT_RADIUS_M * tgt["scale"],
         )
         if fix is None:
             unsolved.append({"entity": slug, "floor": tgt["floor"], "heard_by": len(pts), "reason": "no convergence"})
@@ -2248,4 +2280,8 @@ class BPSSelfTestAPI(HomeAssistantView):
         self.hass = hass
 
     async def get(self, request):
-        return web.json_response(run_selftest(self.hass))
+        # One scipy solve per receiver; run off the event loop. run_selftest
+        # only reads in-memory dicts (layout cache + calibration samples), so
+        # it is safe in the executor.
+        data = await self.hass.async_add_executor_job(run_selftest, self.hass)
+        return web.json_response(data)

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.2"
+    "version": "1.7.3"
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -167,3 +167,27 @@ def test_null_updated_does_not_crash_sort(tmp_path):
     m = ev.score_recording(path)["beacon"]
     assert m["n"] == 2
     assert isinstance(m["duration_s"], (int, float))
+
+
+# --- selftest stats --------------------------------------------------------
+def test_selftest_stats_basic():
+    data = {
+        "counts": {"placed": 3, "solved": 2, "unsolved": 1},
+        "receivers": [
+            {"entity": "a", "floor": "F", "error_m": 1.0},
+            {"entity": "b", "floor": "F", "error_m": 3.0},
+        ],
+        "unsolved": [{"entity": "c", "floor": "F"}],
+    }
+    s = ev.selftest_stats(data)
+    assert s["placed"] == 3 and s["solved"] == 2 and s["unsolved"] == 1
+    assert abs(s["cep50"] - 2.0) < 1e-9      # median of [1, 3]
+    assert abs(s["mean"] - 2.0) < 1e-9 and abs(s["max"] - 3.0) < 1e-9
+    assert s["worst"]["entity"] == "b"
+    assert s["per_floor"]["F"]["solved"] == 2
+
+
+def test_selftest_stats_empty_has_no_cep():
+    s = ev.selftest_stats({"counts": {"placed": 5, "solved": 0, "unsolved": 5},
+                          "receivers": [], "unsolved": []})
+    assert s["solved"] == 0 and "cep50" not in s

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -235,3 +235,13 @@ def test_selftest_error_grows_with_bad_distance():
 def test_selftest_empty_layout_is_safe():
     res = bps.run_selftest(make_hass())
     assert res["counts"]["placed"] == 0 and res["counts"]["solved"] == 0
+
+
+def test_selftest_bounds_include_left_out_perimeter_receiver():
+    # A receiver far outside the OTHER receivers' hull must still be recoverable:
+    # the solver bounds cover ALL placed receivers (mirroring the live path), not
+    # just the ones feeding this solve — otherwise it would clamp and over-report.
+    recs = [("a", 0, 0), ("b", 50, 0), ("c", 0, 50), ("r", 200, 200)]
+    res = bps.run_selftest(_hass_with(recs, _exact_samples(recs)))
+    err = {x["entity"]: x["error_m"] for x in res["receivers"]}
+    assert err["r"] < 0.5   # not clamped to the a/b/c bounding box

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -9,6 +9,7 @@ import math
 
 import bps
 from bps import calibration as cal_mod
+from conftest import make_hass
 
 SCALE = 40.0  # px per metre
 
@@ -158,3 +159,79 @@ def test_elect_hysteresis_and_dwell():
         floor, ch = bps._elect_floor({"a": 0.7, "b": 0.3}, "b", {"a", "b"}, ch)
         seen.append(floor)
     assert seen[:bps.FLOOR_SWITCH_CYCLES] == ["b"] * (bps.FLOOR_SWITCH_CYCLES - 1) + ["a"]
+
+
+# --------------------------------------------------------------------------- #
+# Receiver leave-one-out self-localization (run_selftest)
+# --------------------------------------------------------------------------- #
+def _hass_with(receivers, samples, scale=SCALE, floor="F"):
+    """Fake hass carrying a BPS layout + calibration samples for run_selftest."""
+    hass = make_hass()
+    recs = []
+    for r in receivers:
+        d = {"entity_id": r[0], "cords": {"x": r[1], "y": r[2]}}
+        if len(r) > 3 and r[3] is not None:
+            d["height"] = r[3]
+        recs.append(d)
+    hass.data.setdefault("bps", {})["layout"] = {
+        "floor": [{"name": floor, "scale": scale, "receivers": recs}]
+    }
+    hass.data["bps"]["calibration"] = {"samples": samples}
+    return hass
+
+
+def _exact_samples(receivers, scale=SCALE):
+    """samples["target|rx"] = the true slant distance, so a faithful solve
+    recovers each receiver exactly (heights, when set, are corrected back out)."""
+    pos = {r[0]: (r[1], r[2], (r[3] if len(r) > 3 else None)) for r in receivers}
+    s = {}
+    for a in pos:
+        for b in pos:
+            if a == b:
+                continue
+            ax, ay, ah = pos[a]
+            bx, by, bh = pos[b]
+            horiz = math.hypot(ax - bx, ay - by) / scale
+            dz = (bh - ah) if (ah is not None and bh is not None) else 0.0
+            slant = math.hypot(horiz, dz)
+            s[f"{a}|{b}"] = [slant, slant, slant]
+    return s
+
+
+SQUARE = [("r1", 0, 0), ("r2", 100, 0), ("r3", 0, 100), ("r4", 100, 100)]
+
+
+def test_selftest_recovers_receivers():
+    res = bps.run_selftest(_hass_with(SQUARE, _exact_samples(SQUARE)))
+    assert res["counts"]["solved"] == 4
+    assert all(r["error_m"] < 0.5 for r in res["receivers"])
+
+
+def test_selftest_recovers_with_mount_heights():
+    recs = [("r1", 0, 0, 1.0), ("r2", 100, 0, 3.0), ("r3", 0, 100, 2.0), ("r4", 100, 100, 3.0)]
+    res = bps.run_selftest(_hass_with(recs, _exact_samples(recs)))
+    assert res["counts"]["solved"] == 4          # slant correction round-trips
+    assert all(r["error_m"] < 0.5 for r in res["receivers"])
+
+
+def test_selftest_unsolved_when_too_few_neighbors():
+    recs = SQUARE + [("r5", 200, 200)]           # r5 has no samples at all
+    res = bps.run_selftest(_hass_with(recs, _exact_samples(SQUARE)))
+    solved = {r["entity"] for r in res["receivers"]}
+    unsolved = {u["entity"] for u in res["unsolved"]}
+    assert solved == {"r1", "r2", "r3", "r4"} and "r5" in unsolved
+
+
+def test_selftest_error_grows_with_bad_distance():
+    s = _exact_samples(SQUARE)
+    for o in ("r2", "r3", "r4"):                  # inflate only r1's incoming links
+        s[f"r1|{o}"] = [v * 1.6 for v in s[f"r1|{o}"]]
+    res = bps.run_selftest(_hass_with(SQUARE, s))
+    err = {r["entity"]: r["error_m"] for r in res["receivers"]}
+    # Only the distorted receiver is dragged off; the others still solve clean.
+    assert err["r1"] > 0.2 and max(err["r2"], err["r3"], err["r4"]) < 0.05
+
+
+def test_selftest_empty_layout_is_safe():
+    res = bps.run_selftest(make_hass())
+    assert res["counts"]["placed"] == 0 and res["counts"]["solved"] == 0

--- a/tools/bps_eval.py
+++ b/tools/bps_eval.py
@@ -9,8 +9,8 @@ tool is the guardrail for the precision/jumpiness work that follows.
 Pure standard library on purpose: copy it onto the HA host (or any machine
 that can reach it) and run with `python3` — no pip install.
 
-Two subcommands
----------------
+Three subcommands
+-----------------
   record   Poll /api/bps/cords at ~1 Hz into a JSONL file, de-duplicating on
            each entry's `updated` stamp (a 1 Hz poll of a 1 Hz publisher
            otherwise aliases the same fix many times). Snapshots each floor's
@@ -25,6 +25,14 @@ Two subcommands
            raw pre-Kalman `raw` fix, so an improvement can be attributed to the
            solver vs. the filter. --baseline scores a second file alongside and
            prints the delta for A/B before/after runs.
+
+  selftest Ground-truthed accuracy with NO parked beacon: hits /api/bps/selftest,
+           which solves each receiver's position from the OTHERS' measured
+           distances (leave-one-out, through the real solver + calibration) and
+           compares to its known placed position. Reports CEP50/CEP95 error in
+           metres over all receivers. Measures the solver + calibration, not
+           jumpiness, and is an optimistic bound on real tracker accuracy.
+           --out saves the raw result; --baseline diffs a saved run.
 
 Typical use
 -----------
@@ -310,6 +318,38 @@ def score_recording(path, truth=None, waypoints=None):
             for ent, s in by_ent.items()}
 
 
+def selftest_stats(data):
+    """Aggregate a /api/bps/selftest response into headline accuracy numbers.
+
+    Errors are already in metres (the backend divides by each floor's scale).
+    """
+    recv = data.get("receivers", []) if isinstance(data, dict) else []
+    counts = data.get("counts", {}) if isinstance(data, dict) else {}
+    errors = [r["error_m"] for r in recv if isinstance(r.get("error_m"), (int, float))]
+    out = {
+        "placed": counts.get("placed"),
+        "solved": len(errors),
+        "unsolved": counts.get("unsolved", len(data.get("unsolved", []) or []) if isinstance(data, dict) else 0),
+    }
+    if errors:
+        out["cep50"] = percentile(errors, 50)
+        out["cep95"] = percentile(errors, 95)
+        out["mean"] = sum(errors) / len(errors)
+        out["max"] = max(errors)
+        worst = max(recv, key=lambda r: r.get("error_m", 0))
+        out["worst"] = {"entity": worst.get("entity"), "error_m": worst.get("error_m"),
+                       "floor": worst.get("floor")}
+    floors = {}
+    for r in recv:
+        if isinstance(r.get("error_m"), (int, float)):
+            floors.setdefault(r.get("floor"), []).append(r["error_m"])
+    out["per_floor"] = {
+        f: {"solved": len(es), "cep50": percentile(es, 50), "cep95": percentile(es, 95)}
+        for f, es in floors.items()
+    }
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # Scoring (CLI / reporting)
 # --------------------------------------------------------------------------- #
@@ -392,6 +432,52 @@ def cmd_score(args):
     return 0
 
 
+def _print_selftest(s, base=None):
+    print("\nReceiver self-localization (leave-one-out, ground-truthed):")
+    print(f"  solved {s['solved']}/{s.get('placed')} placed   unsolved={s['unsolved']}")
+    if not s["solved"]:
+        print("  no receivers solvable (each needs >=3 others hearing it, with samples).")
+        return
+    for key, label in [("cep50", "CEP50"), ("cep95", "CEP95"), ("mean", "mean"), ("max", "max")]:
+        line = f"  {label:<8} {s[key]:.3f} m"
+        if base and key in base:
+            d = s[key] - base[key]
+            arrow = "improved" if d < 0 else "worse" if d > 0 else "same"
+            line += f"   (baseline {base[key]:.3f}, {d:+.3f} {arrow})"
+        print(line)
+    w = s.get("worst") or {}
+    print(f"  worst: {w.get('entity')} @ {w.get('error_m')} m ({w.get('floor')})")
+    if len(s.get("per_floor", {})) > 1:
+        for f, fs in s["per_floor"].items():
+            print(f"    floor {f}: solved {fs['solved']}  CEP50 {fs['cep50']:.3f}  CEP95 {fs['cep95']:.3f} m")
+    print("  (Measures the solver + calibration, not jumpiness; optimistic vs a real tracker.)")
+
+
+def cmd_selftest(args):
+    token = args.token or os.environ.get("BPS_TOKEN")
+    if not token:
+        print("error: pass --token or set BPS_TOKEN", file=sys.stderr)
+        return 2
+    data = _get(args.url.rstrip("/") + "/api/bps/selftest", token)
+    if data is None:
+        print("no self-test data (empty layout, or the endpoint returned nothing).", file=sys.stderr)
+        return 1
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        print(f"raw self-test written to {args.out}")
+    stats = selftest_stats(data)
+    baseline = None
+    if args.baseline:
+        with open(args.baseline, encoding="utf-8") as fh:
+            baseline = selftest_stats(json.load(fh))
+    if args.json:
+        print(json.dumps({"stats": stats, "baseline": baseline}, indent=2))
+        return 0
+    _print_selftest(stats, baseline)
+    return 0
+
+
 # --------------------------------------------------------------------------- #
 def build_parser():
     p = argparse.ArgumentParser(
@@ -413,6 +499,14 @@ def build_parser():
     s.add_argument("--waypoints", help="JSON file [{\"x\":px,\"y\":py},...] for a walk crosstrack score")
     s.add_argument("--json", action="store_true", help="emit metrics as JSON")
     s.set_defaults(func=cmd_score)
+
+    t = sub.add_parser("selftest", help="ground-truthed receiver self-localization accuracy (no beacon needed)")
+    t.add_argument("--url", required=True, help="HA base URL, e.g. http://homeassistant.local:8123")
+    t.add_argument("--token", help="long-lived access token (or set BPS_TOKEN)")
+    t.add_argument("--out", help="save the raw endpoint JSON, to diff a later run against")
+    t.add_argument("--baseline", help="a previously saved --out JSON to diff against")
+    t.add_argument("--json", action="store_true", help="emit stats as JSON")
+    t.set_defaults(func=cmd_selftest)
     return p
 
 

--- a/tools/bps_eval.py
+++ b/tools/bps_eval.py
@@ -336,7 +336,8 @@ def selftest_stats(data):
         out["cep95"] = percentile(errors, 95)
         out["mean"] = sum(errors) / len(errors)
         out["max"] = max(errors)
-        worst = max(recv, key=lambda r: r.get("error_m", 0))
+        worst = max((r for r in recv if isinstance(r.get("error_m"), (int, float))),
+                    key=lambda r: r["error_m"])
         out["worst"] = {"entity": worst.get("entity"), "error_m": worst.get("error_m"),
                        "floor": worst.get("floor")}
     floors = {}


### PR DESCRIPTION
A **ground-truthed, zero-setup** accuracy benchmark for the position solver — no parked beacon, no tape measure. Every receiver's true position is known (it's placed on the map) and Bermuda already measures scanner-to-scanner distances, so each receiver's position can be solved from the *others'* measured distances and compared to where it actually is (**leave-one-out**). That's 22 anchor points across the space instead of one hand-placed beacon, and it re-runs instantly for before/after.

## What it does
- **`run_selftest(hass)` + `GET /api/bps/selftest`** (`requires_auth`, read-only): for each receiver, solves its position from the others through the **same `trilaterate()` + per-receiver `correction` + slant** the live tracker uses, fed by the inter-receiver distances BPS already collects for calibration. Returns per-receiver `{known, est, error_m, heard_by}` + counts. Runs in the executor (one scipy solve per receiver).
- **`tools/bps_eval.py selftest`**: fetches the endpoint and reports **CEP50/CEP95** error (metres) over all receivers, per floor, and the worst offender. `--out` saves the raw result; `--baseline` diffs a saved run.

```
python3 tools/bps_eval.py selftest --url http://homeassistant.local:8123 --token "$BPS_TOKEN"
```

## Scope — what it does and doesn't measure
- ✅ **Solver + per-receiver calibration + geometry**, with real ground-truthed **bias**, not just scatter. This is the bench for #4 (robust loss), #2 (adaptive noise), and the calibration work.
- ❌ **Not the temporal filtering** — a static, always-fresh anchor has no motion to smooth or stale readings to reject, so the jumpiness items (#1 staleness, #3 predict-only KF) still need a short live **walk**.
- ⚠️ **Optimistic bound** on real tracker accuracy: calibration is fit on these very inter-receiver links, and receiver-to-receiver paths (ceiling height, clean line of sight) are easier than a body-worn beacon at ~1 m. It also solves on the raw calibration-sample distances, not Bermuda's filtered sensor. Great for *relative* before/after; not a promise of live accuracy.

## Verification
- **62 unit tests** (`python -m pytest tests/ -q`). New: exact recovery (incl. mount-height slant round-trip), unsolved when <3 neighbors, error grows on a bad link, a perimeter receiver outside the others' hull still recovers (bounds regression), empty-layout safe, and the harness stats.
- Adversarial review (3 lenses → per-finding verify): 8 raised, 6 confirmed & fixed here — the important one being that the solver bounds now mirror the live path (receivers + zone polygons) so perimeter receivers aren't clamped and over-reported.

Version **1.7.3** (stacks on the released 1.7.2). No config or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)