### PR TITLE
Per-tracker ref-power trim + drop stale distance readings (v1.8.1, closes #92)

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -77,6 +77,16 @@ apitricords = []
 # "position_timeout" (seconds) in bpsdata.txt.
 STALE_POSITION_SECS = 300
 
+# --- Stale distance readings (per receiver, per tracker) ----------------------
+# A distance_to sensor keeps its last value when its scanner stops hearing the
+# tracker: the reading goes STUCK rather than unavailable (most visible on
+# Bermuda's unfiltered distance entities, which have no timeout of their own).
+# Fed to the solver, a stuck radius anchors the fix to a receiver that can no
+# longer see the device. Readings older than this are dropped from the solve;
+# override with a top-level "reading_max_age" (seconds) in the layout, or set it
+# to 0 to disable the gate entirely.
+READING_MAX_AGE_SECS = 30
+
 # --- Output-position smoothing (constant-velocity Kalman filter) -------------
 # The published position is smoothed with a constant-velocity 2D Kalman filter
 # (state [x, y, vx, vy]) instead of a fixed-length moving average. Unlike the
@@ -249,6 +259,35 @@ def _tracker_height(data, entity=None):
                 and 0 <= configured <= 5:
             return float(configured)
     return TRACKER_HEIGHT_M
+
+
+def _reading_max_age(data):
+    """Seconds after which a distance reading is ignored (0 = never)."""
+    if isinstance(data, dict):
+        configured = data.get("reading_max_age")
+        if isinstance(configured, (int, float)) and not isinstance(configured, bool) \
+                and configured >= 0:
+            return float(configured)
+    return READING_MAX_AGE_SECS
+
+
+def _reading_age_secs(state):
+    """Age of a state in seconds, or None when it can't be determined.
+
+    Uses ``last_updated`` (falling back to ``last_changed``) rather than
+    ``last_reported``: Home Assistant only bumps ``last_updated`` when the
+    value actually changes, so a sensor that keeps re-reporting the SAME stale
+    distance still ages out — which is exactly the stuck-reading case. Returns
+    None (i.e. "don't gate") if the timestamps are missing or unusable, so an
+    unexpected state object can never blank out the whole map.
+    """
+    ts = getattr(state, "last_updated", None) or getattr(state, "last_changed", None)
+    if ts is None:
+        return None
+    try:
+        return max(0.0, time.time() - ts.timestamp())
+    except (AttributeError, OSError, OverflowError, TypeError, ValueError):
+        return None
 
 
 def _tracker_ref_offset(data, entity):
@@ -868,11 +907,26 @@ async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
     tracker_h = _tracker_height(eids["data"], eids["entity"])
     tracker_factor = _tracker_distance_factor(eids["data"], eids["entity"])
+    max_age = _reading_max_age(eids["data"])
     for floor in (f for f in eids["data"]["floor"] if f["scale"] is not None):
         for receiver in floor["receivers"]:
             entity_id = "sensor." + eids["entity"] + "_distance_to_" + receiver["entity_id"]
             rec_value = hass.states.get(entity_id)
             if rec_value is not None:
+                # Drop a STUCK reading: when a scanner stops hearing the
+                # tracker its distance sensor keeps the last value instead of
+                # going unavailable, and that frozen radius would anchor the
+                # fix to a receiver that can no longer see the device. Removing
+                # "distance" takes this receiver out of the cycle's candidate
+                # solve (see extract_candidate_floors).
+                age = _reading_age_secs(rec_value)
+                if max_age and age is not None and age > max_age:
+                    receiver.pop("distance", None)
+                    _LOGGER.debug(
+                        "Ignoring stale distance for %s (%.0fs old, max %.0fs)",
+                        entity_id, age, max_age,
+                    )
+                    continue
                 try:
                     distance = float(rec_value.state)
                     # Bermuda's distance_to sensors can report in feet or

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -44,6 +44,7 @@ from .calibration import (
 from .storage import (
     BPS_FILE_LOCK,
     get_bps_data,
+    get_bps_data_for_edit,
     load_bps_data,
     migrate_legacy,
     save_bps_data,
@@ -157,6 +158,22 @@ def _safe_maps_child(maps_path, raw_name, allowed_exts=None):
 # TRACKER_HEIGHT_M above the floor; override with a top-level
 # "tracker_height" (metres) in bpsdata.txt.
 TRACKER_HEIGHT_M = 1.0
+
+# --- Per-tracker reference-power trim (issue #92) -----------------------------
+# Bermuda turns RSSI into distance with an exponential path-loss model,
+# d = 10 ** ((ref_power - rssi) / (10 * attenuation)). Cheap beacons vary in
+# transmit power, so one Bermuda ref_power can read consistently long or short
+# for a given tag. BPS can't change Bermuda's config, but an offset of `delta`
+# dB on ref_power is exactly a MULTIPLICATIVE scale on every distance from that
+# tracker: 10 ** (delta / (10 * attenuation)). So a per-tracker offset (stored
+# in metres-free dB under the top-level "tracker_ref_offsets" map) is applied
+# here as a distance factor — tunable live from the panel while watching the
+# map, and portable back into Bermuda's own ref_power once a value is found.
+# The exponent below is Bermuda's default attenuation; a user whose Bermuda
+# uses a different one still gets a monotonic trim, just on a slightly
+# different dB scale (this is a relative knob, not a calibrated instrument).
+PATH_LOSS_EXPONENT = 3.0
+TRACKER_REF_OFFSET_MAX_DB = 20.0  # +/- range accepted from the panel/API
 # Slant->horizontal legitimately produces very short radii (tracker nearly
 # under a ceiling probe). The solver's geometric 1/r^2 weight would explode
 # there and let that one receiver dominate the fit, so for WEIGHTING (not for
@@ -232,6 +249,36 @@ def _tracker_height(data, entity=None):
                 and 0 <= configured <= 5:
             return float(configured)
     return TRACKER_HEIGHT_M
+
+
+def _tracker_ref_offset(data, entity):
+    """This tracker's ref-power trim in dB (0.0 when unset). See issue #92."""
+    if not isinstance(data, dict) or entity is None:
+        return 0.0
+    offsets = data.get("tracker_ref_offsets")
+    if not isinstance(offsets, dict):
+        return 0.0
+    value = offsets.get(entity)
+    # not-bool: isinstance(True, int) holds in Python, so a hand-edited
+    # true/false would otherwise read as a valid +1 dB trim.
+    if isinstance(value, (int, float)) and not isinstance(value, bool) \
+            and abs(value) <= TRACKER_REF_OFFSET_MAX_DB:
+        return float(value)
+    return 0.0
+
+
+def _tracker_distance_factor(data, entity):
+    """Multiplicative distance scale from this tracker's ref-power trim.
+
+    A ref_power offset of `delta` dB scales every distance by
+    10 ** (delta / (10 * attenuation)) in Bermuda's path-loss model, so a
+    positive trim reads the tracker as FARTHER and a negative one as nearer.
+    Returns 1.0 (no-op) when no trim is configured.
+    """
+    offset = _tracker_ref_offset(data, entity)
+    if offset == 0.0:
+        return 1.0
+    return 10.0 ** (offset / (10.0 * PATH_LOSS_EXPONENT))
 
 
 def _floor_scale(data, entity, floor_name):
@@ -820,6 +867,7 @@ async def update_receiver_liveness(hass):
 async def update_receiver_radii(hass, eids):
     """Update receiver 'r' values (pixels) and raw 'distance' (meters) for an entity"""
     tracker_h = _tracker_height(eids["data"], eids["entity"])
+    tracker_factor = _tracker_distance_factor(eids["data"], eids["entity"])
     for floor in (f for f in eids["data"]["floor"] if f["scale"] is not None):
         for receiver in floor["receivers"]:
             entity_id = "sensor." + eids["entity"] + "_distance_to_" + receiver["entity_id"]
@@ -842,6 +890,15 @@ async def update_receiver_radii(hass, eids):
                     correction = receiver.get("correction")
                     if isinstance(correction, (int, float)) and correction > 0:
                         distance = distance * correction
+                    # Per-TRACKER ref-power trim (issue #92): a tag whose
+                    # transmit power differs from Bermuda's configured
+                    # ref_power reads consistently long or short from EVERY
+                    # receiver, which no per-receiver correction can fix.
+                    # Applied before the slant leg so the height geometry sees
+                    # the trimmed range, and included in the election distance
+                    # below (a per-tracker constant, so cross-floor ordering
+                    # for this tracker is unchanged).
+                    distance = distance * tracker_factor
                     # Known mount height: the estimate is a slant range, so
                     # remove the vertical leg (mount height vs the assumed
                     # tracker height) to get the horizontal distance the 2D
@@ -1585,6 +1642,7 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSCordsAPI(hass))
             hass.http.register_view(BPSCalibrationAPI())
             hass.http.register_view(BPSSelfTestAPI(hass))
+            hass.http.register_view(BPSTrackerTuneAPI())
             hass.data["bps_views_registered"] = True
 
         config_path = hass.config.path()
@@ -2407,6 +2465,66 @@ def _selftest_summary(result):
         f: round(float(np.percentile(v, 95)), 3) for f, v in by_floor.items()
     }
     return attrs["cep95_m"], attrs
+
+
+class BPSTrackerTuneAPI(HomeAssistantView):
+    """Set one tracker's ref-power trim and apply it immediately (issue #92).
+
+    The panel's "Save Floor Plan" writes the WHOLE layout, so it can't be used
+    for live tuning: it would also commit whatever zone/receiver edits happen to
+    be staged. This writes just the one field under the layout lock, so the
+    tracking loop picks the new value up on its next tick (~1 s) and the map
+    updates on the panel's next poll — the real-time feedback the request asked
+    for — while the panel keeps its own copy in sync so a later full save agrees.
+    """
+
+    url = "/api/bps/tracker_tune"
+    name = "api:bps:tracker_tune"
+    requires_auth = True
+
+    async def post(self, request):
+        hass = request.app["hass"]
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+        entity = body.get("entity")
+        if not isinstance(entity, str) or not entity:
+            return web.json_response({"error": "entity is required"}, status=400)
+
+        raw = body.get("ref_offset_db")
+        offset = None  # None = clear the trim for this tracker
+        if raw is not None:
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                return web.json_response({"error": "ref_offset_db must be a number"}, status=400)
+            if not math.isfinite(raw) or abs(raw) > TRACKER_REF_OFFSET_MAX_DB:
+                return web.json_response(
+                    {"error": f"ref_offset_db must be within +/-{TRACKER_REF_OFFSET_MAX_DB} dB"},
+                    status=400,
+                )
+            offset = float(raw)
+
+        async with BPS_FILE_LOCK:
+            coords = get_bps_data_for_edit(hass)
+            if not isinstance(coords, dict):
+                return web.json_response({"error": "No layout saved yet"}, status=400)
+            offsets = coords.get("tracker_ref_offsets")
+            if not isinstance(offsets, dict):
+                offsets = {}
+            if offset is None or offset == 0.0:
+                offsets.pop(entity, None)  # unset -> back to no trim
+            else:
+                offsets[entity] = offset
+            coords["tracker_ref_offsets"] = offsets
+            await save_bps_data(hass, coords)
+
+        applied = 0.0 if offset is None else offset
+        return web.json_response({
+            "entity": entity,
+            "ref_offset_db": applied,
+            "distance_factor": round(10.0 ** (applied / (10.0 * PATH_LOSS_EXPONENT)), 4),
+        })
 
 
 class BPSSelfTestAPI(HomeAssistantView):

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -2540,8 +2540,13 @@ class BPSTrackerTuneAPI(HomeAssistantView):
         hass = request.app["hass"]
         try:
             body = await request.json()
-        except json.JSONDecodeError:
+        except Exception:
+            # Not just JSONDecodeError: a bad charset raises UnicodeDecodeError,
+            # which is a sibling ValueError and would otherwise escape as a 500.
             return web.json_response({"error": "Invalid JSON body"}, status=400)
+        if not isinstance(body, dict):
+            # A valid non-object body ([], null, 5) parses fine but has no .get.
+            return web.json_response({"error": "Body must be a JSON object"}, status=400)
 
         entity = body.get("entity")
         if not isinstance(entity, str) or not entity:
@@ -2552,12 +2557,22 @@ class BPSTrackerTuneAPI(HomeAssistantView):
         if raw is not None:
             if isinstance(raw, bool) or not isinstance(raw, (int, float)):
                 return web.json_response({"error": "ref_offset_db must be a number"}, status=400)
-            if not math.isfinite(raw) or abs(raw) > TRACKER_REF_OFFSET_MAX_DB:
+            try:
+                # Coerce FIRST: a JSON integer literal with hundreds of digits
+                # parses to a Python int that math.isfinite() can't convert,
+                # raising OverflowError (a 500) for what is just out of range.
+                value = float(raw)
+            except (OverflowError, ValueError):
                 return web.json_response(
                     {"error": f"ref_offset_db must be within +/-{TRACKER_REF_OFFSET_MAX_DB} dB"},
                     status=400,
                 )
-            offset = float(raw)
+            if not math.isfinite(value) or abs(value) > TRACKER_REF_OFFSET_MAX_DB:
+                return web.json_response(
+                    {"error": f"ref_offset_db must be within +/-{TRACKER_REF_OFFSET_MAX_DB} dB"},
+                    status=400,
+                )
+            offset = value
 
         async with BPS_FILE_LOCK:
             coords = get_bps_data_for_edit(hass)

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -2801,6 +2801,12 @@ body {
     outline: 2px solid hsl(var(--ring));
     outline-offset: 1px;
 }
+/* Ref-power trim stepper (issue #92): keep -, value and + on ONE row. The
+   shared .bps-input min-width of 160px would otherwise push the buttons onto
+   their own lines in the narrow setup column. */
+.bps-steprow { flex-wrap: nowrap; }
+.bps-steprow .bps-input { min-width: 0; flex: 1 1 auto; text-align: center; }
+.bps-steprow .bps-btn { flex: 0 0 auto; min-width: 34px; padding: 0 10px; font-size: 15px; }
 textarea#mapname { resize: none; line-height: 28px; overflow: hidden; }
 input.bps-input[type="file"] { padding: 4px 10px; height: 30px; }
 select.bps-input { cursor: pointer; }

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -95,6 +95,23 @@
                                 <input type="number" id="trackerHeightInput" class="bps-input"
                                        min="0" max="5" step="0.1" placeholder="1.0 (default)">
                             </div>
+                            <!-- Per-tracker reference-power trim (issue #92). A cheap
+                                 beacon whose transmit power differs from Bermuda's
+                                 configured ref_power reads consistently long or short
+                                 from every receiver. Stepping this applies LIVE (no
+                                 Save needed) so the map can be watched while tuning;
+                                 the dB value is portable back into Bermuda's own
+                                 ref_power once a good one is found. -->
+                            <div class="bps-field">
+                                <label class="bps-label">Ref power trim (dB)</label>
+                                <div class="bps-viewrow bps-steprow">
+                                    <button type="button" id="refTrimDown" class="bps-btn bps-btn-outline" title="Read nearer (-1 dB)">−</button>
+                                    <input type="number" id="trackerRefTrimInput" class="bps-input"
+                                           min="-20" max="20" step="0.5" placeholder="0 (default)">
+                                    <button type="button" id="refTrimUp" class="bps-btn bps-btn-outline" title="Read farther (+1 dB)">+</button>
+                                </div>
+                                <div id="refTrimHint" class="bps-hint">Applies live. Negative reads nearer, positive farther.</div>
+                            </div>
                             <!-- Colour-coded list of the devices being tracked. Each row's
                                  swatch matches that device's on-map icon, circles and path;
                                  click a row to make the tracker-icon controls target it, × to

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -75,6 +75,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     const entSelector = document.getElementById('entSelector');
     const trackerIconSelector = document.getElementById('trackerIconSelector');
     const trackerHeightInput = document.getElementById('trackerHeightInput');
+    const trackerRefTrimInput = document.getElementById('trackerRefTrimInput');
+    const refTrimDownBtn = document.getElementById('refTrimDown');
+    const refTrimUpBtn = document.getElementById('refTrimUp');
+    const refTrimHint = document.getElementById('refTrimHint');
     const trackerIconUpload = document.getElementById('trackerIconUpload');
     const uploadTrackerIconButton = document.getElementById('uploadTrackerIcon');
     const mapbuttondiv = document.getElementById('mapbuttondiv');
@@ -433,6 +437,76 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!store || typeof store !== "object") return null;
         const v = store[entKey];
         return (typeof v === "number" && v >= 0 && v <= 5) ? v : null;
+    }
+
+    // --- Per-tracker ref-power trim (issue #92) ----------------------------
+    const REF_TRIM_MAX_DB = 20;
+    const REF_TRIM_PATH_LOSS = 3.0;  // mirrors the backend's PATH_LOSS_EXPONENT
+
+    function ensureTrackerRefOffsetsStore() {
+        if (!finalcords.tracker_ref_offsets || typeof finalcords.tracker_ref_offsets !== "object") {
+            finalcords.tracker_ref_offsets = {};
+        }
+    }
+
+    // This device's trim in dB (0 when unset).
+    function trackerRefTrimFor(entKey) {
+        const store = finalcords.tracker_ref_offsets;
+        if (!store || typeof store !== "object") return 0;
+        const v = store[entKey];
+        return (typeof v === "number" && Math.abs(v) <= REF_TRIM_MAX_DB) ? v : 0;
+    }
+
+    function refTrimHintText(db) {
+        if (!db) return "Applies live. Negative reads nearer, positive farther.";
+        const factor = Math.pow(10, db / (10 * REF_TRIM_PATH_LOSS));
+        return `Distances x${factor.toFixed(3)} (${db > 0 ? "+" : ""}${db} dB). Applies live.`;
+    }
+
+    function syncRefTrimUI(entKey) {
+        if (!trackerRefTrimInput) return;
+        const db = entKey ? trackerRefTrimFor(entKey) : 0;
+        trackerRefTrimInput.value = entKey && db ? String(db) : "";
+        if (refTrimHint) refTrimHint.textContent = refTrimHintText(entKey ? db : 0);
+    }
+
+    // Push the trim to the backend so the tracking loop applies it on its next
+    // tick (live feedback on the map). Also kept in finalcords so a later full
+    // "Save Floor Plan" writes the same value instead of reverting it.
+    let refTrimPostSeq = 0;
+    async function applyRefTrim(entKey, db) {
+        ensureTrackerRefOffsetsStore();
+        if (db) {
+            finalcords.tracker_ref_offsets[entKey] = db;
+        } else {
+            delete finalcords.tracker_ref_offsets[entKey];
+        }
+        syncRefTrimUI(entKey);
+        const seq = ++refTrimPostSeq;
+        try {
+            const res = await bpsFetch("/api/bps/tracker_tune", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ entity: entKey, ref_offset_db: db }),
+            });
+            if (seq !== refTrimPostSeq) return;   // a newer step superseded this one
+            if (!res.ok) {
+                bpsToast("Could not apply the ref power trim.");
+            }
+        } catch (e) {
+            if (seq === refTrimPostSeq) bpsToast("Could not apply the ref power trim.");
+        }
+    }
+
+    function stepRefTrim(deltaDb) {
+        if (!activeDevice) {
+            bpsToast("Add a device to track first.");
+            return;
+        }
+        const next = Math.max(-REF_TRIM_MAX_DB,
+                              Math.min(REF_TRIM_MAX_DB,
+                                       Math.round((trackerRefTrimFor(activeDevice) + deltaDb) * 10) / 10));
+        applyRefTrim(activeDevice, next);
     }
 
     // The icon URL a given tracked device should draw with (its saved choice,
