### PR TITLE
Fix the slant-singularity accuracy regression (v1.7.6)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -229,6 +229,23 @@ def _floor_scale(data, entity, floor_name):
     return None
 
 
+def _jump_weight(r, prev_r, min_wr):
+    """Soft down-weight for a radius that jumped since the previous update.
+
+    Compares NEAR-unclamped radii (a small epsilon only guards the 0 <-> 0
+    division): the old code clamped both sides to the full min-weight radius
+    first, which made the gate blind to everything below 0.5 m — a radius that
+    collapsed there (the slant singularity) re-entered EVERY cycle at w = 1.0,
+    sustaining the excursion. Sub-clamp changes now register as jumps.
+    """
+    if prev_r is None:
+        return 1.0  # first sighting on this floor: no basis to distrust it
+    eps = 0.1 * min_wr
+    r_eff, prev_eff = max(r, eps), max(prev_r, eps)
+    rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
+    return 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
+
+
 def _kalman_position_update(entity, floor_name, meas, scale, bounds):
     """Constant-velocity Kalman filter on the trilaterated pixel position.
 
@@ -823,7 +840,18 @@ async def update_receiver_radii(hass, eids):
                     height = receiver.get("height")
                     if isinstance(height, (int, float)) and 0 <= height <= 10:
                         dz = float(height) - tracker_h
-                        horizontal = math.sqrt(max(distance * distance - dz * dz, 0.0))
+                        # Floored at the physical minimum: sqrt(d^2 - dz^2) has
+                        # a singularity at d -> dz where its sensitivity blows
+                        # up, and any d <= dz collapsed to EXACTLY 0. Bermuda's
+                        # filtered distances are sustainedly biased low, so a
+                        # filtered slant could sit below dz for many cycles and
+                        # the collapsed radius (clamped to min weight radius at
+                        # ~100x the weight of a 5 m receiver) dragged the fix
+                        # onto that receiver — the 1.7.0 accuracy regression.
+                        horizontal = math.sqrt(max(
+                            distance * distance - dz * dz,
+                            MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M,
+                        ))
                     receiver["cords"]["r"] = floor["scale"] * horizontal
                     # Raw SLANT distance for the floor election: radii are in
                     # per-floor pixel scales and must not be compared across
@@ -880,7 +908,7 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
     # per-floor pixel scales and must not be compared across floors).
     new_last_r = {}
     for cand in candidates:
-        new_last_r.update({(cand["name"], x, y): r for (x, y, r) in cand["cords"]})
+        new_last_r.update({(cand["name"], x, y): r for (x, y, r, _srad) in cand["cords"]})
 
     incumbent = update_trilateration_and_zone.last_floor.get(entity)
 
@@ -911,21 +939,13 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
         # receiver whose radius jumped versus its previous update is
         # DOWN-WEIGHTED rather than dropped, so the solver keeps enough points
         # to fix a position even while every distance is legitimately changing
-        # during movement. Radii are clamped to the physical minimum for the
-        # comparison: slant correction turns noisy near-readings into exact
-        # 0.0, and an untamed 0 <-> nonzero transition is an infinite relative
-        # jump that used to escape the gate entirely (r > 0 guard) and enter
-        # the fit fully trusted at maximum geometric weight.
+        # during movement. The measured slant (px) rides along as each point's
+        # weight radius, so the solver's 1/r^2 weight reflects what was
+        # MEASURED — a projection collapsed to the minimum can't buy influence.
         weighted = []
-        for (x, y, r) in cords:
-            prev_r = last_r.get((floor_name, x, y))
-            if prev_r is not None:
-                r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
-                rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
-                w = 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
-            else:
-                w = 1.0  # first sighting on this floor: no basis to distrust it
-            weighted.append((x, y, r, w))
+        for (x, y, r, slant_px) in cords:
+            w = _jump_weight(r, last_r.get((floor_name, x, y)), min_wr)
+            weighted.append((x, y, r, w, slant_px))
 
         # The device cannot be outside the floor: bound the solver to the
         # extent of the floor's receivers and zones (with some margin) so the
@@ -1064,7 +1084,7 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
                 "floor": lowest_floor_name,
                 # The exact solver input (post-correction, post-filter), for
                 # the panel's trilateration circles.
-                "radii": [[float(px), float(py), float(pr)] for (px, py, pr, _w) in weighted],
+                "radii": [[float(pt[0]), float(pt[1]), float(pt[2])] for pt in weighted],
                 # Smoothed floor-election probabilities, for debugging "why
                 # did it pick this floor" (issue #94).
                 "floors": {f: round(p, 3) for f, p in probs.items()},
@@ -1178,8 +1198,12 @@ async def process_entities(hass, new_global_data):
 def extract_candidate_floors(new_global_data, tmpentity):
     """Every floor hearing the tracker, ranked by its nearest receiver.
 
