### PR TITLE
Publish self-localization accuracy as an HA sensor (v1.7.4)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -353,6 +353,18 @@ async def update_tracked_entities(hass, jinja_code):
             update_tracked_entities.last_liveness = now_ts
             await update_receiver_liveness(hass)
 
+        # Publish the self-localization accuracy sensor on a slow cadence (runs
+        # on the first tick too, so a fresh deploy shows a value quickly). The
+        # scipy solves run in the executor so the loop is never blocked.
+        if now_ts - getattr(update_tracked_entities, "last_selftest", 0.0) >= SELFTEST_SENSOR_INTERVAL:
+            update_tracked_entities.last_selftest = now_ts
+            try:
+                result = await hass.async_add_executor_job(run_selftest, hass)
+                state, attrs = _selftest_summary(result)
+                update_bps_sensor_state(hass, SELFTEST_SENSOR_ENTITY_ID, state, attrs)
+            except Exception as e:  # never let the diagnostic sensor stall tracking
+                _LOGGER.warning("BPS self-test sensor update failed: %s", e)
+
         await asyncio.sleep(secToUpdate)  # Run every X seconds, set timer in global variables
 
 
@@ -2149,6 +2161,8 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
 # links, and receiver-to-receiver paths (ceiling height, clean line of sight)
 # are easier than a body-worn beacon's. Consumed by tools/bps_eval.py `selftest`.
 SELFTEST_MIN_SAMPLES = 3  # need a median over at least this many raw distances
+SELFTEST_SENSOR_ENTITY_ID = "sensor.bps_position_accuracy"
+SELFTEST_SENSOR_INTERVAL = 1800  # refresh the accuracy sensor every 30 min
 
 
 def _selftest_receivers(coords):
@@ -2267,6 +2281,38 @@ def run_selftest(hass):
         "unsolved": unsolved,
         "counts": {"placed": len(receivers), "solved": len(solved), "unsolved": len(unsolved)},
     }
+
+
+def _selftest_summary(result):
+    """(state, attributes) for the accuracy sensor from a run_selftest result.
+
+    State is CEP95 in metres (lower is better), or None (-> "unknown") when no
+    receiver was solvable. Attributes stay compact (no per-receiver list) so
+    they don't bloat recorder history; the full detail is on /api/bps/selftest.
+    """
+    recv = [r for r in result.get("receivers", []) if isinstance(r.get("error_m"), (int, float))]
+    counts = result.get("counts", {})
+    attrs = {
+        "solved": counts.get("solved"),
+        "placed": counts.get("placed"),
+        "unsolved": counts.get("unsolved"),
+    }
+    if not recv:
+        return None, attrs
+    errs = np.array([r["error_m"] for r in recv], dtype=float)
+    attrs["cep50_m"] = round(float(np.percentile(errs, 50)), 3)
+    attrs["cep95_m"] = round(float(np.percentile(errs, 95)), 3)
+    attrs["mean_m"] = round(float(errs.mean()), 3)
+    attrs["max_m"] = round(float(errs.max()), 3)
+    worst = max(recv, key=lambda r: r["error_m"])
+    attrs["worst"] = f"{worst.get('entity')} ({worst.get('error_m')} m)"
+    by_floor = {}
+    for r in recv:
+        by_floor.setdefault(r.get("floor"), []).append(r["error_m"])
+    attrs["per_floor_cep95_m"] = {
+        f: round(float(np.percentile(v, 95)), 3) for f, v in by_floor.items()
+    }
+    return attrs["cep95_m"], attrs
 
 
 class BPSSelfTestAPI(HomeAssistantView):

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -48,6 +48,7 @@ from .storage import (
     migrate_legacy,
     save_bps_data,
 )
+from .const import ACCURACY_ENTITY_ID
 from .zone_adjust import adjust_zones, adjust_subzones
 
 _LOGGER = logging.getLogger(__name__)