@@ -1652,6 +1726,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const h = activeDevice ? trackerHeightFor(activeDevice) : null;
                 trackerHeightInput.value = h === null ? "" : String(h);
             }
+            syncRefTrimUI(activeDevice);
         }
 
         // Start/stop button visibility follows whether anything is tracked (but
@@ -1748,6 +1823,38 @@ document.addEventListener('DOMContentLoaded', async () => {
                 finalcords.tracker_icons[activeDevice] = trackerIconSelector.value;
                 savebuttondiv.appendChild(saveButton);
                 if (pollTrackActive && img.naturalWidth > 0) redrawAll();
+            });
+        }
+
+        if (refTrimDownBtn) refTrimDownBtn.addEventListener("click", () => stepRefTrim(-1));
+        if (refTrimUpBtn) refTrimUpBtn.addEventListener("click", () => stepRefTrim(1));
+
+        if (trackerRefTrimInput) {
+            trackerRefTrimInput.addEventListener("change", () => {
+                if (!activeDevice) {
+                    bpsToast("Add a device to track first.");
+                    trackerRefTrimInput.value = "";
+                    return;
+                }
+                // Unparseable text reads back as "" with validity.badInput: it
+                // must fail validation, not be mistaken for "cleared".
+                if (trackerRefTrimInput.validity && trackerRefTrimInput.validity.badInput) {
+                    bpsToast(`Ref power trim must be within +/-${REF_TRIM_MAX_DB} dB.`);
+                    syncRefTrimUI(activeDevice);
+                    return;
+                }
+                const raw = trackerRefTrimInput.value.trim();
+                if (raw === "") {
+                    applyRefTrim(activeDevice, 0);   // cleared = no trim
+                    return;
+                }
+                const v = parseFloat(raw);
+                if (!Number.isFinite(v) || Math.abs(v) > REF_TRIM_MAX_DB) {
+                    bpsToast(`Ref power trim must be within +/-${REF_TRIM_MAX_DB} dB.`);
+                    syncRefTrimUI(activeDevice);
+                    return;
+                }
+                applyRefTrim(activeDevice, Math.round(v * 10) / 10);
             });
         }
 

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -473,29 +473,52 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Push the trim to the backend so the tracking loop applies it on its next
     // tick (live feedback on the map). Also kept in finalcords so a later full
     // "Save Floor Plan" writes the same value instead of reverting it.
