### PR TITLE
Per-tracker height, settable from the panel's Tracking section (v1.7.7)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -222,10 +222,14 @@ def _tracker_height(data, entity=None):
         per_tracker = data.get("tracker_heights")
         if entity is not None and isinstance(per_tracker, dict):
             configured = per_tracker.get(entity)
-            if isinstance(configured, (int, float)) and 0 <= configured <= 5:
+            # not-bool: isinstance(True, int) holds in Python, so a hand-edited
+            # true/false would otherwise read as a valid 1.0/0.0 m height.
+            if isinstance(configured, (int, float)) and not isinstance(configured, bool) \
+                    and 0 <= configured <= 5:
                 return float(configured)
         configured = data.get("tracker_height")
-        if isinstance(configured, (int, float)) and 0 <= configured <= 5:
+        if isinstance(configured, (int, float)) and not isinstance(configured, bool) \
+                and 0 <= configured <= 5:
             return float(configured)
     return TRACKER_HEIGHT_M
 

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -210,9 +210,20 @@ _floor_dark_cycles = {}
 _kf_position_state = {}
 
 
-def _tracker_height(data):
-    """Assumed tracker height above the floor (m); "tracker_height" override."""
+def _tracker_height(data, entity=None):
+    """Assumed tracker height above the floor (m) for slant correction.
+
+    Precedence: the device's own entry in "tracker_heights" (set per tracker
+    in the panel — an ankle beacon at 0.1 m and a phone at 1.0 m need
+    different vertical legs), then the top-level "tracker_height" override,
+    then the 1.0 m default. Out-of-range/garbage values fall through.
+    """
     if isinstance(data, dict):
+        per_tracker = data.get("tracker_heights")
+        if entity is not None and isinstance(per_tracker, dict):
+            configured = per_tracker.get(entity)
+            if isinstance(configured, (int, float)) and 0 <= configured <= 5:
+                return float(configured)
         configured = data.get("tracker_height")
         if isinstance(configured, (int, float)) and 0 <= configured <= 5:
             return float(configured)
@@ -804,7 +815,7 @@ async def update_receiver_liveness(hass):
 
 async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
-    tracker_h = _tracker_height(eids["data"])
+    tracker_h = _tracker_height(eids["data"], eids["entity"])
     for floor in (f for f in eids["data"]["floor"] if f["scale"] is not None):
         for receiver in floor["receivers"]:
             entity_id = "sensor." + eids["entity"] + "_distance_to_" + receiver["entity_id"]

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -85,6 +85,16 @@
                                     <button type="button" id="uploadTrackerIcon" class="bps-btn bps-btn-outline">Upload</button>
                                 </div>
                             </div>
+                            <!-- Per-tracker carry height for the mount-height slant
+                                 correction: an ankle beacon (~0.1 m) and a phone
+                                 (~1.0 m) need different vertical legs. Targets the
+                                 active (highlighted) device; blank = the 1.0 m
+                                 default. Persisted with Save Floor Plan. -->
+                            <div class="bps-field">
+                                <label class="bps-label">Tracker height (m)</label>
+                                <input type="number" id="trackerHeightInput" class="bps-input"
+                                       min="0" max="5" step="0.1" placeholder="1.0 (default)">
+                            </div>
                             <!-- Colour-coded list of the devices being tracked. Each row's
                                  swatch matches that device's on-map icon, circles and path;
                                  click a row to make the tracker-icon controls target it, × to

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1646,8 +1646,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ensureIconOption(icon);
                 trackerIconSelector.value = icon;
             }
-            if (trackerHeightInput && activeDevice) {
-                const h = trackerHeightFor(activeDevice);
+            if (trackerHeightInput) {
+                // Clear when no device is active (e.g. the last tracked device
+                // was removed) so the field never shows a stale height.
+                const h = activeDevice ? trackerHeightFor(activeDevice) : null;
                 trackerHeightInput.value = h === null ? "" : String(h);
             }
         }
@@ -1754,6 +1756,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (!activeDevice) {
                     bpsToast("Add a device to track first.");
                     trackerHeightInput.value = "";
+                    return;
+                }
+                // Unparseable text in a number input ("1e", "2,5", a lone "-")
+                // reads back as value === "" with validity.badInput set — it
+                // must fail validation, NOT be mistaken for an intentional
+                // clear that silently deletes the saved height (same guard as
+                // the receiver-height field).
+                if (trackerHeightInput.validity && trackerHeightInput.validity.badInput) {
+                    bpsToast("Tracker height must be between 0 and 5 m.");
+                    const prev = trackerHeightFor(activeDevice);
+                    trackerHeightInput.value = prev === null ? "" : String(prev);
                     return;
                 }
                 const raw = trackerHeightInput.value.trim();

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -74,6 +74,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const mapSelector = document.getElementById('mapSelector');
     const entSelector = document.getElementById('entSelector');
     const trackerIconSelector = document.getElementById('trackerIconSelector');