@@ -315,6 +316,30 @@ async def update_tracked_entities(hass, jinja_code):
     global secToUpdate
     template = Template(jinja_code, hass)  # compile once; async_render re-evaluates each tick
     while True:
+        # Receiver liveness and the self-localization accuracy sensor are
+        # receiver-side diagnostics, independent of how many beacons are being
+        # tracked — so they run on their own slow cadence at the TOP of the loop,
+        # BEFORE the "too few trackers" early-continues below (otherwise a fresh
+        # deploy, or any time nobody is home, would never publish them).
+        now_ts = time.time()
+        if now_ts - getattr(update_tracked_entities, "last_liveness", 0.0) >= RECEIVER_DUMP_INTERVAL:
+            update_tracked_entities.last_liveness = now_ts
+            await update_receiver_liveness(hass)
+
+        # Runs on the first tick too, so a fresh deploy shows a value quickly.
+        # The scipy solves run in the executor so the loop is never blocked; the
+        # calibration sample deques are snapshotted here on the loop thread first
+        # to avoid a "mutated during iteration" race with calibration's ingest.
+        if now_ts - getattr(update_tracked_entities, "last_selftest", 0.0) >= SELFTEST_SENSOR_INTERVAL:
+            update_tracked_entities.last_selftest = now_ts
+            try:
+                samples = {k: list(v) for k, v in get_calibration_state(hass).get("samples", {}).items()}
+                result = await hass.async_add_executor_job(run_selftest, hass, samples)
+                state, attrs = _selftest_summary(result)
+                update_bps_sensor_state(hass, ACCURACY_ENTITY_ID, state, attrs)
+            except Exception as e:  # never let the diagnostic sensor stall tracking
+                _LOGGER.warning("BPS self-test sensor update failed: %s", e)
+
         try:
             tracked_entities = template.async_render()
             # The template matches every "_distance_to_" sensor; keep only the
@@ -335,35 +360,17 @@ async def update_tracked_entities(hass, jinja_code):
                 _LOGGER.info("There are not enough trackers with available data to track, sleep 10 seconds")
                 await asyncio.sleep(10)
                 continue  # Skip and start over
-            
+
             cleaned = [item.split("_distance_to_")[0].replace("sensor.", "") for item in tracked_entities]
             unique_values = list(set(cleaned))
             # Use a separate copy per entity to avoid cross-entity mutation side effects.
             layout = get_bps_data(hass)
             new_global_data = [{"entity": ent, "data": copy.deepcopy(layout)} for ent in unique_values]
-            
+
             await process_entities(hass, new_global_data)
 
         except Exception as e:
             _LOGGER.info(f"Error executing Jinja code: {e}")
-
-        # Refresh receiver liveness on its own slower cadence.
-        now_ts = time.time()
-        if now_ts - getattr(update_tracked_entities, "last_liveness", 0.0) >= RECEIVER_DUMP_INTERVAL:
-            update_tracked_entities.last_liveness = now_ts
-            await update_receiver_liveness(hass)
-
-        # Publish the self-localization accuracy sensor on a slow cadence (runs
-        # on the first tick too, so a fresh deploy shows a value quickly). The
-        # scipy solves run in the executor so the loop is never blocked.
-        if now_ts - getattr(update_tracked_entities, "last_selftest", 0.0) >= SELFTEST_SENSOR_INTERVAL:
-            update_tracked_entities.last_selftest = now_ts
-            try:
-                result = await hass.async_add_executor_job(run_selftest, hass)
-                state, attrs = _selftest_summary(result)
-                update_bps_sensor_state(hass, SELFTEST_SENSOR_ENTITY_ID, state, attrs)
-            except Exception as e:  # never let the diagnostic sensor stall tracking
-                _LOGGER.warning("BPS self-test sensor update failed: %s", e)
 
         await asyncio.sleep(secToUpdate)  # Run every X seconds, set timer in global variables
 