-    let refTrimPostSeq = 0;
-    async function applyRefTrim(entKey, db) {
+    // Per-DEVICE sequence + single-flight chain. Per-device so a request for one
+    // tracker can't silence another's error; single-flight so rapid stepping
+    // reaches the backend in order (concurrent POSTs could otherwise land out of
+    // order and leave the stored trim different from the one on screen).
+    const refTrimSeq = new Map();
+    const refTrimChain = new Map();
+
+    function setRefTrimLocal(entKey, db) {
         ensureTrackerRefOffsetsStore();
         if (db) {
             finalcords.tracker_ref_offsets[entKey] = db;
         } else {
             delete finalcords.tracker_ref_offsets[entKey];
         }
+    }
+
+    function applyRefTrim(entKey, db) {
+        const previous = trackerRefTrimFor(entKey);   // to roll back to if the write fails
+        setRefTrimLocal(entKey, db);
         syncRefTrimUI(entKey);
-        const seq = ++refTrimPostSeq;
-        try {
-            const res = await bpsFetch("/api/bps/tracker_tune", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ entity: entKey, ref_offset_db: db }),
-            });
-            if (seq !== refTrimPostSeq) return;   // a newer step superseded this one
-            if (!res.ok) {
+        const seq = (refTrimSeq.get(entKey) || 0) + 1;
+        refTrimSeq.set(entKey, seq);
+
+        const send = async () => {
+            let ok = false;
+            try {
+                const res = await bpsFetch("/api/bps/tracker_tune", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ entity: entKey, ref_offset_db: db }),
+                });
+                ok = res.ok;
+            } catch (e) {
+                ok = false;
+            }
+            if (seq !== refTrimSeq.get(entKey)) return;   // a newer step for this device won
+            if (!ok) {
+                // Never leave the UI claiming a trim the backend rejected.
+                setRefTrimLocal(entKey, previous);
+                if (entKey === activeDevice) syncRefTrimUI(entKey);
                 bpsToast("Could not apply the ref power trim.");
             }