-    Returns a list of {"name", "cords": [(x, y, r), ...], "placed", "nearest_m"}
-    sorted by nearest_m. The ranking compares raw slant distances (meters),
+    Returns a list of {"name", "cords": [(x, y, r, slant_px), ...], "placed",
+    "nearest_m"} sorted by nearest_m — slant_px is the measured (corrected)
+    slant distance in this floor's pixels, carried alongside the projected
+    radius r so the solver can weight by what was MEASURED rather than by the
+    projection (whose height-corrected value can legitimately collapse to the
+    minimum). The ranking compares raw slant distances (meters),
     not radii: radii are scaled into each floor's own pixel space, so
     comparing them across floors would let the floor with the smallest scale
     win regardless of where the tracker actually is. Ties (the same receiver
@@ -1198,7 +1222,10 @@ def extract_candidate_floors(new_global_data, tmpentity):
                 if distance is None or "r" not in receiver.get("cords", {}):
                     continue
                 nearest = min(nearest, distance)
-                cords.append((receiver["cords"]["x"], receiver["cords"]["y"], receiver["cords"]["r"]))
+                cords.append((
+                    receiver["cords"]["x"], receiver["cords"]["y"],
+                    receiver["cords"]["r"], distance * floor["scale"],
+                ))
             if cords:
                 candidates.append({
                     "name": floor["name"],
@@ -1223,7 +1250,8 @@ def _score_floor_fit(fix, weighted, scale):
     x, y = fix
     n = len(weighted)
     num = den = 0.0
-    for (xi, yi, ri, wi) in weighted:
+    for pt in weighted:  # (x, y, r, w[, slant_px]) — indexed so both shapes work
+        xi, yi, ri, wi = pt[0], pt[1], pt[2], pt[3]
         res = math.hypot(xi - x, yi - y) - ri
         num += wi * res * res
         den += wi
@@ -2133,8 +2161,14 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
         for pt in known_points:
             xi, yi, ri = pt[0], pt[1], pt[2]
             wi = pt[3] if len(pt) > 3 else 1.0
+            # Weight radius: the MEASURED slant when supplied (5th element),
+            # else the fit radius. Height correction can legitimately collapse
+            # the projected radius to the minimum while the measured slant is
+            # ~dz (metres) — weighting by the projection handed such a receiver
+            # ~100x influence and the fit snapped onto it (1.7.0 regression).
+            wri = pt[4] if len(pt) > 4 else ri
             residuals.append(np.sqrt((xi - x)**2 + (yi - y)**2) - ri)
-            weights.append(wi / max(ri, min_weight_radius)**2)  # reliability x geometric (1/r^2) weight
+            weights.append(wi / max(wri, min_weight_radius)**2)  # reliability x geometric (1/r^2) weight
         return np.sqrt(np.array(weights)) * np.array(residuals)
 
     # Start from the receiver centroid: it is always a plausible position,
@@ -2286,13 +2320,17 @@ def run_selftest(hass, samples=None):
             horizontal = d
             if tgt["height"] is not None and o["height"] is not None:
                 dz = o["height"] - tgt["height"]
-                horizontal = math.sqrt(max(d * d - dz * dz, 0.0))
-            pts.append((o["x"], o["y"], horizontal * tgt["scale"]))  # radius in pixels
+                # Same floored projection as the live path (singularity guard).
+                horizontal = math.sqrt(max(
+                    d * d - dz * dz, MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M))
+            # (x, y, projected radius, measured slant) in pixels — the slant is
+            # the weight radius, mirroring the live solve.
+            pts.append((o["x"], o["y"], horizontal * tgt["scale"], d * tgt["scale"]))
         if len(pts) < 3:
             unsolved.append({"entity": slug, "floor": tgt["floor"], "heard_by": len(pts)})
             continue
         fix = trilaterate(
-            [(px, py, pr, 1.0) for (px, py, pr) in pts],
+            [(px, py, pr, 1.0, psl) for (px, py, pr, psl) in pts],
             bounds=floor_bounds.get(tgt["floor"]),
             min_weight_radius=MIN_WEIGHT_RADIUS_M * tgt["scale"],
         )

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -232,16 +232,17 @@ def _floor_scale(data, entity, floor_name):
 def _jump_weight(r, prev_r, min_wr):
     """Soft down-weight for a radius that jumped since the previous update.
 
-    Compares NEAR-unclamped radii (a small epsilon only guards the 0 <-> 0
-    division): the old code clamped both sides to the full min-weight radius
-    first, which made the gate blind to everything below 0.5 m — a radius that
-    collapsed there (the slant singularity) re-entered EVERY cycle at w = 1.0,
-    sustaining the excursion. Sub-clamp changes now register as jumps.
+    Radii are clamped to the physical minimum for the comparison: a tracker
+    genuinely next to a receiver bounces between sub-clamp readings from pure
+    RSSI noise (0.1 <-> 0.3 m is noise, not motion), and an unclamped relative
+    gate would penalize that — its most informative receiver — every tick.
+    The slant-collapse pathology needs no gate help: the projection floor
+    keeps a collapsed radius constant at the clamp (rel = 1 either way) and
+    the measured-slant weight radius bounds its influence in the solve.
     """
     if prev_r is None:
         return 1.0  # first sighting on this floor: no basis to distrust it
-    eps = 0.1 * min_wr
-    r_eff, prev_eff = max(r, eps), max(prev_r, eps)
+    r_eff, prev_eff = max(r, min_wr), max(prev_r, min_wr)
     rel = max(r_eff / prev_eff, prev_eff / r_eff)  # symmetric relative change, >= 1
     return 1.0 / (1.0 + ((rel - 1.0) / RADIUS_JUMP_TOL) ** 2)
 
@@ -840,18 +841,21 @@ async def update_receiver_radii(hass, eids):
                     height = receiver.get("height")
                     if isinstance(height, (int, float)) and 0 <= height <= 10:
                         dz = float(height) - tracker_h
-                        # Floored at the physical minimum: sqrt(d^2 - dz^2) has
-                        # a singularity at d -> dz where its sensitivity blows
-                        # up, and any d <= dz collapsed to EXACTLY 0. Bermuda's
-                        # filtered distances are sustainedly biased low, so a
-                        # filtered slant could sit below dz for many cycles and
-                        # the collapsed radius (clamped to min weight radius at
+                        # Floored: sqrt(d^2 - dz^2) has a singularity at
+                        # d -> dz where its sensitivity blows up, and any
+                        # d <= dz collapsed to EXACTLY 0. Bermuda's filtered
+                        # distances are sustainedly biased low, so a filtered
+                        # slant could sit below dz for many cycles and the
+                        # collapsed radius (clamped to min weight radius at
                         # ~100x the weight of a 5 m receiver) dragged the fix
                         # onto that receiver — the 1.7.0 accuracy regression.
-                        horizontal = math.sqrt(max(
-                            distance * distance - dz * dz,
-                            MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M,
-                        ))
+                        # The floor never exceeds the raw slant itself, so a
+                        # receiver at ~tracker height (dz ~ 0, no singularity)
+                        # keeps honest sub-floor readings like the no-height
+                        # path does.
+                        floor_sq = min(distance * distance,
+                                       MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M)
+                        horizontal = math.sqrt(max(distance * distance - dz * dz, floor_sq))
                     receiver["cords"]["r"] = floor["scale"] * horizontal
                     # Raw SLANT distance for the floor election: radii are in
                     # per-floor pixel scales and must not be compared across
@@ -1198,7 +1202,7 @@ async def process_entities(hass, new_global_data):
 def extract_candidate_floors(new_global_data, tmpentity):
     """Every floor hearing the tracker, ranked by its nearest receiver.
 
-    Returns a list of {"name", "cords": [(x, y, r, slant_px), ...], "placed",
+    Returns a list of {"name", "cords": [(x, y, r, slant_px), ...],
     "nearest_m"} sorted by nearest_m — slant_px is the measured (corrected)
     slant distance in this floor's pixels, carried alongside the projected
     radius r so the solver can weight by what was MEASURED rather than by the
@@ -2132,10 +2136,15 @@ class BPSCordsAPI(HomeAssistantView):
 def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     """Weighted least-squares position fit.
 
-    known_points are (x, y, r) or (x, y, r, w) tuples. The optional w is a
-    per-point reliability in [0, 1] (1 = fully trusted); it multiplies the
-    geometric 1/r^2 weight, so a spiky reading pulls the fit less without being
-    dropped. Missing w defaults to 1.
+    known_points are (x, y, r[, w[, wr]]) tuples. The optional w is a per-point
+    reliability in [0, 1] (1 = fully trusted); it multiplies the geometric
+    1/r^2 weight, so a spiky reading pulls the fit less without being dropped.
+    Missing w defaults to 1. The optional wr overrides r as the RADIUS USED IN
+    THE GEOMETRIC WEIGHT (the residual always uses r): live callers pass the
+    measured slant (px) here, so a height-corrected projection that collapsed
+    to the floor cannot buy itself dominant 1/r^2 influence — following the
+    4-tuple form with collapsed projected radii reintroduces exactly the 1.7.0
+    hijack. min_weight_radius clamps whichever weight radius is in use.
 
     bounds, when given as (minx, miny, maxx, maxy), constrains the solution to
     the floor's extent: the fit then finds the best position WITHIN the map,
@@ -2320,9 +2329,10 @@ def run_selftest(hass, samples=None):
             horizontal = d
             if tgt["height"] is not None and o["height"] is not None:
                 dz = o["height"] - tgt["height"]
-                # Same floored projection as the live path (singularity guard).
-                horizontal = math.sqrt(max(
-                    d * d - dz * dz, MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M))
+                # Same floored projection as the live path (singularity guard;
+                # the floor never exceeds the raw slant).
+                floor_sq = min(d * d, MIN_WEIGHT_RADIUS_M * MIN_WEIGHT_RADIUS_M)
+                horizontal = math.sqrt(max(d * d - dz * dz, floor_sq))
             # (x, y, projected radius, measured slant) in pixels — the slant is
             # the weight radius, mirroring the live solve.
             pts.append((o["x"], o["y"], horizontal * tgt["scale"], d * tgt["scale"]))

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.5"
+    "version": "1.7.6"
 }

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -91,9 +91,11 @@ def test_height_removes_vertical_leg_from_radius_only():
     assert abs(r["distance"] - 2.3) < 1e-9
 
 
-def test_height_underneath_clamps_radius_to_zero():
-    r = _run_radii("1.0", height=2.2)  # slant < vertical leg
-    assert r["cords"]["r"] == 0.0
+def test_height_underneath_floors_radius_at_min_weight_radius():
+    # slant < vertical leg used to collapse to EXACTLY 0 px — the singularity
+    # behind the 1.7.0 regression. Now floored at MIN_WEIGHT_RADIUS_M (0.5 m).
+    r = _run_radii("1.0", height=2.2)
+    assert abs(r["cords"]["r"] - bps.MIN_WEIGHT_RADIUS_M * SCALE) < 1e-9
 
 
 def test_nan_and_out_of_range_height_ignored():
@@ -314,3 +316,52 @@ def test_robust_loss_beats_linear_on_an_outlier():
     d_linear = math.dist(_linear_fit(pts), truth)
     assert d_soft < d_linear              # robust loss helps...
     assert d_soft < 0.75 * d_linear       # ...by a clear margin (here ~0.62x)
+
+
+# --------------------------------------------------------------------------- #
+# Slant-singularity regression (the 1.7.0 accuracy collapse)
+# --------------------------------------------------------------------------- #
+def test_collapsed_radius_cannot_hijack_the_fix():
+    # THE 1.7.0 regression scenario: a height-corrected receiver whose filtered
+    # slant latched below dz collapses its projected radius to the 0.5 m floor
+    # while the tracker is really ~5.7 m away. In a realistic mesh (8 honest
+    # receivers at 1.5-5 m), weighting by the PROJECTION (old, 4-tuple
+    # behaviour) hands the collapsed receiver dominant 1/r^2 weight and drags
+    # the fix ~3 m toward it — the observed live swings. Weighting by the
+    # measured SLANT (5th element) keeps the fix on the honest majority.
+    truth = (200.0, 200.0)
+    recs = [(140, 200), (260, 200), (200, 120), (200, 300),
+            (80, 80), (340, 100), (100, 340), (360, 300)]
+    honest = [(x, y, math.dist((x, y), truth)) for (x, y) in recs]
+    liar_at = (360.0, 360.0)
+    r_floor = bps.MIN_WEIGHT_RADIUS_M * SCALE   # collapsed projection (20 px)
+    slant_px = 1.5 * SCALE                      # measured slant ~ dz = 1.5 m
+    min_wr = bps.MIN_WEIGHT_RADIUS_M * SCALE
+
+    old = [(x, y, r, 1.0) for (x, y, r) in honest]
+    old.append((liar_at[0], liar_at[1], r_floor, 1.0))            # weight from projection
+    new = [(x, y, r, 1.0, r) for (x, y, r) in honest]             # honest: slant == radius
+    new.append((liar_at[0], liar_at[1], r_floor, 1.0, slant_px))  # weight from slant
+
+    d_old = math.dist(bps.trilaterate(old, min_weight_radius=min_wr), truth)
+    d_new = math.dist(bps.trilaterate(new, min_weight_radius=min_wr), truth)
+    assert d_old > 2.0 * SCALE      # the old weighting really was hijacked (~3 m)
+    assert d_new < 1.0 * SCALE      # the fix now stays within 1 m of truth
+
+
+def test_jump_weight_registers_sub_clamp_changes():
+    min_wr = 20.0  # 0.5 m at 40 px/m
+    # First sighting: fully trusted.
+    assert bps._jump_weight(10.0, None, min_wr) == 1.0
+    # Steady radius: fully trusted (whether above or below the clamp).
+    assert bps._jump_weight(100.0, 100.0, min_wr) == 1.0
+    assert bps._jump_weight(2.0, 2.0, min_wr) == 1.0
+    # A change entirely BELOW the old clamp used to compare as "unchanged"
+    # (both sides clamped to min_wr -> rel=1 -> w=1). It must now register.
+    assert bps._jump_weight(2.0, 18.0, min_wr) < 0.1
+    # 0 <-> nonzero stays finite (epsilon guard) and heavily down-weighted.
+    w0 = bps._jump_weight(0.0, 18.0, min_wr)
+    assert 0.0 < w0 < 0.1
+    # Normal above-clamp jumps behave as before.
+    assert bps._jump_weight(100.0, 150.0, min_wr) < 1.0
+    assert bps._jump_weight(100.0, 102.0, min_wr) > 0.9

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -349,19 +349,29 @@ def test_collapsed_radius_cannot_hijack_the_fix():
     assert d_new < 1.0 * SCALE      # the fix now stays within 1 m of truth
 
 
-def test_jump_weight_registers_sub_clamp_changes():
+def test_jump_weight_ignores_sub_clamp_noise():
     min_wr = 20.0  # 0.5 m at 40 px/m
     # First sighting: fully trusted.
     assert bps._jump_weight(10.0, None, min_wr) == 1.0
-    # Steady radius: fully trusted (whether above or below the clamp).
+    # Steady radius: fully trusted (above or below the clamp).
     assert bps._jump_weight(100.0, 100.0, min_wr) == 1.0
     assert bps._jump_weight(2.0, 2.0, min_wr) == 1.0
-    # A change entirely BELOW the old clamp used to compare as "unchanged"
-    # (both sides clamped to min_wr -> rel=1 -> w=1). It must now register.
-    assert bps._jump_weight(2.0, 18.0, min_wr) < 0.1
-    # 0 <-> nonzero stays finite (epsilon guard) and heavily down-weighted.
-    w0 = bps._jump_weight(0.0, 18.0, min_wr)
-    assert 0.0 < w0 < 0.1
-    # Normal above-clamp jumps behave as before.
+    # Sub-clamp bouncing is RSSI noise, not motion: a tracker genuinely next
+    # to a receiver (readings jittering 0.05 <-> 0.45 m) must keep its most
+    # informative receiver at full weight — the clamp exists to protect this.
+    # (The slant-collapse case needs no gate: the projection floor keeps a
+    # collapsed radius constant, and the slant weight radius bounds its pull.)
+    assert bps._jump_weight(2.0, 18.0, min_wr) == 1.0
+    assert bps._jump_weight(0.0, 18.0, min_wr) == 1.0
+    # Genuine above-clamp jumps register as before.
     assert bps._jump_weight(100.0, 150.0, min_wr) < 1.0
     assert bps._jump_weight(100.0, 102.0, min_wr) > 0.9
+    # A sub-clamp <-> far transition still reads as a big jump.
+    assert bps._jump_weight(10.0, 200.0, min_wr) < 0.05
+
+
+def test_projection_floor_never_exceeds_raw_slant():
+    # A receiver at ~tracker height (dz ~ 0) has no singularity: an honest
+    # 0.2 m reading must stay 0.2 m, not get inflated to the 0.5 m floor.
+    r = _run_radii("0.2", height=1.0)  # tracker_height default 1.0 -> dz = 0
+    assert abs(r["cords"]["r"] - 0.2 * SCALE) < 1e-9


### PR DESCRIPTION
Fixes the severe live-tracking degradation since mount heights were set. Root-caused by a 50-commit regression audit (7 analyst lenses → per-mechanism adversarial verification): the culprit is the v1.7.0 slant projection, triggered specifically by Bermuda's *filtered* distance dynamics.

## Root cause
`r = √(d² − dz²)` has a **singularity at `d → dz`**: sensitivity blows up, and any reading `d ≤ dz` collapses to **exactly 0 px**. Bermuda's filtered distances are sustainedly biased low (decreases trusted instantly, increases ramped slowly), so a filtered slant can **latch below `dz` for many cycles**. The collapsed radius — clamped to 0.5 m in the solver's `1/r²` weighting — carried **~100× the weight** of a 5 m receiver, and plain least-squares dragged the fix onto that receiver. That's the observed snapping/swinging.

This also explains every apparent contradiction: the **unfiltered** entity skews long/transient (never latches → tight through the same pipeline); the **self-test** never crosses `dz` at ceiling height (healthy 1.3 m); **both** the phone and the ankle beacon are hit (the phone's real height ≈ the 1.0 m default, so its true slant sits *on* the singularity directly under a receiver).

## Fix (two guards; the reviewed-out third documented below)
1. **Weight by the measured slant, not the projection.** Candidate tuples carry `slant_px`; `trilaterate` accepts an optional 5th element as the `1/r²` weight radius (residual still uses the projected `r`; 3-/4-tuple callers unchanged). A collapsed projection can no longer buy influence. `run_selftest` mirrors it, so the accuracy sensor keeps measuring the live math.
2. **Projection floored** so `r = 0` is unreachable — bounded by the raw slant itself, so a receiver at ~tracker height (`dz ≈ 0`, no singularity) keeps honest sub-floor readings.

**Reverted during review:** an un-blinding of the radius-jump gate below the clamp. The review proved it *inert* against the singularity (the floor keeps a collapsed radius constant → passes any relative gate) and *harmful* for a tracker genuinely next to a receiver (sub-clamp RSSI noise would down-weight its best receiver to ~6% every tick). The gate keeps its original clamped comparison, now extracted as a tested helper.

## Verification
- **Regression test encodes the live scenario**: 8 honest receivers at 1.5–5 m + one collapsed-radius liar → the old weighting hijacks the fix **~3 m** (matches the observed swings); the new weighting stays **< 1 m** (measured 0.33 m).
- **70 unit tests pass**; existing solver/slant/selftest tests unchanged in meaning (the underneath-clamp test now asserts the 0.5 m floor).
- Adversarial review: 6 findings confirmed, 0 refuted — all applied (gate revert, dz≈0 floor bound, contract docstrings).

## After deploying
- The filtered trackers should stop snapping toward receivers; accuracy should return to (or beat) pre-1.7.0 behavior **with mount heights kept**.
- `sensor.bps_position_accuracy` may shift slightly (the selftest now weights by slant) — that's the bench following the live math, not a regression.
- The separate `tracker_height` gap (global 1.0 m vs a 0.1 m ankle beacon) still stands as a follow-up: per-tracker height.

Version **1.7.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)