+    const trackerHeightInput = document.getElementById('trackerHeightInput');
     const trackerIconUpload = document.getElementById('trackerIconUpload');
     const uploadTrackerIconButton = document.getElementById('uploadTrackerIcon');
     const mapbuttondiv = document.getElementById('mapbuttondiv');
@@ -417,6 +418,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!finalcords.tracker_icons || typeof finalcords.tracker_icons !== "object") {
             finalcords.tracker_icons = {};
         }
+    }
+
+    function ensureTrackerHeightsStore() {
+        if (!finalcords.tracker_heights || typeof finalcords.tracker_heights !== "object") {
+            finalcords.tracker_heights = {};
+        }
+    }
+
+    // The device's saved carry height (m), or null when unset (backend then
+    // uses the global "tracker_height" override or its 1.0 m default).
+    function trackerHeightFor(entKey) {
+        const store = finalcords.tracker_heights;
+        if (!store || typeof store !== "object") return null;
+        const v = store[entKey];
+        return (typeof v === "number" && v >= 0 && v <= 5) ? v : null;
     }
 
     // The icon URL a given tracked device should draw with (its saved choice,
@@ -1630,6 +1646,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ensureIconOption(icon);
                 trackerIconSelector.value = icon;
             }
+            if (trackerHeightInput && activeDevice) {
+                const h = trackerHeightFor(activeDevice);
+                trackerHeightInput.value = h === null ? "" : String(h);
+            }
         }
 
         // Start/stop button visibility follows whether anything is tracked (but
@@ -1726,6 +1746,33 @@ document.addEventListener('DOMContentLoaded', async () => {
                 finalcords.tracker_icons[activeDevice] = trackerIconSelector.value;
                 savebuttondiv.appendChild(saveButton);
                 if (pollTrackActive && img.naturalWidth > 0) redrawAll();
+            });
+        }
+
+        if (trackerHeightInput) {
+            trackerHeightInput.addEventListener("change", () => {
+                if (!activeDevice) {
+                    bpsToast("Add a device to track first.");
+                    trackerHeightInput.value = "";
+                    return;
+                }
+                const raw = trackerHeightInput.value.trim();
+                ensureTrackerHeightsStore();
+                if (raw === "") {
+                    // Cleared = unset: fall back to the global/default height.
+                    delete finalcords.tracker_heights[activeDevice];
+                } else {
+                    const v = parseFloat(raw);
+                    if (!Number.isFinite(v) || v < 0 || v > 5) {
+                        bpsToast("Tracker height must be between 0 and 5 m.");
+                        const prev = trackerHeightFor(activeDevice);
+                        trackerHeightInput.value = prev === null ? "" : String(prev);
+                        return;
+                    }
+                    finalcords.tracker_heights[activeDevice] = v;
+                }
+                savebuttondiv.appendChild(saveButton);
+                bpsToast("Tracker height staged. Click Save Floor Plan to persist.");
             });
         }
 

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.6"
+    "version": "1.7.7"
 }

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -375,3 +375,44 @@ def test_projection_floor_never_exceeds_raw_slant():
     # 0.2 m reading must stay 0.2 m, not get inflated to the 0.5 m floor.
     r = _run_radii("0.2", height=1.0)  # tracker_height default 1.0 -> dz = 0
     assert abs(r["cords"]["r"] - 0.2 * SCALE) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Per-tracker height