-        } catch (e) {
-            if (seq === refTrimPostSeq) bpsToast("Could not apply the ref power trim.");
-        }
+        };
+        const chained = (refTrimChain.get(entKey) || Promise.resolve()).then(send, send);
+        refTrimChain.set(entKey, chained);
+        return chained;
     }
 
     function stepRefTrim(deltaDb) {

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.7.7"
+    "version": "1.8.0"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.8.0"
+    "version": "1.8.1"
 }

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -250,6 +250,14 @@ def test_tune_rejects_bad_input(tmp_path):
     assert _tune(hass, {"entity": "cat", "ref_offset_db": "3"}).status == 400   # string
     assert _tune(hass, {"entity": "cat", "ref_offset_db": float("nan")}).status == 400
     assert _tune(hass, _BAD_JSON).status == 400                       # malformed body
+    # A syntactically valid NON-OBJECT body parses fine but has no .get(): it
+    # must 400, not raise AttributeError (which HA surfaces as a 500).
+    for body in ([], None, 5, "x", 1.5):
+        assert _tune(hass, body).status == 400, body
+    # A giant JSON integer parses to a Python int that math.isfinite() cannot
+    # convert (OverflowError -> 500); it must read as plainly out of range.
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": 10 ** 400}).status == 400
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": float("inf")}).status == 400
     assert "tracker_ref_offsets" not in (_layout(hass) or {})         # nothing written
 
 