@@ -2161,7 +2168,6 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
 # links, and receiver-to-receiver paths (ceiling height, clean line of sight)
 # are easier than a body-worn beacon's. Consumed by tools/bps_eval.py `selftest`.
 SELFTEST_MIN_SAMPLES = 3  # need a median over at least this many raw distances
-SELFTEST_SENSOR_ENTITY_ID = "sensor.bps_position_accuracy"
 SELFTEST_SENSOR_INTERVAL = 1800  # refresh the accuracy sensor every 30 min
 
 
@@ -2221,17 +2227,24 @@ def _selftest_floor_bounds(coords, receivers):
     return out
 
 
-def run_selftest(hass):
+def run_selftest(hass, samples=None):
     """Leave-one-out receiver self-localization accuracy against known positions.
 
     Solves on the RAW inter-receiver distances BPS collects for calibration
     (median per link), not the Bermuda-filtered distance sensor the live tracker
     reads — so the numbers also exclude Bermuda's own smoothing.
+
+    ``samples`` may be a pre-snapshotted ``{"tx|rx": [floats]}`` taken on the
+    event loop; callers running this in the executor MUST pass one, since the
+    live calibration deques are appended to on the loop and iterating them off
+    thread would race ("deque mutated during iteration"). Defaults to the live
+    samples for direct/synchronous callers.
     """
     coords = get_bps_data(hass)
     receivers = _selftest_receivers(coords)
     floor_bounds = _selftest_floor_bounds(coords, receivers)
-    samples = get_calibration_state(hass).get("samples", {})
+    if samples is None:
+        samples = get_calibration_state(hass).get("samples", {})
 
     def _measured_m(target, rx):
         # The live tracker sees the beacon (target) transmit and a receiver hear
@@ -2326,8 +2339,9 @@ class BPSSelfTestAPI(HomeAssistantView):
         self.hass = hass
 
     async def get(self, request):
-        # One scipy solve per receiver; run off the event loop. run_selftest
-        # only reads in-memory dicts (layout cache + calibration samples), so
-        # it is safe in the executor.
-        data = await self.hass.async_add_executor_job(run_selftest, self.hass)
+        # One scipy solve per receiver; run off the event loop. Snapshot the
+        # calibration sample deques HERE (on the loop) before handing to the
+        # executor, so iterating them off-thread can't race calibration's ingest.
+        samples = {k: list(v) for k, v in get_calibration_state(self.hass).get("samples", {}).items()}
+        data = await self.hass.async_add_executor_job(run_selftest, self.hass, samples)
         return web.json_response(data)

--- a/custom_components/bps/const.py
+++ b/custom_components/bps/const.py
@@ -1,1 +1,5 @@
 DOMAIN = "bps"