+# --------------------------------------------------------------------------- #
+def test_tracker_height_per_tracker_precedence():
+    data = {"tracker_height": 0.7, "tracker_heights": {"ankle": 0.1, "bogus": 99}}
+    # Per-tracker entry wins over the global override.
+    assert bps._tracker_height(data, "ankle") == 0.1
+    # Unknown / no entity falls back to the global override.
+    assert bps._tracker_height(data, "phone") == 0.7
+    assert bps._tracker_height(data) == 0.7
+    # Out-of-range per-tracker value falls through to the global.
+    assert bps._tracker_height(data, "bogus") == 0.7
+    # Nothing configured at all: the 1.0 m default.
+    assert bps._tracker_height({}, "ankle") == bps.TRACKER_HEIGHT_M
+    assert bps._tracker_height({"tracker_heights": "junk"}, "ankle") == bps.TRACKER_HEIGHT_M
+
+
+def test_per_tracker_height_feeds_slant_correction():
+    # Same reading, receiver at 2.2 m: an ankle beacon (0.1 m) has a larger
+    # vertical leg than the default 1.0 m, so its horizontal radius is shorter.
+    class St:
+        state = "2.3"
+        attributes = {"unit_of_measurement": "m"}
+
+    class Hass:
+        states = type("S", (), {"get": staticmethod(lambda _eid: St())})()
+
+    def radius(data):
+        rec = {"entity_id": "probe", "cords": {"x": 0, "y": 0}, "height": 2.2}
+        d = dict(data)
+        d["floor"] = [{"name": "F", "scale": SCALE, "receivers": [rec]}]
+        run(bps.update_receiver_radii(Hass(), {"entity": "ankle", "data": d}))
+        return rec["cords"]["r"]
+
+    r_default = radius({})                                   # dz = 1.2
+    r_ankle = radius({"tracker_heights": {"ankle": 0.1}})    # dz = 2.1
+    assert abs(r_default - math.sqrt(2.3**2 - 1.2**2) * SCALE) < 0.1
+    assert abs(r_ankle - math.sqrt(2.3**2 - 2.1**2) * SCALE) < 0.1
+    assert r_ankle < r_default

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -392,6 +392,11 @@ def test_tracker_height_per_tracker_precedence():
     # Nothing configured at all: the 1.0 m default.
     assert bps._tracker_height({}, "ankle") == bps.TRACKER_HEIGHT_M
     assert bps._tracker_height({"tracker_heights": "junk"}, "ankle") == bps.TRACKER_HEIGHT_M
+    # Bools are ints in Python: a hand-edited true/false must fall through,
+    # not read as a valid 1.0/0.0 m height (frontend rejects them too).
+    assert bps._tracker_height({"tracker_height": 0.7,
+                                "tracker_heights": {"x": False}}, "x") == 0.7
+    assert bps._tracker_height({"tracker_height": True}) == bps.TRACKER_HEIGHT_M
 
 
 def test_per_tracker_height_feeds_slant_correction():


### PR DESCRIPTION
Adds a **"Tracker height (m)" field to the panel's Tracking section** so each tracked device gets the right vertical leg in the mount-height slant correction — the design gap exposed by the 1.7.0 regression hunt. Until now the only knob was the global `tracker_height` (default 1.0 m), editable only by hand in `.storage`, and one value can't serve both an ankle beacon (~0.1 m) and a phone (~1.0 m).

## How it works
- **Panel**: the field sits under the tracker-icon controls and targets the **active (highlighted) device**, same as the icon picker. It shows the device's saved height; **blank = unset** (falls back to the global/default). Validates 0–5 m, reverts bad input, and stages into the layout for the normal **Save Floor Plan** flow — the exact `tracker_icons` persistence pattern, so it survives saves, restarts, and the storage migration.
- **Backend**: `_tracker_height(data, entity)` resolves **per-tracker → global `tracker_height` → 1.0 m default** (out-of-range/garbage values fall through); `update_receiver_radii` passes its entity, so `dz` is now correct per device.

Typical use: select the ankle beacon in the tracking legend → set `0.1` → Save. The phone can stay blank (1.0 m default fits a carried phone).

## Verification
- **72 unit tests** pass — new: precedence rules (per-tracker beats global, bad values fall through incl. the Python `bool`-is-`int` trap) and the slant effect (an ankle at 0.1 m under a 2.2 m receiver correctly shortens the projected radius vs the default).
- **Browser harness, 10/10** (real panel + fetch shim): populate on device select, per-device isolation, store round-trip, out-of-range revert, genuine-clear unsets, **badInput restores instead of deleting**, Save staging.
- Adversarial review (data-flow / backend / frontend lenses → per-finding verify): 5 confirmed, all fixed —
  - **HIGH**: unparseable number-input text (`1e`, lone `-`, locale `2,5`) reads as `""` + `validity.badInput`, and was treated as an intentional clear → **silently deleted the saved height with a success toast**. Now guarded like the existing receiver-height field (toast + restore).
  - LOW: `isinstance(True, int)` let a hand-edited `true`/`false` read as 1.0/0.0 m — both backend guards now exclude bools, matching the frontend.
  - LOW: the field showed a stale height after the last tracked device was removed — now cleared.
  - (Data-flow lens confirmed the key survives every save path — panel save, Adjust Zones, calibration writers — since all serialize the full layout object.)

⚠️ Real-HA smoke: set a height on one device, Save, restart HA — the value should persist in the panel and the device's map behaviour should reflect the new dz (for an ankle beacon under a ceiling receiver: radii shorten when it's genuinely near).

Version **1.7.7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)