--- a/tests/test_http_safety.py
+++ b/tests/test_http_safety.py
@@ -172,3 +172,87 @@ def test_delete_traversal_still_blocked(tmp_path):
     outside.write_bytes(b"x")
     run(_write(hass, maps, _Dict(remove="../secret.png"), {}))
     assert outside.exists()  # '../' collapsed to basename; the real file survives
+
+
+# --- tracker ref-power trim endpoint (issue #92) --------------------------- #
+class _Req:
+    """Minimal aiohttp-request stand-in: .app["hass"] + await .json()."""
+
+    def __init__(self, hass, body):
+        self.app = {"hass": hass}
+        self._body = body
+
+    async def json(self):
+        if self._body is _BAD_JSON:
+            raise bps.json.JSONDecodeError("bad", "", 0)
+        return self._body
+
+
+_BAD_JSON = object()
+
+
+def _tune(hass, body):
+    return run(bps.BPSTrackerTuneAPI().post(_Req(hass, body)))
+
+
+def _layout(hass):
+    return hass._store_backing.get("bps")
+
+
+def _hass_with_layout(tmp_path):
+    hass = make_hass(tmp_path)
+    run(bps.save_bps_data(hass, {"floor": [{"name": "F", "scale": 40, "receivers": []}]}))
+    return hass
+
+
+def test_tune_sets_and_persists_offset(tmp_path):
+    hass = _hass_with_layout(tmp_path)
+    res = _tune(hass, {"entity": "cat", "ref_offset_db": -6.0})
+    assert res.status == 200
+    assert res.json_body["ref_offset_db"] == -6.0
+    assert res.json_body["distance_factor"] < 1.0          # negative reads nearer
+    assert _layout(hass)["tracker_ref_offsets"] == {"cat": -6.0}
+    # The live cache the tracking loop reads is updated too.
+    assert bps.get_bps_data(hass)["tracker_ref_offsets"] == {"cat": -6.0}
+
+
+def test_tune_zero_or_null_clears_the_entry(tmp_path):
+    hass = _hass_with_layout(tmp_path)
+    _tune(hass, {"entity": "cat", "ref_offset_db": -6.0})
+    _tune(hass, {"entity": "dog", "ref_offset_db": 3.0})
+    _tune(hass, {"entity": "cat", "ref_offset_db": 0})
+    assert _layout(hass)["tracker_ref_offsets"] == {"dog": 3.0}   # only cat cleared
+    _tune(hass, {"entity": "dog"})                                # omitted = clear
+    assert _layout(hass)["tracker_ref_offsets"] == {}
+
+
+def test_tune_preserves_the_rest_of_the_layout(tmp_path):
+    # Surgical write: it must not disturb floors or other top-level keys (the
+    # panel's full save is deliberately NOT reused, so staged edits stay staged).
+    hass = make_hass(tmp_path)
+    run(bps.save_bps_data(hass, {
+        "floor": [{"name": "F", "scale": 40, "receivers": [{"entity_id": "r1"}]}],
+        "tracker_heights": {"cat": 0.1},
+    }))
+    _tune(hass, {"entity": "cat", "ref_offset_db": 2.5})
+    layout = _layout(hass)
+    assert layout["tracker_heights"] == {"cat": 0.1}
+    assert layout["floor"][0]["receivers"] == [{"entity_id": "r1"}]
+    assert layout["tracker_ref_offsets"] == {"cat": 2.5}
+
+
+def test_tune_rejects_bad_input(tmp_path):
+    hass = _hass_with_layout(tmp_path)
+    assert _tune(hass, {"ref_offset_db": 1}).status == 400            # no entity
+    assert _tune(hass, {"entity": "", "ref_offset_db": 1}).status == 400
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": 99}).status == 400   # out of range
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": True}).status == 400  # bool
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": "3"}).status == 400   # string
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": float("nan")}).status == 400
+    assert _tune(hass, _BAD_JSON).status == 400                       # malformed body
+    assert "tracker_ref_offsets" not in (_layout(hass) or {})         # nothing written
+
+
+def test_tune_without_a_layout_is_rejected(tmp_path):
+    hass = make_hass(tmp_path)          # fresh install: no layout saved yet
+    assert _tune(hass, {"entity": "cat", "ref_offset_db": 1}).status == 400

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -421,3 +421,57 @@ def test_per_tracker_height_feeds_slant_correction():
     assert abs(r_default - math.sqrt(2.3**2 - 1.2**2) * SCALE) < 0.1
     assert abs(r_ankle - math.sqrt(2.3**2 - 2.1**2) * SCALE) < 0.1
     assert r_ankle < r_default