+
+# Global diagnostic sensor: receiver self-localization accuracy (CEP95, m).
+# Shared by sensor.py (the entity) and __init__.py (the periodic publisher).
+ACCURACY_ENTITY_ID = "sensor.bps_position_accuracy"

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.3"
+    "version": "1.7.4"
 }

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -1,4 +1,4 @@
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import device_registry as dr
@@ -8,6 +8,10 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bps_sensors"
+
+# Global diagnostic sensor (not per-tracker): receiver self-localization
+# accuracy, published by the backend loop via update_bps_sensor_state.
+ACCURACY_ENTITY_ID = "sensor.bps_position_accuracy"
 
 # (entity_id suffix / unique_id prefix, display label) per tracked device.
 SENSOR_KINDS = [
@@ -146,6 +150,39 @@ class CustomDistanceSensor(SensorEntity):
         # Used by the sub-zone sensor to carry "parent_zone"; empty for the rest.
         return self._attrs
 
+class BPSAccuracySensor(SensorEntity):
+    """Receiver self-localization accuracy (CEP95 in metres), a global diagnostic.
+
+    Its value is pushed by the backend loop (update_bps_sensor_state sets
+    ``_state`` -> native_value); None reads as "unknown" until the first solve.
+    """
+
+    _attr_native_unit_of_measurement = "m"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:target"
+
+    def __init__(self):
+        self._attr_name = "BPS Position Accuracy"
+        self._attr_unique_id = "bps_position_accuracy"
+        self.entity_id = ACCURACY_ENTITY_ID
+        self._state = None
+        self._attrs = {}
+        self._attr_device_info = DeviceInfo(
+            identifiers={("bps", "bps_system")},
+            name="BPS System",
+            manufacturer="BPS",
+            model="BLE Positioning System",
+        )
+
+    @property
+    def native_value(self):
+        return self._state
+
+    @property
+    def extra_state_attributes(self):
+        return self._attrs
+
+
 def cleanup_legacy_bps_entities(hass):
     """Remove old duplicated-name BPS entities from entity registry."""
     entity_registry = er.async_get(hass)
@@ -259,12 +296,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entry.entity_id
             for entry in entity_registry.entities.values()
             if entry.platform == "bps" and entry.entity_id not in expected_entity_ids
+            and entry.entity_id != ACCURACY_ENTITY_ID  # keep the global diagnostic
         ]
         for entity_id in stale_bps_ids:
             _LOGGER.info("Removing stale BPS registry entity: %s", entity_id)
             entity_registry.async_remove(entity_id)
 
     new_sensors = []
+    # The global accuracy diagnostic (once), before the per-tracker sensors.
+    if ACCURACY_ENTITY_ID not in hass.data["bps_sensors"]:
+        accuracy = BPSAccuracySensor()
+        hass.data["bps_sensors"][ACCURACY_ENTITY_ID] = accuracy
+        new_sensors.append(accuracy)
     for entity in entities:
         ensure_sensors_for_entity(hass, entity, hass.data["bps_sensors"], new_sensors)
 

--- a/custom_components/bps/sensor.py
+++ b/custom_components/bps/sensor.py
@@ -5,13 +5,11 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 import logging
 