+
+
+# --------------------------------------------------------------------------- #
+# Per-tracker ref-power trim (issue #92)
+# --------------------------------------------------------------------------- #
+def test_ref_offset_reads_and_validates():
+    data = {"tracker_ref_offsets": {"cat": -6.0, "big": 99, "boolish": True, "txt": "3"}}
+    assert bps._tracker_ref_offset(data, "cat") == -6.0
+    assert bps._tracker_ref_offset(data, "big") == 0.0        # out of range
+    assert bps._tracker_ref_offset(data, "boolish") == 0.0    # bool is not a number here
+    assert bps._tracker_ref_offset(data, "txt") == 0.0        # wrong type
+    assert bps._tracker_ref_offset(data, "unknown") == 0.0    # no entry
+    assert bps._tracker_ref_offset({}, "cat") == 0.0
+    assert bps._tracker_ref_offset({"tracker_ref_offsets": "junk"}, "cat") == 0.0
+
+
+def test_ref_offset_distance_factor_matches_path_loss_model():
+    # delta dB scales distance by 10 ** (delta / (10 * attenuation)).
+    n = bps.PATH_LOSS_EXPONENT
+    assert bps._tracker_distance_factor({}, "cat") == 1.0     # unset = no-op
+    f_up = bps._tracker_distance_factor({"tracker_ref_offsets": {"cat": 6.0}}, "cat")
+    f_dn = bps._tracker_distance_factor({"tracker_ref_offsets": {"cat": -6.0}}, "cat")
+    assert abs(f_up - 10 ** (6.0 / (10 * n))) < 1e-12
+    assert f_up > 1.0 and f_dn < 1.0                          # + reads farther, - nearer
+    assert abs(f_up * f_dn - 1.0) < 1e-12                     # symmetric in dB
+
+
+def test_ref_trim_scales_the_live_radius():
+    # A -6 dB trim must shrink the radius by the model's factor; the election
+    # distance is scaled the same way (a per-tracker constant).
+    class St:
+        state = "4.0"
+        attributes = {"unit_of_measurement": "m"}
+
+    class Hass:
+        states = type("S", (), {"get": staticmethod(lambda _eid: St())})()
+
+    def run_with(offsets):
+        rec = {"entity_id": "probe", "cords": {"x": 0, "y": 0}}
+        data = {"floor": [{"name": "F", "scale": SCALE, "receivers": [rec]}]}
+        if offsets is not None:
+            data["tracker_ref_offsets"] = offsets
+        run(bps.update_receiver_radii(Hass(), {"entity": "cat", "data": data}))
+        return rec
+
+    plain = run_with(None)
+    trimmed = run_with({"cat": -6.0})
+    factor = 10 ** (-6.0 / (10 * bps.PATH_LOSS_EXPONENT))
+    assert abs(plain["cords"]["r"] - 4.0 * SCALE) < 1e-6
+    assert abs(trimmed["cords"]["r"] - 4.0 * factor * SCALE) < 1e-6
+    assert abs(trimmed["distance"] - 4.0 * factor) < 1e-9
+    # Another tracker's trim must not leak onto this one.
+    other = run_with({"dog": -6.0})
+    assert abs(other["cords"]["r"] - 4.0 * SCALE) < 1e-6

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -475,3 +475,87 @@ def test_ref_trim_scales_the_live_radius():
     # Another tracker's trim must not leak onto this one.
     other = run_with({"dog": -6.0})
     assert abs(other["cords"]["r"] - 4.0 * SCALE) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Stale distance readings (stuck values from a scanner that stopped hearing)
+# --------------------------------------------------------------------------- #
+class _Stamp:
+    """Minimal stand-in for a state's tz-aware timestamp."""
+
+    def __init__(self, age_secs):
+        import time as _t
+        self._ts = _t.time() - age_secs
+
+    def timestamp(self):
+        return self._ts
+
+
+def _run_radii_aged(state, age_secs, max_age=None, stamp_attr="last_updated"):
+    class St:
+        def __init__(self):
+            self.state = state
+            self.attributes = {"unit_of_measurement": "m"}
+            setattr(self, stamp_attr, _Stamp(age_secs))
+
+    class Hass:
+        states = type("S", (), {"get": staticmethod(lambda _eid: St())})()
+
+    rec = {"entity_id": "probe", "cords": {"x": 0, "y": 0}}
+    data = {"floor": [{"name": "F", "scale": SCALE, "receivers": [rec]}]}
+    if max_age is not None:
+        data["reading_max_age"] = max_age
+    run(bps.update_receiver_radii(Hass(), {"entity": "cat", "data": data}))
+    return rec
+
+
+def test_fresh_reading_is_used():
+    rec = _run_radii_aged("3.0", age_secs=2)
+    assert abs(rec["distance"] - 3.0) < 1e-9
+    assert abs(rec["cords"]["r"] - 3.0 * SCALE) < 1e-6
+
+
+def test_stuck_reading_is_dropped_from_the_solve():
+    # Older than READING_MAX_AGE_SECS: no "distance" key, so
+    # extract_candidate_floors leaves this receiver out of the fix entirely.
+    rec = _run_radii_aged("3.0", age_secs=bps.READING_MAX_AGE_SECS + 10)
+    assert "distance" not in rec
+
+
+def test_stale_receiver_is_excluded_from_candidates():
+    fresh = {"entity_id": "a", "cords": {"x": 0, "y": 0, "r": 40.0}, "distance": 1.0}
+    stale = {"entity_id": "b", "cords": {"x": 80, "y": 0, "r": 40.0}}  # gate popped it
+    data = [{"entity": "cat", "data": {"floor": [
+        {"name": "F", "scale": SCALE, "receivers": [fresh, stale]}]}}]
+    cands = bps.extract_candidate_floors(data, "cat")
+    assert len(cands) == 1 and len(cands[0]["cords"]) == 1   # only the fresh one
+
+
+def test_reading_max_age_override_and_disable():
+    # A tighter override drops a reading the default would have accepted.
+    assert "distance" not in _run_radii_aged("3.0", age_secs=10, max_age=5)
+    # 0 disables the gate: even an ancient reading is used (opt-out).
+    assert _run_radii_aged("3.0", age_secs=9999, max_age=0)["distance"] == 3.0
+    # Garbage override falls back to the default (still gates).
+    assert "distance" not in _run_radii_aged("3.0", age_secs=9999, max_age=True)
+
+
+def test_age_falls_back_to_last_changed_and_fails_open():
+    # Only last_changed available: still gated.
+    assert "distance" not in _run_radii_aged(
+        "3.0", age_secs=9999, stamp_attr="last_changed")
+
+    # No usable timestamp at all: fail OPEN (never blank the map on an
+    # unexpected state object).
+    class St:
+        state = "3.0"
+        attributes = {"unit_of_measurement": "m"}
+
+    class Hass:
+        states = type("S", (), {"get": staticmethod(lambda _eid: St())})()
+
+    rec = {"entity_id": "probe", "cords": {"x": 0, "y": 0}}
+    run(bps.update_receiver_radii(
+        Hass(), {"entity": "cat", "data": {"floor": [
+            {"name": "F", "scale": SCALE, "receivers": [rec]}]}}))
+    assert rec["distance"] == 3.0