+from .const import ACCURACY_ENTITY_ID  # single source of truth (shared with __init__)
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bps_sensors"
-
-# Global diagnostic sensor (not per-tracker): receiver self-localization
-# accuracy, published by the backend loop via update_bps_sensor_state.
-ACCURACY_ENTITY_ID = "sensor.bps_position_accuracy"
 
 # (entity_id suffix / unique_id prefix, display label) per tracked device.
 SENSOR_KINDS = [

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -245,3 +245,33 @@ def test_selftest_bounds_include_left_out_perimeter_receiver():
     res = bps.run_selftest(_hass_with(recs, _exact_samples(recs)))
     err = {x["entity"]: x["error_m"] for x in res["receivers"]}
     assert err["r"] < 0.5   # not clamped to the a/b/c bounding box
+
+
+def test_selftest_summary_reports_cep_and_worst():
+    result = {
+        "counts": {"placed": 3, "solved": 2, "unsolved": 1},
+        "receivers": [
+            {"entity": "a", "floor": "F", "error_m": 1.0},
+            {"entity": "b", "floor": "F", "error_m": 3.0},
+        ],
+        "unsolved": [{"entity": "c"}],
+    }
+    state, attrs = bps._selftest_summary(result)
+    assert abs(state - attrs["cep95_m"]) < 1e-9        # state is CEP95
+    assert abs(attrs["cep50_m"] - 2.0) < 1e-9          # median of [1, 3]
+    assert abs(attrs["max_m"] - 3.0) < 1e-9 and abs(attrs["mean_m"] - 2.0) < 1e-9
+    assert attrs["solved"] == 2 and attrs["placed"] == 3
+    assert attrs["worst"].startswith("b")
+    assert "F" in attrs["per_floor_cep95_m"]
+
+
+def test_selftest_summary_unknown_when_none_solved():
+    state, attrs = bps._selftest_summary(
+        {"counts": {"placed": 4, "solved": 0, "unsolved": 4}, "receivers": [], "unsolved": []})
+    assert state is None and "cep95_m" not in attrs and attrs["solved"] == 0
+
+
+def test_selftest_summary_end_to_end_near_zero():
+    res = bps.run_selftest(_hass_with(SQUARE, _exact_samples(SQUARE)))
+    state, attrs = bps._selftest_summary(res)
+    assert state is not None and state < 0.5 and attrs["solved"] == 4

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -275,3 +275,11 @@ def test_selftest_summary_end_to_end_near_zero():
     res = bps.run_selftest(_hass_with(SQUARE, _exact_samples(SQUARE)))
     state, attrs = bps._selftest_summary(res)
     assert state is not None and state < 0.5 and attrs["solved"] == 4
+
+
+def test_selftest_accepts_explicit_samples_snapshot():
+    # The executor path passes a pre-snapshotted samples dict; run_selftest must
+    # use it instead of reading the (possibly concurrently-mutated) live deques.
+    hass = _hass_with(SQUARE, {})            # empty LIVE samples
+    res = bps.run_selftest(hass, samples=_exact_samples(SQUARE))
+    assert res["counts"]["solved"] == 4      # solved from the snapshot, not live state


### PR DESCRIPTION
Surfaces the receiver self-test (#111) **inside Home Assistant** so accuracy is visible with no CLI — you just watch a sensor.

## What you get
**`sensor.bps_position_accuracy`** — state = **CEP95 in metres** (lower is better), under a "BPS System" device. Attributes: `cep50_m`, `cep95_m`, `mean_m`, `max_m`, `solved`/`placed`/`unsolved`, per-floor CEP95, and the worst receiver. It's a `measurement` sensor, so HA graphs it and keeps long-term statistics.

The tuning loop becomes: **deploy a change → the value steps in history**, no command, no clicks — and you can alert/automate on it.

## How it works
- `sensor.py`: `BPSAccuracySensor` created once in `async_setup_entry` under a dedicated device, excluded from the stale-registry cleanup; value pushed via the existing `update_bps_sensor_state` (`None` → "unknown" until the first solve).
- `__init__.py`: `_selftest_summary(result)` → `(cep95, attrs)`; the tracking loop refreshes it every ~30 min (and on the first tick, so a fresh deploy shows a value fast), running `run_selftest` in the executor so the scipy solves never block the loop.
- Reads the same inter-receiver distances calibration already collects — no beacon, no new dependency.

## Review-driven fixes (this is the important part)
Adversarial review (3 lenses → per-finding verify) raised 8, confirmed 5 — the top two mattered:
- **The publish (and the pre-existing liveness refresh) were below the "too few trackers" `continue`**, so with 0–2 tracked beacons — a fresh deploy or nobody home — they never ran. Both are receiver-side, so they now run at the **top** of the loop, independent of tracker count. (Also fixes a latent liveness bug.)
- **`run_selftest` iterated the calibration deques in the executor while calibration appends on the loop** ("mutated during iteration"). Samples are now **snapshotted on the loop thread** before dispatch, at both call sites.
- Entity-id constant deduped into `const.py`.

## Verification
- **66 unit tests** (`python -m pytest tests/ -q`): `_selftest_summary` (cep/worst/per-floor, unknown-when-none, end-to-end via `run_selftest`, explicit-samples snapshot) + all prior positioning/selftest tests. `py_compile` clean on the changed backend files.
- ⚠️ **`sensor.py` isn't in the harness** (needs a live HA), so please smoke-test on real HA: after deploy, `sensor.bps_position_accuracy` appears and shows a metres value within ~30 min (or right after restart), with the attributes populated.

Version **1.7.4** (stacks on the still-unreleased 1.7.3 / #111). No config or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)