### PR DESCRIPTION
Two tracking-path changes: the live ref-power tuning requested in #92, and a fix for stuck distance readings anchoring the position.

---

## 1. Per-tracker ref-power trim, tunable live (closes #92)

Cheap beacons vary in transmit power, so one Bermuda `ref_power` can read consistently long or short for a given tag — an error **no per-receiver correction can fix**, because it affects every receiver equally. #92 asked to trim it *while watching the map*, instead of editing Bermuda and reloading.

In Bermuda's path-loss model `d = 10^((ref_power − rssi)/(10·attenuation))`, a ref_power offset of `Δ` dB is **exactly** a multiplicative scale on distance, `10^(Δ/(10·attenuation))` — so BPS can apply the same effect without touching Bermuda's config.

- **Panel**: a **"Ref power trim (dB)"** stepper (`−` / value / `+`) in the Tracking section, targeting the highlighted device, with a live readout of the resulting factor (`Distances ×0.794 (-3 dB). Applies live.`).
- **Applies immediately**: a new `POST /api/bps/tracker_tune` (`requires_auth`) writes **just that field** under the layout lock, so the tracking loop picks it up next tick (~1 s) and the map updates on the next poll. Deliberately *not* the panel's "Save Floor Plan", which writes the whole layout and would also commit any staged zone/receiver edits. The panel's own copy is updated too, so a later full save agrees instead of reverting.
- The dB value is **portable**: fold a good trim into Bermuda's own `ref_power` for that device once found.

## 2. Stale distance readings no longer anchor the fix

**Reported:** a tracked beacon's distance to a scanner never drops even after that scanner hasn't seen it for several cycles — the reading goes **stuck** rather than unavailable (most visible on Bermuda's *unfiltered* distance entities, which have no timeout of their own). Fed to the solver, that frozen radius keeps anchoring the position to a receiver that can no longer see the device.

This was the **top-ranked finding of the positioning audit** ("time-blindness"): a grep confirmed *no* `last_updated`/`last_changed`/`last_reported` use anywhere in the backend, so the stalest reading was trusted exactly like the freshest.

- New `READING_MAX_AGE_SECS = 30` (matching Bermuda's own distance timeout and `RECEIVER_OFFLINE_SECS`), overridable via a top-level `reading_max_age`; **`0` disables** the gate.
- Too-old readings are dropped from that cycle's solve; the remaining receivers still solve, and a floor falling under 3 keeps its last values via the existing dark-incumbent grace rather than producing a garbage fix.
- Age uses **`last_updated`** (fallback `last_changed`), **not `last_reported`** — HA only bumps `last_updated` when the value actually *changes*, so a sensor that keeps re-reporting the same stale distance still ages out, which is precisely the stuck case. Deliberate trade-off: a genuinely constant distance for >30 s is also dropped — fine, since BLE distance always jitters, so an unchanged value for that long *is* the signal that no new measurement arrived.
- **Fails open** when no usable timestamp exists, so an unexpected state object can never blank the map.

---

## Verification
- **85 unit tests.** Trim: offset validation, the factor matches the model and is symmetric in dB, the live radius/election distance scale, no cross-tracker leakage, and the endpoint (persist, clear on 0/omitted, **layout preserved**, bad input rejected, no-layout rejected). Staleness: fresh used, stuck dropped, stale receiver excluded from candidates, override/0-disable/garbage-fallback, `last_changed` fallback, fail-open.
- **Browser harness, 26 checks across two runs** on the real panel — including one with **failure and latency injection**: optimistic value then rollback on a rejected write, three rapid steps arriving in issue order with the last click winning, and one device's failure surviving another device's later success.
- **Adversarial review: 15 raised, 5 confirmed (all fixed), 10 refuted.** Two were backend crash paths the verifiers proved *by executing the handler* — a non-object JSON body (`[]`, `null`) raised `AttributeError`, and a 400-digit integer raised `OverflowError`, both surfacing as 500s; neither could corrupt state (they raise before the lock). Three were async state bugs in the panel (no rollback on failure, out-of-order concurrent writes, a global stale-guard silencing another device's error) — all fixed and now covered by the injection tests above.

Version **1.8.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)