### PR TITLE
Position history: replay where a tracked device has been

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Accuracy
 - [Kalman position smoothing](#kalman-position-smoothing) — a motion-aware filter replaces the fixed moving average: less lag when walking, steadier when still.
 - [Trilateration visualization](#trilateration-visualization) — see the distance circles that place each device.
 - [Trace path](#trace-path) — replay the route a tracked device took during the session, faded by age.
+- [Position history](#position-history) — scrub back through where a device has been, hours or days later, with a time slider and playback.
 - [Receiver distances](#receiver-distances) — measured vs real distance between every receiver pair, colour-coded on the map to spot bad values fast.
 
 The Lovelace card
@@ -510,6 +511,47 @@ accurate fix — a stark reminder to track the filtered distance, and to keep
 receivers well calibrated (see [Receiver distances](#receiver-distances)).
 
 ![The same ankle beacon tracked on unfiltered vs filtered Bermuda distance: the unfiltered trace is a chaotic tangle in the centre of the floor while the filtered position is a single stable fix at lower-right](img/screenshots/filtered_unfiltered_difference.png)
+
+## Position history
+
+Trace path only knows the tab you have open. **Position history** is the
+recorded version: BPS keeps every fix it publishes, so you can come back hours
+or days later and ask *where was this device at 3 pm?*
+
+Switch **History** on above the map and a scrubber appears:
+
+- **Device** and **how far back** to load, then drag the **slider** to move
+  through the recording. The trail is solid up to the marker and a faint dashed
+  ghost beyond it, so the moment you are looking at is unmistakable.
+- The **time picker** jumps straight to a moment and reloads the window
+  *centred* on it — the point of it is to see the movement **around** that time,
+  not just the instant.
+- **▶** replays forward on its own at 1× to 600×; **Live** jumps back to now and
+  keeps following.
+- Off-floor stretches are excluded and the status line says so, exactly like
+  Trace path — the coordinates are real, they just aren't for the map on screen.
+
+**How long is kept** is set by *Position history* in the Tracking column
+(off, 1 hour … 7 days; 6 hours by default), and **Clear** forgets everything
+immediately.
+
+Some deliberate choices worth knowing:
+
+- The record is **BPS's own**, under `config/.storage/bps_history/`, not the
+  Home Assistant recorder. The recorder purges in whole days for the whole
+  database, which cannot express "keep six hours of this"; and at roughly one
+  fix per second per device it would add tens of megabytes a day to your
+  database for data only this map can use.
+- Positions are stored in **metres on their floor**, not pixels. Re-export a
+  floor plan at a different resolution and the past still lands where it
+  actually happened.
+- It is **not** in `www/`, so it is never served to anyone who guesses a URL.
+- Points are only kept when the device actually moved (or every 30 s as a
+  heartbeat), so a phone sitting on a table costs about 120 points an hour, not
+  3600.
+- Breaks are recorded as breaks: a floor change, a restart, or a device that
+  went missing for a while starts a new line instead of drawing a straight
+  segment across the gap.
 
 ## Receiver distances
 

--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ Trace path only knows the tab you have open. **Position history** is the
 recorded version: BPS keeps every fix it publishes, so you can come back hours
 or days later and ask *where was this device at 3 pm?*
 
-The scrubber sits **under the map** and is always there — there is nothing to
-switch on:
+The scrubber sits **under the map**, shown by default — the **History** toggle
+in the Tracking column hides it (and its trail) when it is in the way:
 
 - **Device** and **how far back** to load, then drag the **slider** to move
   through the recording. The trail is solid up to the marker and a faint dashed

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Accuracy
 - [Kalman position smoothing](#kalman-position-smoothing) — a motion-aware filter replaces the fixed moving average: less lag when walking, steadier when still.
 - [Trilateration visualization](#trilateration-visualization) — see the distance circles that place each device.
 - [Trace path](#trace-path) — replay the route a tracked device took during the session, faded by age.
-- [Position history](#position-history) — scrub back through where a device has been, hours or days later, with a time slider and playback.
+- [Position history](#position-history) — scrub back through where a device has been, hours or days later, with a time slider and playback under the map.
 - [Receiver distances](#receiver-distances) — measured vs real distance between every receiver pair, colour-coded on the map to spot bad values fast.
 
 The Lovelace card
@@ -518,11 +518,16 @@ Trace path only knows the tab you have open. **Position history** is the
 recorded version: BPS keeps every fix it publishes, so you can come back hours
 or days later and ask *where was this device at 3 pm?*
 
-Switch **History** on above the map and a scrubber appears:
+The scrubber sits **under the map** and is always there — there is nothing to
+switch on:
 
 - **Device** and **how far back** to load, then drag the **slider** to move
   through the recording. The trail is solid up to the marker and a faint dashed
   ghost beyond it, so the moment you are looking at is unmistakable.
+- **Click a device** — in the tracked-device list, or its beacon on the map —
+  and the scrubber follows it, so the trail on screen belongs to the device you
+  just clicked. It works the other way too: picking a device in the scrubber
+  highlights it in the list.
 - The **time picker** jumps straight to a moment and reloads the window
   *centred* on it — the point of it is to see the movement **around** that time,
   not just the instant.

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -50,6 +50,7 @@ from .storage import (
     save_bps_data,
 )
 from .const import ACCURACY_ENTITY_ID
+from . import history as history_mod
 from .zone_adjust import adjust_zones, adjust_subzones
 
 _LOGGER = logging.getLogger(__name__)
@@ -261,6 +262,137 @@ def _tracker_height(data, entity=None):
     return TRACKER_HEIGHT_M
 
 
+HISTORY_FLUSH_INTERVAL = 60  # s between appends of buffered history to disk
+
+
+def get_position_history(hass):
+    """The per-install position history, created on first use."""
+    bucket = hass.data.setdefault(DOMAIN, {})
+    hist = bucket.get("_history")
+    if hist is None:
+        hist = bucket["_history"] = history_mod.PositionHistory(
+            history_mod.history_config(get_bps_data(hass)))
+    return hist
+
+
+def history_dir(hass):
+    """Where the NDJSON day segments live (under .storage, never web-served)."""
+    return hass.config.path(".storage", history_mod.HISTORY_DIRNAME)
+
+
+def _history_lock(hass):
+    """Serialises every history disk operation (flush, prune, restore, clear).
+
+    Without it a Clear can be undone: the periodic flush drains the queue and
+    hands it to the executor, the Clear deletes the segments, and then the
+    append lands - putting the forgotten positions back on disk, where the next
+    restart reads them in again. The per-tracker rewrite has the mirror problem
+    (read-filter-replace losing rows an append wrote in the meantime).
+    """
+    bucket = hass.data.setdefault(DOMAIN, {})
+    lock = bucket.get("_history_lock")
+    if lock is None:
+        lock = bucket["_history_lock"] = asyncio.Lock()
+    return lock
+
+
+def _history_prunable_max_age(hass, hist):
+    """The retention to prune against, or None when it can't be trusted.
+
+    Pruning DELETES days of record irreversibly, so it must never run on a
+    guessed window: if the layout cache isn't a dict (a fresh install, or a
+    store that failed to load this boot) history_config falls back to the 6 h
+    default, which would take a configured 7-day record down to six hours.
+    """
+    layout = get_bps_data(hass)
+    if not isinstance(layout, dict):
+        return None
+    return hist.cfg["max_age"]
+
+
+async def flush_position_history(hass, prune=False):
+    """Append buffered points to today's segment; optionally prune old days.
+
+    All file work happens in the executor. Failing here loses at most the
+    buffered points (the in-memory ring is untouched), so it must never
+    propagate into the tracking loop.
+    """
+    hist = get_position_history(hass)
+    hist.configure(history_mod.history_config(get_bps_data(hass)))
+    # Age every track, not just the ones that recorded this cycle: a tracker
+    # that went silent (or a history since switched off) would otherwise keep
+    # serving points past the configured window.
+    hist.evict_all()
+    if not hist.pending_count() and not prune:
+        return
+    dirpath = history_dir(hass)
+    max_age = _history_prunable_max_age(hass, hist) if prune else None
+
+    async with _history_lock(hass):
+        # Drain INSIDE the lock so a Clear cannot slip between the drain and
+        # the write and be overwritten by it.
+        grouped = hist.drain_pending()
+        if not grouped and max_age is None:
+            return
+
+        def _work():
+            if grouped:
+                history_mod.append_segments(dirpath, grouped)
+            if max_age is not None:
+                history_mod.prune_segments(dirpath, max_age)
+
+        try:
+            await hass.async_add_executor_job(_work)
+        except Exception:
+            # The write failed; put the rows back rather than dropping them on
+            # the floor. requeue() honours the pending cap, so a disk that
+            # stays broken cannot grow this without bound.
+            hist.requeue(grouped)
+            raise
+
+
+async def restore_position_history(hass):
+    """Reload the retained window from disk at startup.
+
+    Every restored track is gap-marked afterwards: the integration was down
+    for an unknown span, so the first new fix must start a fresh polyline
+    rather than draw a straight line across the outage.
+    """
+    hist = get_position_history(hass)
+    # A config-entry reload re-enters setup with the SAME PositionHistory:
+    # async_unload_entry cancels the tracking task but leaves hass.data[DOMAIN]
+    # alone, so re-reading the segments would append a second copy of every
+    # point already held and leave the arrays unsorted, breaking every bisect
+    # in query() and evict(). There is nothing to restore into a live ring.
+    if hist.entities() or hist.pending_count():
+        hist.mark_all_gaps()
+        return
+    dirpath = history_dir(hass)
+    cfg = dict(hist.cfg)
+
+    # Parse AND build the tracks off the loop: the retained window can be
+    # hundreds of thousands of rows and this runs during setup.
+    def _work():
+        history_mod.prune_segments(dirpath, cfg["max_age"])
+        loaded = history_mod.PositionHistory(cfg)
+        loaded.load_rows(history_mod.restore_recent(dirpath, cfg))
+        # The rows came FROM disk; nothing here needs writing back out.
+        loaded.drain_pending()
+        return loaded
+
+    try:
+        async with _history_lock(hass):
+            loaded = await hass.async_add_executor_job(_work)
+    except Exception as e:
+        _LOGGER.warning("BPS position history could not be restored: %s", e)
+        return
+    hist.adopt(loaded)
+    hist.mark_all_gaps()
+    ents = hist.entities()
+    _LOGGER.info("BPS position history restored: %d points across %d trackers",
+                 sum((hist.retained(e) or {}).get("points", 0) for e in ents), len(ents))
+
+
 def _reading_max_age(data):
     """Seconds after which a distance reading is ignored (0 = never)."""
     if isinstance(data, dict):
@@ -464,6 +596,18 @@ async def update_tracked_entities(hass, jinja_code):
                 update_bps_sensor_state(hass, ACCURACY_ENTITY_ID, state, attrs)
             except Exception as e:  # never let the diagnostic sensor stall tracking
                 _LOGGER.warning("BPS self-test sensor update failed: %s", e)
+
+        # Persist the position history at a slow cadence (and prune expired day
+        # segments hourly), so a restart does not lose the scrubback window.
+        if now_ts - getattr(update_tracked_entities, "last_history_flush", 0.0) >= HISTORY_FLUSH_INTERVAL:
+            update_tracked_entities.last_history_flush = now_ts
+            prune_due = now_ts - getattr(update_tracked_entities, "last_history_prune", 0.0) >= 3600
+            if prune_due:
+                update_tracked_entities.last_history_prune = now_ts
+            try:
+                await flush_position_history(hass, prune=prune_due)
+            except Exception as e:  # disk trouble must not stop tracking
+                _LOGGER.warning("BPS position history flush failed: %s", e)
 
         try:
             tracked_entities = template.async_render()
@@ -1231,6 +1375,17 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
             },
         )
         await update_apitricords(hass, apitricords)
+        # Feed the position history. Stored in METRES in this floor's frame, so
+        # a later map re-export (which changes every pixel) cannot move the
+        # past; the pixel projection happens at render time. A floor with no
+        # scale has no metric frame, so its fixes are not recordable.
+        if scale:
+            try:
+                get_position_history(hass).record(
+                    entity, time.time(), avg_x / scale, avg_y / scale,
+                    lowest_floor_name, scale)
+            except Exception as e:  # history must never break tracking
+                _LOGGER.debug("Position history record failed for %s: %s", entity, e)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_nearest_zone", nearest_zone)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_floor", lowest_floor_name)
@@ -1275,6 +1430,15 @@ async def prune_stale_positions(hass):
         return
     apitricords = [e for e in apitricords if e["ent"] not in stale_ents]
     await update_apitricords(hass, apitricords)
+    # History is deliberately NOT pruned with the live entry: the point of it is
+    # to survive the absence. Just break the line so the scrubber does not draw
+    # a straight segment across the gap.
+    try:
+        hist = get_position_history(hass)
+        for ent in stale_ents:
+            hist.mark_gap(ent)
+    except Exception as e:
+        _LOGGER.debug("Position history gap mark failed: %s", e)
     for ent in sorted(stale_ents):
         # Drop the Kalman state too: a returning tracker should re-seed fresh
         # rather than predict velocity across the whole absence. Same for the
@@ -1697,6 +1861,7 @@ async def async_setup(hass, config):
             hass.http.register_view(BPSCalibrationAPI())
             hass.http.register_view(BPSSelfTestAPI(hass))
             hass.http.register_view(BPSTrackerTuneAPI())
+            hass.http.register_view(BPSHistoryAPI(hass))
             hass.data["bps_views_registered"] = True
 
         config_path = hass.config.path()
@@ -1757,6 +1922,9 @@ async def async_setup(hass, config):
         # a crash can no longer leave a 0-byte layout (issue #104).
         await migrate_legacy(hass)
         await load_bps_data(hass)
+        # Layout is loaded, so the history settings are readable: bring the
+        # retained window back before the tracking loop starts appending.
+        await restore_position_history(hass)
 
         jinja_code = """
         {{
@@ -1779,6 +1947,10 @@ async def async_setup(hass, config):
             update_task = hass.data.pop("bps_update_task", None)
             if update_task:
                 update_task.cancel()
+            try:
+                await flush_position_history(hass)
+            except Exception as e:
+                _LOGGER.debug("BPS position history final flush failed: %s", e)
             await async_shutdown_calibration(hass)
 
         hass.bus.async_listen_once("homeassistant_stop", handle_homeassistant_stop)
@@ -1806,6 +1978,15 @@ async def async_unload_entry(hass: HomeAssistant, entry):
     state_listener_unsub = hass.data.pop("bps_state_listener_unsub", None)
     if state_listener_unsub:
         state_listener_unsub()
+
+    # Get whatever the tracking loop buffered since the last 60 s flush onto
+    # disk before the task goes away. The in-memory ring survives an unload
+    # (hass.data[DOMAIN] is not cleared), so this is belt-and-braces, but an
+    # unload followed by a hard stop would otherwise lose that minute.
+    try:
+        await flush_position_history(hass)
+    except Exception as e:
+        _LOGGER.debug("BPS position history flush on unload failed: %s", e)
 
     cleanup_legacy_bps_registry_and_states(hass)
 
@@ -2594,6 +2775,126 @@ class BPSTrackerTuneAPI(HomeAssistantView):
             "ref_offset_db": applied,
             "distance_factor": round(10.0 ** (applied / (10.0 * PATH_LOSS_EXPONENT)), 4),
         })
+
+
+# Points returned per history query when the caller does not ask. Enough to
+# draw a smooth trail on a floor plan; the decimation still spans the window.
+HISTORY_DEFAULT_POINTS = 3000
+HISTORY_MAX_QUERY_POINTS = 20000
+
+
+class BPSHistoryAPI(HomeAssistantView):
+    """Past positions of a tracked device, for the map's time scrubber.
+
+    GET with no ``entity`` returns the index (what is retained, for whom, plus
+    the effective settings) so the panel can populate its picker and size the
+    slider. GET with an ``entity`` returns that tracker's trail over
+    [from, to], decimated to ``max_points``.
+
+    Coordinates come back in METRES in the named floor's frame together with
+    that floor's scale, so the panel projects them with the CURRENT map scale
+    and a re-exported floor plan does not misplace the past.
+    """
+
+    url = "/api/bps/history"
+    name = "api:bps:history"
+    requires_auth = True
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    @staticmethod
+    def _num(raw, default):
+        """A query param as a float, falling back rather than 400-ing on junk."""
+        if raw is None:
+            return default
+        try:
+            value = float(raw)
+        except (TypeError, ValueError, OverflowError):
+            return default
+        return value if math.isfinite(value) else default
+
+    async def get(self, request):
+        hass = self.hass
+        hist = get_position_history(hass)
+        hist.configure(history_mod.history_config(get_bps_data(hass)))
+        # Drop anything now outside the window before answering: record() only
+        # ages the tracker it touched, so a device that stopped reporting would
+        # otherwise still be served long past the configured retention.
+        hist.evict_all()
+        cfg = dict(hist.cfg)
+        now = time.time()
+
+        entity = request.query.get("entity")
+        if not entity:
+            files, size = await hass.async_add_executor_job(
+                history_mod.disk_usage, history_dir(hass))
+            return web.json_response({
+                "now": now,
+                "config": cfg,
+                "trackers": [dict(hist.retained(e) or {}, ent=e) for e in hist.entities()],
+                "disk": {"files": files, "bytes": size},
+                "pending": hist.pending_count(),
+                "dropped": hist.dropped_pending,
+            })
+
+        to = self._num(request.query.get("to"), now)
+        # Default window = the whole retained span, so the slider opens showing
+        # everything there is rather than an arbitrary slice.
+        frm = self._num(request.query.get("from"), to - cfg["max_age"])
+        if frm > to:
+            frm, to = to, frm
+        max_points = int(min(max(2.0, self._num(request.query.get("max_points"),
+                                                HISTORY_DEFAULT_POINTS)),
+                             HISTORY_MAX_QUERY_POINTS))
+
+        data = hist.query(entity, frm, to, max_points)
+        data["now"] = now
+        data["from"] = frm
+        data["to"] = to
+        data["retained"] = hist.retained(entity)
+        data["config"] = cfg
+        return web.json_response(data)
+
+    async def post(self, request):
+        """Clear the record — for one tracker, or all of it.
+
+        Settings live in the layout (``history_*``) and are written by the
+        normal floor-plan save; the only stateful action worth its own endpoint
+        is forgetting, which nothing else can do.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+        if not isinstance(body, dict):
+            return web.json_response({"error": "Body must be a JSON object"}, status=400)
+        if body.get("action") != "clear":
+            return web.json_response({"error": "Unsupported action"}, status=400)
+
+        hass = self.hass
+        hist = get_position_history(hass)
+        entity = body.get("entity")
+        if entity is not None and not isinstance(entity, str):
+            return web.json_response({"error": "entity must be a string"}, status=400)
+
+        dirpath = history_dir(hass)
+        # Under the flush lock from end to end: otherwise a flush that has
+        # already drained its rows lands after the delete and puts the
+        # forgotten positions straight back on disk.
+        async with _history_lock(hass):
+            # Forget in memory FIRST - this also drops that tracker's queued
+            # rows, so the next flush cannot write back what we just erased.
+            hist.forget(entity or None)
+            if entity:
+                # Segments are shared by every tracker, so a per-tracker clear
+                # cannot just delete files: rewrite them without its rows.
+                removed = await hass.async_add_executor_job(
+                    history_mod.drop_entity, dirpath, entity, hist.cfg)
+            else:
+                removed = await hass.async_add_executor_job(
+                    history_mod.clear_segments, dirpath)
+        return web.json_response({"cleared": entity or "*", "removed": removed})
 
 
 class BPSSelfTestAPI(HomeAssistantView):

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3339,19 +3339,29 @@ input[type="checkbox"] { accent-color: hsl(var(--sidebar-primary)); }
 }
 
 /* ---- Position-history time scrubber -------------------------------------
-   A strip directly above the map: device + span pickers and playback on the
+   A strip directly UNDER the map: device + span pickers and playback on the
    first row, the scrubber itself on the second. The slider is given the whole
    remaining width because dragging it IS the feature — the timestamp beside it
-   is fixed-width and tabular so the digits don't shuffle as you scrub. */
+   is fixed-width and tabular so the digits don't shuffle as you scrub. It is
+   always present (there is no toggle), so it is styled as part of the map's
+   furniture rather than as a panel that appears. */
 .bps-history-bar {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    margin-top: 12px;
+    margin-top: 10px;
     padding: 8px 10px;
     border: 1px solid hsl(var(--border));
     border-radius: 8px;
     background: hsl(var(--muted) / 0.45);
+}
+/* Names the strip, since it no longer has a labelled toggle to introduce it. */
+.bps-history-title {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
 }
 .bps-history-row {
     display: flex;

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3337,3 +3337,54 @@ input[type="checkbox"] { accent-color: hsl(var(--sidebar-primary)); }
     .bps-main { flex-direction: column; }
     .bps-sidebar { flex: 1 1 auto; width: 100%; position: static; max-height: none; }
 }
+
+/* ---- Position-history time scrubber -------------------------------------
+   A strip directly above the map: device + span pickers and playback on the
+   first row, the scrubber itself on the second. The slider is given the whole
+   remaining width because dragging it IS the feature — the timestamp beside it
+   is fixed-width and tabular so the digits don't shuffle as you scrub. */
+.bps-history-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 12px;
+    padding: 8px 10px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    background: hsl(var(--muted) / 0.45);
+}
+.bps-history-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+.bps-history-bar .bps-input {
+    width: auto;
+    min-width: 0;
+    flex: 0 1 auto;
+    height: 28px;
+    padding: 0 6px;
+    font-size: 12.5px;
+}
+.bps-history-bar .bps-btn { height: 28px; padding: 0 10px; font-size: 12px; }
+.bps-history-bar .bps-history-rate { flex: 0 0 auto; }
+/* Latched (following the newest fix) reads as "on", not as another button. */
+#historyLive.is-live {
+    border-color: hsl(142 70% 40%);
+    color: hsl(142 70% 40%);
+    font-weight: 600;
+}
+.bps-history-slider {
+    flex: 1 1 220px;
+    min-width: 140px;
+    accent-color: hsl(var(--sidebar-primary));
+}
+.bps-history-stamp {
+    flex: 0 0 auto;
+    font-size: 12.5px;
+    font-variant-numeric: tabular-nums;
+    color: hsl(var(--foreground));
+    white-space: nowrap;
+}
+.bps-history-status { margin: 0; }

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -176,20 +176,6 @@
                                         <span class="tooltip-text">Draw the path each tracked device has taken since tracking started, in that device's colour — brighter is more recent. The traces clear when a new tracking session starts.</span>
                                     </span>
                                 </span>
-                                <!-- Unlike "Trace path" (this session only, live), the
-                                     history overlay reads the recorded past, so it needs
-                                     no tracking session and shows whenever the Tracking
-                                     column does. -->
-                                <span id="historyControl">
-                                    <label class="bps-switch">
-                                        <input type="checkbox" id="historyToggle">
-                                        <span class="bps-slider"></span>
-                                        <span>History</span>
-                                    </label>
-                                    <span class="tooltip">❓
-                                        <span class="tooltip-text">Replay where a device has been. Pick the device and how far back to look, then drag the slider (or type a time) to move through the recording — the marker shows where it was at that moment and the trail brightens up to it. Play walks forward on its own; Live jumps back to now and follows. How long is kept is set by "Position history" above.</span>
-                                    </span>
-                                </span>
                                 <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
                                 <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>
@@ -229,11 +215,44 @@
                         <button type="button" id="switchFloorBtn" class="bps-btn bps-btn-outline bps-switch-floor" style="display: none"></button>
                     </div>
 
+                    <!-- Adjust-preview tuning knobs (summary + Snap + Square), a
+                         centered strip ABOVE the map so they don't cover the zones
+                         being adjusted; its ✓ Apply / ✕ Cancel live at the map's
+                         top-left corner with the other tools. Filled/shown by JS. -->
+                    <div id="bpsAdjustControls" class="bps-adjust-controls" style="display: none"></div>
+
+                    <div class="bps-canvas-wrap">
+                        <canvas id="canvas"></canvas>
+                        <!-- Colour-gradient key for the receiver-distances overlay. Shown by
+                             JS only while that overlay is actually drawing; click-through so it
+                             never blocks the map beneath it. -->
+                        <div id="recDistLegend" class="bps-recdist-legend" style="display: none" aria-hidden="true">
+                            <div class="bps-recdist-legend-title">Measured vs real distance</div>
+                            <div class="bps-recdist-legend-bar"></div>
+                            <div class="bps-recdist-legend-scale"><span>too short</span><span>accurate</span><span>too long</span></div>
+                            <div class="bps-recdist-legend-note"><span class="bps-recdist-legend-dash"></span>moved since calibration — recalibrate</div>
+                        </div>
+                        <button type="button" id="viewReset" title="Reset zoom and position">⤢ Reset view</button>
+                        <!-- Save/Cancel for the active layout tool, pinned to the map's
+                             top-left. Shown only while a tool is active; the tool buttons
+                             themselves keep their label and just start the tool. -->
+                        <div id="mapToolActions" style="display: none">
+                            <button type="button" id="saveToolBtn" title="Save current tool">✓ Save</button>
+                            <button type="button" id="cancelToolBtn" title="Cancel current tool (Esc)">✕ Cancel</button>
+                        </div>
+                    </div>
+
                     <!-- Time scrubber for the position-history overlay. Sits directly
-                         above the map so the marker and the time you are scrubbing to
-                         are read together. Shown by the History toggle. -->
-                    <div id="historyBar" class="bps-history-bar" style="display: none">
+                         UNDER the map: it is a control for what the map is showing, and
+                         reading the trail and the time you are scrubbing to together is
+                         easier when the eye travels down rather than back up past the
+                         floor plan. Always on screen — there is nothing to switch on. -->
+                    <div id="historyBar" class="bps-history-bar">
                         <div class="bps-history-row">
+                            <span class="bps-history-title">History</span>
+                            <span class="tooltip">❓
+                                <span class="tooltip-text">Replay where a device has been. Pick the device and how far back to look, then drag the slider (or type a time) to move through the recording — the marker shows where it was at that moment and the trail brightens up to it. Play walks forward on its own; Live jumps back to now and follows. Clicking a device (in the list above or its beacon on the map) points this at that device. How long is kept is set by "Position history" in the Tracking column.</span>
+                            </span>
                             <select id="historyDevice" class="bps-input" title="Which device's history to replay"></select>
                             <select id="historySpan" class="bps-input" title="How far back to load">
                                 <option value="900">Last 15 min</option>
@@ -261,32 +280,6 @@
                         <div id="historyStatus" class="bps-hint bps-history-status"></div>
                     </div>
 
-                    <!-- Adjust-preview tuning knobs (summary + Snap + Square), a
-                         centered strip ABOVE the map so they don't cover the zones
-                         being adjusted; its ✓ Apply / ✕ Cancel live at the map's
-                         top-left corner with the other tools. Filled/shown by JS. -->
-                    <div id="bpsAdjustControls" class="bps-adjust-controls" style="display: none"></div>
-
-                    <div class="bps-canvas-wrap">
-                        <canvas id="canvas"></canvas>
-                        <!-- Colour-gradient key for the receiver-distances overlay. Shown by
-                             JS only while that overlay is actually drawing; click-through so it
-                             never blocks the map beneath it. -->
-                        <div id="recDistLegend" class="bps-recdist-legend" style="display: none" aria-hidden="true">
-                            <div class="bps-recdist-legend-title">Measured vs real distance</div>
-                            <div class="bps-recdist-legend-bar"></div>
-                            <div class="bps-recdist-legend-scale"><span>too short</span><span>accurate</span><span>too long</span></div>
-                            <div class="bps-recdist-legend-note"><span class="bps-recdist-legend-dash"></span>moved since calibration — recalibrate</div>
-                        </div>
-                        <button type="button" id="viewReset" title="Reset zoom and position">⤢ Reset view</button>
-                        <!-- Save/Cancel for the active layout tool, pinned to the map's
-                             top-left. Shown only while a tool is active; the tool buttons
-                             themselves keep their label and just start the tool. -->
-                        <div id="mapToolActions" style="display: none">
-                            <button type="button" id="saveToolBtn" title="Save current tool">✓ Save</button>
-                            <button type="button" id="cancelToolBtn" title="Cancel current tool (Esc)">✕ Cancel</button>
-                        </div>
-                    </div>
                 </div>
 
                 <aside class="bps-sidebar">

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -112,6 +112,28 @@
                                 </div>
                                 <div id="refTrimHint" class="bps-hint">Applies live. Negative reads nearer, positive farther.</div>
                             </div>
+                            <!-- How long the position history keeps recording for.
+                                 The record is kept by BPS itself (under .storage, not
+                                 in the recorder database) so this window can be set in
+                                 hours rather than the recorder's whole-days purge, and
+                                 so a floor-plan re-export can't move the past — points
+                                 are stored in metres, not pixels. -->
+                            <div class="bps-field">
+                                <label class="bps-label">Position history</label>
+                                <div class="bps-viewrow bps-steprow">
+                                    <select id="historyMaxAge" class="bps-input" title="How far back the map's time scrubber can go">
+                                        <option value="0">Off</option>
+                                        <option value="3600">1 hour</option>
+                                        <option value="21600">6 hours</option>
+                                        <option value="43200">12 hours</option>
+                                        <option value="86400">24 hours</option>
+                                        <option value="259200">3 days</option>
+                                        <option value="604800">7 days</option>
+                                    </select>
+                                    <button type="button" id="historyClear" class="bps-btn bps-btn-outline" title="Forget every recorded position">Clear</button>
+                                </div>
+                                <div id="historyUsage" class="bps-hint">Persisted with Save Floor Plan.</div>
+                            </div>
                             <!-- Colour-coded list of the devices being tracked. Each row's
                                  swatch matches that device's on-map icon, circles and path;
                                  click a row to make the tracker-icon controls target it, × to
@@ -154,6 +176,20 @@
                                         <span class="tooltip-text">Draw the path each tracked device has taken since tracking started, in that device's colour — brighter is more recent. The traces clear when a new tracking session starts.</span>
                                     </span>
                                 </span>
+                                <!-- Unlike "Trace path" (this session only, live), the
+                                     history overlay reads the recorded past, so it needs
+                                     no tracking session and shows whenever the Tracking
+                                     column does. -->
+                                <span id="historyControl">
+                                    <label class="bps-switch">
+                                        <input type="checkbox" id="historyToggle">
+                                        <span class="bps-slider"></span>
+                                        <span>History</span>
+                                    </label>
+                                    <span class="tooltip">❓
+                                        <span class="tooltip-text">Replay where a device has been. Pick the device and how far back to look, then drag the slider (or type a time) to move through the recording — the marker shows where it was at that moment and the trail brightens up to it. Play walks forward on its own; Live jumps back to now and follows. How long is kept is set by "Position history" above.</span>
+                                    </span>
+                                </span>
                                 <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
                                 <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>
@@ -191,6 +227,38 @@
                              (+ Switch button) when it isn't the floor being viewed. -->
                         <span id="zonefloor" class="bps-zonefloor"></span>
                         <button type="button" id="switchFloorBtn" class="bps-btn bps-btn-outline bps-switch-floor" style="display: none"></button>
+                    </div>
+
+                    <!-- Time scrubber for the position-history overlay. Sits directly
+                         above the map so the marker and the time you are scrubbing to
+                         are read together. Shown by the History toggle. -->
+                    <div id="historyBar" class="bps-history-bar" style="display: none">
+                        <div class="bps-history-row">
+                            <select id="historyDevice" class="bps-input" title="Which device's history to replay"></select>
+                            <select id="historySpan" class="bps-input" title="How far back to load">
+                                <option value="900">Last 15 min</option>
+                                <option value="3600" selected>Last hour</option>
+                                <option value="21600">Last 6 hours</option>
+                                <option value="86400">Last 24 hours</option>
+                                <option value="604800">Last 7 days</option>
+                            </select>
+                            <input type="datetime-local" id="historyAt" class="bps-input" step="1"
+                                   title="Jump to a moment (loads the window around it)">
+                            <button type="button" id="historyPlay" class="bps-btn bps-btn-outline" title="Play / pause the replay">▶</button>
+                            <select id="historyRate" class="bps-input bps-history-rate" title="Replay speed">
+                                <option value="1">1×</option>
+                                <option value="10">10×</option>
+                                <option value="60" selected>60×</option>
+                                <option value="600">600×</option>
+                            </select>
+                            <button type="button" id="historyLive" class="bps-btn bps-btn-outline is-live" title="Jump to now and keep following">Live</button>
+                        </div>
+                        <div class="bps-history-row">
+                            <input type="range" id="historySlider" class="bps-history-slider"
+                                   min="0" max="0" value="0" step="1" title="Scrub through the loaded window">
+                            <span id="historyStamp" class="bps-history-stamp">—</span>
+                        </div>
+                        <div id="historyStatus" class="bps-hint bps-history-status"></div>
                     </div>
 
                     <!-- Adjust-preview tuning knobs (summary + Snap + Square), a

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -176,6 +176,22 @@
                                         <span class="tooltip-text">Draw the path each tracked device has taken since tracking started, in that device's colour — brighter is more recent. The traces clear when a new tracking session starts.</span>
                                     </span>
                                 </span>
+                                <!-- Hides the history scrubber (and its trail) under the
+                                     map. On by default: the scrubber is a standing map
+                                     control, not something you switch on to use — this is
+                                     here for when it is in the way. Sits with the other
+                                     overlay toggles rather than on the bar itself, so the
+                                     bar can go away completely. -->
+                                <span id="historyControl">
+                                    <label class="bps-switch">
+                                        <input type="checkbox" id="historyToggle" checked>
+                                        <span class="bps-slider"></span>
+                                        <span>History</span>
+                                    </label>
+                                    <span class="tooltip">❓
+                                        <span class="tooltip-text">Show or hide the position-history scrubber under the map, and the recorded trail it draws. On by default; hiding it also stops it polling.</span>
+                                    </span>
+                                </span>
                                 <button type="button" id="starttrack" class="bps-btn bps-btn-primary" style="display: none">Start tracking</button>
                                 <button type="button" id="stoptrack" class="bps-btn bps-btn-primary" style="display: none">Stop tracking</button>
                             </div>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -644,6 +644,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             tracePointsByDevice.clear(); // each session traces from its own start
             lastTracks.clear();
             focusedDevice = null;
+            // The legend paints the isolated row differently; clearing the
+            // isolation without rebuilding it leaves a row claiming to be
+            // isolated when nothing is.
+            if (refreshTrackLegend) refreshTrackLegend();
             starttrackbtn.style.display = "none";
             stoptrackbtn.style.display = "";
             if (circleControl) circleControl.style.display = ""; // reveal while tracking
@@ -655,6 +659,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     stoptrackstat = false;
                     lastTracks.clear();
                     focusedDevice = null;
+                    if (refreshTrackLegend) refreshTrackLegend();
                     starttrackbtn.style.display = trackedDevices.length ? "" : "none";
                     stoptrackbtn.style.display = "none";
                     if (circleControl) circleControl.style.display = "none"; // hide when not tracking
@@ -762,6 +767,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     // device. Cleared when the device is no longer tracked or a session
     // starts/stops.
     let focusedDevice = null;
+
+    // setActiveDevice/renderTrackLegend are declared one scope deeper (inside
+    // the setup block), but the map's click handling and the history scrubber
+    // both live out here. A hoisted `var` the inner scope fills in bridges the
+    // two without moving either.
+    var makeDeviceActive = null;
+    var refreshTrackLegend = null;
 
     // Icon world size. Fixed to the canvas normally; while tracking it is zoom-
     // compensated so icons don't balloon when you zoom in — but only 2/3 as
@@ -1622,8 +1634,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     // hoisted as undefined, so the overlay simply no-ops until the block below
     // has initialised, where a const would throw on the temporal-dead-zone read.
     var historyReady = false;
-    var historyRestoreOnInit = null;   // set when the toggle was left on
-    const historyToggle = document.getElementById("historyToggle");
     const historyBar = document.getElementById("historyBar");
     const historyDeviceSel = document.getElementById("historyDevice");
     const historySpanSel = document.getElementById("historySpan");
@@ -1649,8 +1659,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         loading: false,
         retention: null, // server's configured max_age, for the span options
     };
-
-    const historyOn = () => !!(historyToggle && historyToggle.checked);
 
     // Colour for the replayed device. deviceBaseHue only knows devices being
     // tracked in THIS tab and returns hue 0 (red) for everything else - which
@@ -1774,14 +1782,61 @@ document.addEventListener('DOMContentLoaded', async () => {
             opt.textContent = "No recorded devices";
             historyDeviceSel.appendChild(opt);
         }
+        const prevEnt = historyState.ent;
         historyState.ent = names.includes(wanted) ? wanted : (names[0] || null);
         historyDeviceSel.value = historyState.ent || "";
+        // The picker just moved itself off the device whose window is on screen
+        // - it stopped being tracked before recording anything, or its last
+        // point aged out of the index. Drop that window so the caller's
+        // `!historyState.data` reload fires, instead of leaving the bar and the
+        // trail describing a device the picker no longer names.
+        if (prevEnt && historyState.ent !== prevEnt) {
+            historyState.data = null;
+            historyState.idx = 0;
+        }
+    }
+
+    // Point the scrubber at a device the user just picked - a legend row, or a
+    // beacon on the map. Only while History is open: clicking a beacon should
+    // not start loading a movement record nobody asked to see.
+    //
+    // The historyReady guard has to come FIRST and short-circuit: this is
+    // called from setActiveDevice, which runs while tracked devices are
+    // restored on load - before the consts below this point in the closure
+    // exist, so touching one of them here would throw on the dead zone.
+    function historyFollowDevice(ent) {
+        if (!historyReady || !ent) return;
+        if (historyState.ent === ent) return;   // re-click / focus toggle-off
+        if (historyDeviceSel) {
+            // The index is re-polled every ~30 s, so a device tracked seconds
+            // ago may not be an option yet; add it rather than silently fail
+            // to select it (a <select> drops an assignment it has no option for).
+            const opts = [...historyDeviceSel.options];
+            const placeholder = opts.find(o => !o.value);
+            if (placeholder) placeholder.remove();
+            if (!opts.some(o => o.value === ent)) {
+                const opt = document.createElement("option");
+                opt.value = ent;
+                opt.textContent = ent;
+                historyDeviceSel.appendChild(opt);
+            }
+            historyDeviceSel.value = ent;
+        }
+        historyState.ent = ent;
+        historyState.data = null;               // the old device's trail is not this one's
+        historyState.idx = 0;
+        historyStopPlayback();
+        // Repaint NOW rather than when the fetch lands: otherwise the previous
+        // device's trail stays on the map for the whole round trip, and stays
+        // there for good if the request fails.
+        if (img.naturalWidth > 0) redrawAll();
+        historyLoad();
     }
 
     // Resolves to true when this call actually applied a window (callers that
     // then move the cursor must not act on a failed or superseded load).
     async function historyLoad() {
-        if (!historyOn() || !historyState.ent) {
+        if (!historyState.ent) {
             // Nothing selected: drop the previous device's window rather than
             // keep drawing its trail under a picker that no longer names it.
             historyState.data = null;
@@ -1821,12 +1876,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         const prevTime = historyState.data && historyState.data.t
             && historyState.data.t[historyState.idx];
         historyState.data = data;
-        if (wasLive || !Number.isFinite(prevTime)) {
+        if (wasLive) {
             historyState.idx = Math.max(0, (data.count || 0) - 1);
-        } else {
+        } else if (Number.isFinite(prevTime)) {
             // Keep pointing at the same MOMENT across a reload, not the same
             // index — decimation changes what index N means.
             historyState.idx = historyIndexAt(prevTime);
+        } else if (Number.isFinite(historyState.anchor)) {
+            // Scrubbed back, but with no previous window to carry a moment
+            // from: a device switch cleared it. Land on the moment under
+            // review — the window was loaded centred on it. Otherwise clicking
+            // a second device to see where IT was at 14:05 silently shows you
+            // 14:35 (the end of a window centred on 14:05) and says nothing.
+            historyState.idx = historyIndexAt(historyState.anchor);
+        } else {
+            historyState.idx = Math.max(0, (data.count || 0) - 1);
         }
         historyRender();
         if (img.naturalWidth > 0) redrawAll();
@@ -1861,15 +1925,25 @@ document.addEventListener('DOMContentLoaded', async () => {
             historyAtInput.value = historyToLocalInput(ts);
         }
         const floorName = data.floors[data.f[Math.min(historyState.idx, count - 1)]] || "";
-        const offFloor = floorName && !sameFloorName(floorName, SelMapName);
         const parts = [
             `${count} point${count === 1 ? "" : "s"}`,
             historyAgeText((data.now || Date.now() / 1000) - ts),
         ];
         if (data.stride > 1) parts.push(`1 in ${data.stride} shown`);
-        if (offFloor) parts.push(`on ${floorName} — not this floor`);
-        const scale = (currentFloor() || {}).scale;
-        if (!scale) parts.push("this floor has no scale set, so the trail can't be drawn");
+        // The bar is always on screen, so it is the first thing seen on a fresh
+        // panel - before any floor is chosen. Complaining that the fix is "not
+        // this floor" or that "this floor has no scale" is nonsense there, so
+        // say the one useful thing instead: pick a floor.
+        if (!SelMapName) {
+            parts.push("select a floor to draw the trail");
+        } else {
+            if (floorName && !sameFloorName(floorName, SelMapName)) {
+                parts.push(`on ${floorName} — not this floor`);
+            }
+            if (!(currentFloor() || {}).scale) {
+                parts.push("this floor has no scale set, so the trail can't be drawn");
+            }
+        }
         if (historyStatus) historyStatus.textContent = parts.filter(Boolean).join(" · ");
     }
 
@@ -1877,7 +1951,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Drawn whenever the toggle is on, with or without a live tracking session:
     // reviewing yesterday afternoon shouldn't require starting one.
     function drawHistoryOverlay() {
-        if (!historyReady || !historyOn()) return;
+        if (!historyReady) return;
         const data = historyState.data;
         if (!data || !data.count) return;
         const floor = currentFloor();
@@ -1970,7 +2044,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // on a floor switch and does not come back until something else triggers a
     // full repaint - and the status line keeps naming the previous floor.
     function historyAfterFloorChange() {
-        if (!historyReady || !historyOn()) return;
+        if (!historyReady) return;
         historyRender();
         drawHistoryOverlay();
     }
@@ -2029,10 +2103,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (historyRefreshTimer) return;
         let ticks = 0;
         historyRefreshTimer = setInterval(() => {
-            if (!historyOn()) return;
-            // Re-poll the index every ~30 s: the picker was otherwise filled
-            // once, on toggle-on, so a panel opened before the first fix was
-            // recorded stayed stuck on "No recorded devices" forever.
+            // Re-poll the index every ~30 s: the picker is otherwise filled
+            // once, at startup, so a panel opened before the first fix was
+            // recorded would stay stuck on "No recorded devices" forever.
             if (++ticks % 6 === 0) {
                 historyLoadDevices().then(() => {
                     if (!historyState.data && historyState.ent) historyLoad();
@@ -2044,40 +2117,41 @@ document.addEventListener('DOMContentLoaded', async () => {
         }, HISTORY_REFRESH_MS);
     }
 
-    function historyStopRefresh() {
-        if (historyRefreshTimer) { clearInterval(historyRefreshTimer); historyRefreshTimer = null; }
-    }
-
     // --- wiring --------------------------------------------------------------
-    if (historyToggle) {
-        historyToggle.checked = localStorage.getItem("bpsHistory") === "on"; // off by default
-        const applyHistoryVisibility = async () => {
-            const on = historyToggle.checked;
-            if (historyBar) historyBar.style.display = on ? "" : "none";
-            if (on) {
-                await historyLoadDevices();
-                historySetLive(true);
-                historyStartRefresh();
-            } else {
-                historyStopPlayback();
-                historyStopRefresh();
-                if (img.naturalWidth > 0) redrawAll();
-            }
-        };
-        historyToggle.addEventListener("change", () => {
-            localStorage.setItem("bpsHistory", historyToggle.checked ? "on" : "off");
-            applyHistoryVisibility();
-        });
-        // The first application is deferred to the end of this block (below
-        // `historyReady = true`) so its opening repaint actually draws.
-        historyRestoreOnInit = historyToggle.checked ? applyHistoryVisibility : null;
+    // The scrubber is a permanent map control - it has no on/off switch, so
+    // this runs once at startup rather than on a toggle. Deferred to the end of
+    // this block (below `historyReady = true`) so its opening repaint draws.
+    async function historyInit() {
+        await historyLoadDevices();
+        historySetLive(true);
+        historyStartRefresh();
     }
 
     if (historyDeviceSel) {
         historyDeviceSel.addEventListener("change", () => {
+            // Set state BEFORE makeDeviceActive: setActiveDevice calls back
+            // into historyFollowDevice, which no-ops once the device matches.
             historyState.ent = historyDeviceSel.value || null;
             historyState.data = null;
+            historyState.idx = 0;
             historyStopPlayback();
+            // Highlight it in the legend too, so the scrubber and the map agree
+            // on which device is being looked at. Only for a TRACKED device:
+            // making an untracked one active would point the icon / height /
+            // ref-trim controls at a device the legend cannot even show.
+            if (makeDeviceActive && historyState.ent
+                && trackedDevices.indexOf(historyState.ent) >= 0) {
+                // If the map is ALREADY isolating some other device, move the
+                // isolation across rather than leave the two disagreeing about
+                // which device is being looked at. Never start isolating: that
+                // would hide the other live beacons as a side effect of using
+                // the scrubber.
+                if (focusedDevice && focusedDevice !== historyState.ent) {
+                    focusedDevice = historyState.ent;
+                    if (img.naturalWidth > 0) redrawAll();
+                }
+                makeDeviceActive(historyState.ent);
+            }
             historyLoad();
         });
     }
@@ -2173,7 +2247,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     historyReady = true;
-    if (historyRestoreOnInit) historyRestoreOnInit();
+    historyInit();
 
     if (historyClearBtn) {
         historyClearBtn.addEventListener("click", async () => {
@@ -2334,7 +2408,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Make a device the active one: the icon selector/upload target it, and
         // its legend row is highlighted. Reflects its saved icon in the selector.
-        function setActiveDevice(entKey) {
+        // `follow` is false for the one caller that is NOT a user pick: the
+        // fallback after the active device is removed from tracking. History
+        // outliving the tracking session is the whole premise of the record,
+        // so untracking a device must not throw away the window being replayed.
+        function setActiveDevice(entKey, follow = true) {
             activeDevice = entKey || "";
             if (trackerIconSelector && activeDevice) {
                 const icon = trackerIconFor(activeDevice);
@@ -2348,6 +2426,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 trackerHeightInput.value = h === null ? "" : String(h);
             }
             syncRefTrimUI(activeDevice);
+            // Picking a device (legend row, or adding one) also points the
+            // history scrubber at it, so the trail on screen is the trail of
+            // the device you just clicked. Ignores the empty key used when the
+            // last tracked device is removed - that must not blank the record
+            // you were looking at.
+            if (follow) historyFollowDevice(activeDevice);
         }
 
         // Start/stop button visibility follows whether anything is tracked (but
@@ -2406,6 +2490,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
         }
 
+        // Hand the outer scope (map beacon clicks, the history picker) a way
+        // to make a device active - see makeDeviceActive above.
+        makeDeviceActive = (entKey) => {
+            setActiveDevice(entKey);
+            renderTrackLegend();
+        };
+        refreshTrackLegend = renderTrackLegend;
+
         function addTrackedDevice(entKey) {
             if (!entKey) return;
             if (!trackedDevices.includes(entKey)) trackedDevices.push(entKey);
@@ -2419,7 +2511,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             lastTracks.delete(entKey);
             tracePointsByDevice.delete(entKey);
             if (focusedDevice === entKey) focusedDevice = null;
-            if (activeDevice === entKey) setActiveDevice(trackedDevices[0] || "");
+            if (activeDevice === entKey) setActiveDevice(trackedDevices[0] || "", false);
             renderTrackLegend();
             if (trackedDevices.length === 0 && pollTrackActive) stoptrackfunc();
             refreshTrackButtons();
@@ -2528,6 +2620,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                     bpsToast("Choose an icon file first.");
                     return;
                 }
+                // Pin the device this upload is FOR. activeDevice can change
+                // while the POST is in flight - clicking a beacon on the map
+                // now retargets it too - and the icon must land on the device
+                // the user was configuring, not whoever is active when the
+                // response happens to arrive. (Same convention as applyRefTrim.)
+                const target = activeDevice;
                 const uploadData = new FormData();
                 uploadData.append("icon", iconFile);
                 try {
@@ -2545,11 +2643,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                         return;
                     }
                     ensureIconOption(payload.icon_url, payload.icon_name || payload.icon_url);
-                    if (trackerIconSelector) {
+                    // Only move the selector if it is still showing that device.
+                    if (trackerIconSelector && target === activeDevice) {
                         trackerIconSelector.value = payload.icon_url;
                     }
                     ensureTrackerIconsStore();
-                    finalcords.tracker_icons[activeDevice] = payload.icon_url;
+                    finalcords.tracker_icons[target] = payload.icon_url;
                     savebuttondiv.appendChild(saveButton);
                     if (pollTrackActive && img.naturalWidth > 0) redrawAll();
                     bpsToast("Tracker icon uploaded. Click Save Floor Plan to persist.");
@@ -4074,12 +4173,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         // takes priority over the receiver/link/empty-space handling below.
         if (devTarget) {
             focusedDevice = devTarget === focusedDevice ? null : devTarget;
+            // Same gesture as clicking its legend row, so make it mean the same
+            // thing: this is now the device the per-tracker controls and the
+            // history scrubber are about.
+            if (makeDeviceActive) makeDeviceActive(devTarget);
             redrawAll();
             return;
         }
         // Any other plain click reverts beacon isolation ("show all again")...
         let changed = false;
-        if (focusedDevice) { focusedDevice = null; changed = true; }
+        if (focusedDevice) {
+            focusedDevice = null;
+            changed = true;
+            // The legend paints the isolated row differently, so it has to be
+            // rebuilt here too - otherwise it keeps claiming a device is
+            // isolated after the click that un-isolated it.
+            if (refreshTrackLegend) refreshTrackLegend();
+        }
         if (target) {
             // Clicked a receiver: focus it (only it + its links stay); clicking
             // the focused one again clears it. Any single-link highlight clears.

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -245,11 +245,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         // then goes on top so the live fix still updates while editing.
         if (drawAreaButton.dataset.active === 'true' || drawSubZoneButton.dataset.active === 'true') {
             drawZonePreview();
+            drawHistoryOverlay();
             drawTrackOverlay();
             return;
         }
         clearCanvas();
         drawElements();
+        drawHistoryOverlay();
         drawTrackOverlay();
     }
 
@@ -1604,6 +1606,601 @@ document.addEventListener('DOMContentLoaded', async () => {
         ctx.restore();
     }
 
+    // =================================================================
+    // Position history — replaying where a device has been
+    // =================================================================
+    // The "Trace path" overlay above only knows this browser session. This one
+    // reads /api/bps/history, which the integration keeps on disk, so it
+    // survives a reload, a restart, and being away from the tab entirely.
+    //
+    // Points arrive in METRES in their own floor's frame (plus the scale that
+    // was in force when they were recorded); they are projected here with the
+    // CURRENT floor's scale, so re-exporting a floor plan at a different
+    // resolution does not move the past.
+    // `var`, not const: redrawAll() lives near the top of this closure and can
+    // fire (via selectExistingMap) before these declarations have run. A var is
+    // hoisted as undefined, so the overlay simply no-ops until the block below
+    // has initialised, where a const would throw on the temporal-dead-zone read.
+    var historyReady = false;
+    var historyRestoreOnInit = null;   // set when the toggle was left on
+    const historyToggle = document.getElementById("historyToggle");
+    const historyBar = document.getElementById("historyBar");
+    const historyDeviceSel = document.getElementById("historyDevice");
+    const historySpanSel = document.getElementById("historySpan");
+    const historyAtInput = document.getElementById("historyAt");
+    const historySlider = document.getElementById("historySlider");
+    const historyStamp = document.getElementById("historyStamp");
+    const historyStatus = document.getElementById("historyStatus");
+    const historyPlayBtn = document.getElementById("historyPlay");
+    const historyRateSel = document.getElementById("historyRate");
+    const historyLiveBtn = document.getElementById("historyLive");
+
+    const HISTORY_REFRESH_MS = 5000;   // while latched to Live
+    const HISTORY_MAX_POINTS = 3000;   // server decimates to this, spanning the window
+
+    const historyState = {
+        ent: null,
+        data: null,      // last /api/bps/history response for `ent`
+        idx: 0,          // slider position (index into data.t)
+        live: true,      // follow the newest fix
+        playing: false,
+        anchor: null,    // seconds; centre of the window when not live
+        seq: 0,          // in-flight guard: only the newest response is applied
+        loading: false,
+        retention: null, // server's configured max_age, for the span options
+    };
+
+    const historyOn = () => !!(historyToggle && historyToggle.checked);
+
+    // Colour for the replayed device. deviceBaseHue only knows devices being
+    // tracked in THIS tab and returns hue 0 (red) for everything else - which
+    // on a fresh page load is every device with a history. Fall back to a hash
+    // of the name so the colour is at least stable and per-device.
+    function historyHue(ent) {
+        if (!ent) return 0;
+        if (trackedDevices.indexOf(ent) >= 0) return deviceBaseHue(ent);
+        let h = 0;
+        for (let i = 0; i < ent.length; i++) h = (h * 31 + ent.charCodeAt(i)) % 360;
+        return Math.round((h * GOLDEN_ANGLE) % 360);
+    }
+
+    // --- time helpers --------------------------------------------------------
+    // `datetime-local` speaks LOCAL wall-clock with no zone, so both directions
+    // have to go through the Date constructor rather than toISOString (which
+    // would silently shift the picker by the UTC offset).
+    function historyToLocalInput(ts) {
+        const d = new Date(ts * 1000);
+        const p = (n) => String(n).padStart(2, "0");
+        return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}` +
+               `T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+    }
+    function historyFromLocalInput(value) {
+        if (!value) return null;
+        const ms = new Date(value).getTime();
+        return Number.isFinite(ms) ? ms / 1000 : null;
+    }
+    function historyStampText(ts) {
+        const d = new Date(ts * 1000);
+        const p = (n) => String(n).padStart(2, "0");
+        const today = new Date();
+        const sameDay = d.getFullYear() === today.getFullYear()
+            && d.getMonth() === today.getMonth() && d.getDate() === today.getDate();
+        const clock = `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+        return sameDay ? clock : `${p(d.getMonth() + 1)}-${p(d.getDate())} ${clock}`;
+    }
+    function historyAgeText(secs) {
+        if (!Number.isFinite(secs) || secs < 0) return "";
+        if (secs < 60) return `${Math.round(secs)}s ago`;
+        if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+        if (secs < 86400) return `${(secs / 3600).toFixed(1)}h ago`;
+        return `${(secs / 86400).toFixed(1)}d ago`;
+    }
+
+    // Index of the last point at or before `ts` (binary search — the arrays can
+    // hold thousands of points and this runs on every playback frame).
+    function historyIndexAt(ts) {
+        const t = historyState.data && historyState.data.t;
+        if (!t || !t.length) return 0;
+        let lo = 0, hi = t.length - 1;
+        if (ts <= t[0]) return 0;
+        if (ts >= t[hi]) return hi;
+        while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1;
+            if (t[mid] <= ts) lo = mid; else hi = mid - 1;
+        }
+        return lo;
+    }
+
+    // --- loading -------------------------------------------------------------
+    function historySpanSecs() {
+        const v = parseFloat(historySpanSel && historySpanSel.value);
+        return Number.isFinite(v) && v > 0 ? v : 3600;
+    }
+
+    // Hide span options the server will not have data for: offering "Last 7
+    // days" against a 6 h retention just produces an empty-looking scrubber.
+    function historyApplyRetention(maxAge) {
+        historyState.retention = maxAge;
+        if (!historySpanSel || !Number.isFinite(maxAge) || maxAge <= 0) return;
+        // Keep every option up to the retention PLUS the first one past it,
+        // so "show me the whole record" is always one click away. Hiding
+        // everything longer than the window meant a 12 h retention offered
+        // nothing above 6 h — half the record unreachable in one view.
+        const opts = [...historySpanSel.options];
+        let firstOver = null;
+        opts.forEach(opt => {
+            const secs = parseFloat(opt.value);
+            if (secs > maxAge && firstOver === null) firstOver = opt.value;
+        });
+        let widest = null;
+        opts.forEach(opt => {
+            const secs = parseFloat(opt.value);
+            const usable = secs <= maxAge || opt.value === firstOver;
+            opt.hidden = !usable && opt.value !== historySpanSel.value;
+            if (usable) widest = opt.value;
+        });
+        if (widest && historySpanSel.selectedOptions[0]
+            && historySpanSel.selectedOptions[0].hidden) {
+            historySpanSel.value = widest;
+        }
+    }
+
+    async function historyLoadDevices() {
+        if (!historyDeviceSel) return;
+        let index = null;
+        try {
+            const res = await bpsFetch("/api/bps/history");
+            if (res.ok) index = await res.json();
+        } catch (e) { /* keep whatever the picker already offers */ }
+        if (index && index.config) historyApplyRetention(index.config.max_age);
+        // Devices with something recorded, plus anything currently tracked (so a
+        // freshly added device is selectable before its first point lands).
+        const recorded = (index && Array.isArray(index.trackers) ? index.trackers : [])
+            .map(t => t.ent).filter(Boolean);
+        const names = [...new Set([...recorded, ...trackedDevices])];
+        const wanted = historyState.ent
+            || (activeDevice && names.includes(activeDevice) ? activeDevice : null)
+            || names[0] || null;
+        historyDeviceSel.innerHTML = "";
+        names.forEach(name => {
+            const opt = document.createElement("option");
+            opt.value = name;
+            opt.textContent = name;
+            historyDeviceSel.appendChild(opt);
+        });
+        if (names.length === 0) {
+            const opt = document.createElement("option");
+            opt.value = "";
+            opt.textContent = "No recorded devices";
+            historyDeviceSel.appendChild(opt);
+        }
+        historyState.ent = names.includes(wanted) ? wanted : (names[0] || null);
+        historyDeviceSel.value = historyState.ent || "";
+    }
+
+    // Resolves to true when this call actually applied a window (callers that
+    // then move the cursor must not act on a failed or superseded load).
+    async function historyLoad() {
+        if (!historyOn() || !historyState.ent) {
+            // Nothing selected: drop the previous device's window rather than
+            // keep drawing its trail under a picker that no longer names it.
+            historyState.data = null;
+            historyState.idx = 0;
+            historyRender();
+            if (img.naturalWidth > 0) redrawAll();
+            return false;
+        }
+        const span = historySpanSecs();
+        const now = Date.now() / 1000;
+        // Live follows the newest fix; otherwise the window is CENTRED on the
+        // moment being looked at, which is what "see movements around that
+        // time" means — clamped so asking for a recent moment doesn't waste
+        // half the window on the future. The isFinite guard is load-bearing:
+        // `null + span / 2` is a number (0 + span/2), which would silently ask
+        // for a window near the epoch instead of failing.
+        const anchor = Number.isFinite(historyState.anchor) ? historyState.anchor : now;
+        const to = historyState.live ? now : Math.min(now, anchor + span / 2);
+        const from = to - span;
+        const seq = ++historyState.seq;
+        historyState.loading = true;
+        let data = null;
+        try {
+            const res = await bpsFetch(`/api/bps/history?entity=${encodeURIComponent(historyState.ent)}`
+                + `&from=${from.toFixed(0)}&to=${to.toFixed(0)}&max_points=${HISTORY_MAX_POINTS}`);
+            if (res.ok) data = await res.json();
+        } catch (e) { /* leave the previous window on screen */ }
+        // A slower earlier request must not overwrite a newer one's result.
+        if (seq !== historyState.seq) return false;
+        historyState.loading = false;
+        if (!data) {
+            if (historyStatus) historyStatus.textContent = "Could not load history.";
+            return false;
+        }
+        if (data.config) historyApplyRetention(data.config.max_age);
+        const wasLive = historyState.live;
+        const prevTime = historyState.data && historyState.data.t
+            && historyState.data.t[historyState.idx];
+        historyState.data = data;
+        if (wasLive || !Number.isFinite(prevTime)) {
+            historyState.idx = Math.max(0, (data.count || 0) - 1);
+        } else {
+            // Keep pointing at the same MOMENT across a reload, not the same
+            // index — decimation changes what index N means.
+            historyState.idx = historyIndexAt(prevTime);
+        }
+        historyRender();
+        if (img.naturalWidth > 0) redrawAll();
+        return true;
+    }
+
+    // --- rendering the bar ---------------------------------------------------
+    function historyRender() {
+        if (!historyBar) return;
+        const data = historyState.data;
+        const count = data && data.count ? data.count : 0;
+        if (historySlider) {
+            historySlider.max = String(Math.max(0, count - 1));
+            historySlider.disabled = count === 0;
+            historySlider.value = String(Math.min(historyState.idx, Math.max(0, count - 1)));
+        }
+        if (historyLiveBtn) historyLiveBtn.classList.toggle("is-live", historyState.live);
+        if (historyPlayBtn) historyPlayBtn.textContent = historyState.playing ? "❚❚" : "▶";
+        if (!count) {
+            if (historyStamp) historyStamp.textContent = "—";
+            if (historyStatus) {
+                historyStatus.textContent = historyState.ent
+                    ? "Nothing recorded in this window."
+                    : "No device selected.";
+            }
+            return;
+        }
+        const ts = data.t[Math.min(historyState.idx, count - 1)];
+        if (historyStamp) historyStamp.textContent = historyStampText(ts);
+        // Only update the picker when the user isn't typing in it.
+        if (historyAtInput && document.activeElement !== historyAtInput) {
+            historyAtInput.value = historyToLocalInput(ts);
+        }
+        const floorName = data.floors[data.f[Math.min(historyState.idx, count - 1)]] || "";
+        const offFloor = floorName && !sameFloorName(floorName, SelMapName);
+        const parts = [
+            `${count} point${count === 1 ? "" : "s"}`,
+            historyAgeText((data.now || Date.now() / 1000) - ts),
+        ];
+        if (data.stride > 1) parts.push(`1 in ${data.stride} shown`);
+        if (offFloor) parts.push(`on ${floorName} — not this floor`);
+        const scale = (currentFloor() || {}).scale;
+        if (!scale) parts.push("this floor has no scale set, so the trail can't be drawn");
+        if (historyStatus) historyStatus.textContent = parts.filter(Boolean).join(" · ");
+    }
+
+    // --- the map overlay -----------------------------------------------------
+    // Drawn whenever the toggle is on, with or without a live tracking session:
+    // reviewing yesterday afternoon shouldn't require starting one.
+    function drawHistoryOverlay() {
+        if (!historyReady || !historyOn()) return;
+        const data = historyState.data;
+        if (!data || !data.count) return;
+        const floor = currentFloor();
+        const scale = floor && floor.scale;
+        if (!scale) return;  // no metres->pixels for this floor: nothing truthful to draw
+
+        const onFloor = (i) => sameFloorName(data.floors[data.f[i]] || "", SelMapName);
+        const px = (i) => ({ x: data.x_m[i] * scale, y: data.y_m[i] * scale });
+        const cursor = Math.min(historyState.idx, data.count - 1);
+        const baseHue = historyHue(historyState.ent);
+
+        // Segments joining consecutive points, skipping the ones the recorder
+        // marked as a break (floor change, restart, tracker absence) and any
+        // stretch that isn't on the floor being viewed.
+        const segs = [];
+        for (let i = 1; i < data.count; i++) {
+            if (data.gap[i]) continue;
+            if (!onFloor(i - 1) || !onFloor(i)) continue;
+            segs.push([px(i - 1), px(i), i]);
+        }
+
+        ctx.save();
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        const strokeSegs = (list, style, width) => {
+            if (!list.length) return;
+            ctx.beginPath();
+            let prev = -2;
+            list.forEach(([a, b, i]) => {
+                if (i !== prev + 1) ctx.moveTo(a.x, a.y);
+                ctx.lineTo(b.x, b.y);
+                prev = i;
+            });
+            ctx.strokeStyle = style;
+            ctx.lineWidth = width;
+            ctx.stroke();
+        };
+        // Split at the cursor: the stretch already replayed is a solid, cased
+        // line; what comes next is a faint dashed ghost with no casing. Making
+        // the difference structural (not just alpha) keeps the scrub position
+        // obvious without having to hunt for the marker.
+        const past = segs.filter(s => s[2] <= cursor);
+        const future = segs.filter(s => s[2] > cursor);
+        ctx.setLineDash([10, 10]);
+        strokeSegs(future, `hsla(${baseHue}, 60%, 62%, 0.35)`, 2.5);
+        ctx.setLineDash([]);
+        strokeSegs(past, "rgba(15, 15, 20, 0.55)", 7);   // casing, for map art
+        strokeSegs(past, `hsla(${baseHue}, 95%, 60%, 0.95)`, 3.5);
+
+        // Where the window starts (only meaningful if it's on this floor).
+        if (onFloor(0)) {
+            const a = px(0);
+            const r0 = Math.max(5, canvas.width * 0.005);
+            ctx.beginPath();
+            ctx.arc(a.x, a.y, r0, 0, Math.PI * 2);
+            ctx.fillStyle = "rgba(15, 15, 20, 0.55)";
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(a.x, a.y, r0 * 0.5, 0, Math.PI * 2);
+            ctx.fillStyle = `hsl(${baseHue}, 95%, 60%)`;
+            ctx.fill();
+        }
+
+        // The scrubbed position. Sized off the canvas like the tracker icons
+        // (the world is a fixed 2000 px wide, so fixed radii would vanish on a
+        // large floor plan). Dimmed to a hollow ring when that fix belongs to
+        // another floor — the coordinates are real, just not for this map.
+        const here = px(cursor);
+        const off = !onFloor(cursor);
+        const r = Math.max(7, canvas.width * 0.008);
+        ctx.beginPath();
+        ctx.arc(here.x, here.y, r * 1.6, 0, Math.PI * 2);
+        ctx.fillStyle = `hsla(${baseHue}, 95%, 60%, ${off ? 0.1 : 0.25})`;
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(here.x, here.y, r, 0, Math.PI * 2);
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = "rgba(15, 15, 20, 0.75)";
+        ctx.stroke();
+        ctx.fillStyle = off ? "transparent" : `hsl(${baseHue}, 95%, 60%)`;
+        ctx.fill();
+        ctx.strokeStyle = `hsl(${baseHue}, 95%, 70%)`;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    // Called after the selected floor changes. selectExistingMap paints with a
+    // bare drawElements() (not redrawAll), so without this the trail vanishes
+    // on a floor switch and does not come back until something else triggers a
+    // full repaint - and the status line keeps naming the previous floor.
+    function historyAfterFloorChange() {
+        if (!historyReady || !historyOn()) return;
+        historyRender();
+        drawHistoryOverlay();
+    }
+
+    // --- playback ------------------------------------------------------------
+    let historyPlayTimer = null;
+    let historyRefreshTimer = null;
+
+    function historyStopPlayback() {
+        historyState.playing = false;
+        if (historyPlayTimer) { clearInterval(historyPlayTimer); historyPlayTimer = null; }
+        historyRender();
+    }
+
+    function historyStartPlayback() {
+        const data = historyState.data;
+        if (!data || data.count < 2) return;
+        // Restarting from the end would look like nothing happened.
+        if (historyState.idx >= data.count - 1) historyState.idx = 0;
+        historyState.live = false;
+        historyState.anchor = data.t[historyState.idx];
+        historyState.playing = true;
+        let clock = data.t[historyState.idx];
+        const tick = 100;
+        historyPlayTimer = setInterval(() => {
+            const d = historyState.data;
+            if (!d || !d.count) { historyStopPlayback(); return; }
+            const rate = parseFloat(historyRateSel && historyRateSel.value) || 60;
+            clock += (tick / 1000) * rate;
+            const end = d.t[d.count - 1];
+            if (clock >= end) {
+                historyState.idx = d.count - 1;
+                historyStopPlayback();
+            } else {
+                historyState.idx = historyIndexAt(clock);
+                historyState.anchor = d.t[historyState.idx];
+                historyRender();
+            }
+            if (img.naturalWidth > 0) redrawAll();
+        }, tick);
+        historyRender();
+    }
+
+    function historySetLive(on) {
+        historyState.live = on;
+        if (on) {
+            historyStopPlayback();
+            historyState.anchor = null;
+            historyLoad();
+        } else {
+            historyRender();
+        }
+    }
+
+    function historyStartRefresh() {
+        if (historyRefreshTimer) return;
+        let ticks = 0;
+        historyRefreshTimer = setInterval(() => {
+            if (!historyOn()) return;
+            // Re-poll the index every ~30 s: the picker was otherwise filled
+            // once, on toggle-on, so a panel opened before the first fix was
+            // recorded stayed stuck on "No recorded devices" forever.
+            if (++ticks % 6 === 0) {
+                historyLoadDevices().then(() => {
+                    if (!historyState.data && historyState.ent) historyLoad();
+                });
+            }
+            // Only the Live latch pulls new data on its own: while scrubbing or
+            // replaying, a silent reload under the cursor would be disorienting.
+            if (historyState.live && !historyState.loading) historyLoad();
+        }, HISTORY_REFRESH_MS);
+    }
+
+    function historyStopRefresh() {
+        if (historyRefreshTimer) { clearInterval(historyRefreshTimer); historyRefreshTimer = null; }
+    }
+
+    // --- wiring --------------------------------------------------------------
+    if (historyToggle) {
+        historyToggle.checked = localStorage.getItem("bpsHistory") === "on"; // off by default
+        const applyHistoryVisibility = async () => {
+            const on = historyToggle.checked;
+            if (historyBar) historyBar.style.display = on ? "" : "none";
+            if (on) {
+                await historyLoadDevices();
+                historySetLive(true);
+                historyStartRefresh();
+            } else {
+                historyStopPlayback();
+                historyStopRefresh();
+                if (img.naturalWidth > 0) redrawAll();
+            }
+        };
+        historyToggle.addEventListener("change", () => {
+            localStorage.setItem("bpsHistory", historyToggle.checked ? "on" : "off");
+            applyHistoryVisibility();
+        });
+        // The first application is deferred to the end of this block (below
+        // `historyReady = true`) so its opening repaint actually draws.
+        historyRestoreOnInit = historyToggle.checked ? applyHistoryVisibility : null;
+    }
+
+    if (historyDeviceSel) {
+        historyDeviceSel.addEventListener("change", () => {
+            historyState.ent = historyDeviceSel.value || null;
+            historyState.data = null;
+            historyStopPlayback();
+            historyLoad();
+        });
+    }
+
+    if (historySpanSel) {
+        historySpanSel.addEventListener("change", () => {
+            historyStopPlayback();
+            historyLoad();
+        });
+    }
+
+    if (historySlider) {
+        historySlider.addEventListener("input", () => {
+            const idx = parseInt(historySlider.value, 10);
+            if (!Number.isFinite(idx)) return;
+            // Dragging means "show me this moment", so it drops the Live latch
+            // and stops playback — otherwise the two would fight over the cursor.
+            historyState.live = false;
+            historyStopPlayback();
+            historyState.idx = idx;
+            // Remember WHEN we are looking at, not just which index: a later
+            // reload (span change, device change) re-centres on this moment.
+            const t = historyState.data && historyState.data.t;
+            if (t && Number.isFinite(t[idx])) historyState.anchor = t[idx];
+            historyRender();
+            if (img.naturalWidth > 0) redrawAll();
+        });
+    }
+
+    if (historyAtInput) {
+        historyAtInput.addEventListener("change", () => {
+            const ts = historyFromLocalInput(historyAtInput.value);
+            if (ts === null) return;
+            historyStopPlayback();
+            historyState.live = false;
+            historyState.anchor = ts;
+            // Reload centred on the chosen moment, then park the cursor on
+            // it. Only when THIS load actually applied: a failed or superseded
+            // request would otherwise leave the previous window on screen with
+            // the cursor moved, which reads as a successful jump.
+            historyLoad().then((applied) => {
+                if (!applied || !historyState.data || !historyState.data.count) return;
+                historyState.idx = historyIndexAt(ts);
+                historyState.anchor = historyState.data.t[historyState.idx];
+                historyRender();
+                if (img.naturalWidth > 0) redrawAll();
+            });
+        });
+    }
+
+    if (historyPlayBtn) {
+        historyPlayBtn.addEventListener("click", () => {
+            if (historyState.playing) historyStopPlayback();
+            else historyStartPlayback();
+        });
+    }
+
+    if (historyLiveBtn) {
+        historyLiveBtn.addEventListener("click", () => historySetLive(true));
+    }
+
+    // Retention + clear, in the Tracking column. The window is a layout field
+    // (staged like the other tracking settings and written by Save Floor Plan);
+    // clearing is immediate, because there is no sane "staged forget".
+    const historyMaxAgeSel = document.getElementById("historyMaxAge");
+    const historyClearBtn = document.getElementById("historyClear");
+
+    // Looks the element up rather than closing over historyMaxAgeSel: this is
+    // called from fetchBPSData, which runs before the const below is reached.
+    function historySyncSettings() {
+        const historyMaxAgeSel = document.getElementById("historyMaxAge");
+        if (!historyMaxAgeSel) return;
+        const enabled = finalcords.history_enabled !== false;
+        const raw = finalcords.history_max_age;
+        const secs = enabled && Number.isFinite(raw) ? String(Math.round(raw))
+                   : enabled ? "21600" : "0";
+        historyMaxAgeSel.value = [...historyMaxAgeSel.options].some(o => o.value === secs)
+            ? secs : "21600";
+    }
+
+    if (historyMaxAgeSel) {
+        historyMaxAgeSel.addEventListener("change", () => {
+            const secs = parseFloat(historyMaxAgeSel.value);
+            if (secs === 0) {
+                finalcords.history_enabled = false;
+            } else {
+                finalcords.history_enabled = true;
+                finalcords.history_max_age = secs;
+            }
+            savebuttondiv.appendChild(saveButton);
+            bpsToast("History window staged. Click Save Floor Plan to persist.");
+        });
+    }
+
+    historyReady = true;
+    if (historyRestoreOnInit) historyRestoreOnInit();
+
+    if (historyClearBtn) {
+        historyClearBtn.addEventListener("click", async () => {
+            const ok = await bpsConfirm(
+                "Forget every recorded position? This cannot be undone.",
+                { confirmText: "Clear history", danger: true });
+            if (!ok) return;
+            try {
+                const res = await bpsFetch("/api/bps/history", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ action: "clear" }),
+                });
+                if (!res.ok) { bpsToast("Could not clear the history."); return; }
+            } catch (e) {
+                bpsToast("Could not clear the history.");
+                return;
+            }
+            historyState.data = null;
+            historyState.idx = 0;
+            historyStopPlayback();
+            historyRender();
+            if (img.naturalWidth > 0) redrawAll();
+            bpsToast("Position history cleared.");
+        });
+    }
+
     // Zone-bar floor readout for the tracked device. Muted "· <floor>" when it's
     // the floor on screen; a red "· on <floor> — not this floor" plus a
     // "Switch to <floor>" button (if that floor has a map) when it isn't.
@@ -1691,6 +2288,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 tmpfinalcords = finalcords; //Store original cords in a temp to compare later if it is changed
             }
             ensureTrackerIconsStore();
+            historySyncSettings();   // reflect the saved history window
             // finalcords is now loaded; re-label the map dropdown (built earlier
             // at startup from filenames) with each floor's set name.
             Array.from(mapSelector.options).forEach(o => {
@@ -4466,6 +5064,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await setupCanvasWithImage(img, canvas);
         new_floor = false;
         drawElements();
+        historyAfterFloorChange();
     }
 
     mapSelector.addEventListener('change', async () => {

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1634,6 +1634,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // hoisted as undefined, so the overlay simply no-ops until the block below
     // has initialised, where a const would throw on the temporal-dead-zone read.
     var historyReady = false;
+    const historyToggle = document.getElementById("historyToggle");
     const historyBar = document.getElementById("historyBar");
     const historyDeviceSel = document.getElementById("historyDevice");
     const historySpanSel = document.getElementById("historySpan");
@@ -1644,6 +1645,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const historyPlayBtn = document.getElementById("historyPlay");
     const historyRateSel = document.getElementById("historyRate");
     const historyLiveBtn = document.getElementById("historyLive");
+
+    // On unless explicitly switched off. Unlike the other overlay toggles this
+    // one defaults to SHOWN: the scrubber is a standing map control, and the
+    // switch exists to get it out of the way rather than to opt into it. A
+    // missing element (older cached index.html) also reads as shown.
+    const historyOn = () => !historyToggle || historyToggle.checked;
 
     const HISTORY_REFRESH_MS = 5000;   // while latched to Live
     const HISTORY_MAX_POINTS = 3000;   // server decimates to this, spanning the window
@@ -1803,9 +1810,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // The historyReady guard has to come FIRST and short-circuit: this is
     // called from setActiveDevice, which runs while tracked devices are
     // restored on load - before the consts below this point in the closure
-    // exist, so touching one of them here would throw on the dead zone.
+    // exist, so evaluating historyOn() there would throw on the dead zone.
     function historyFollowDevice(ent) {
-        if (!historyReady || !ent) return;
+        if (!historyReady || !historyOn() || !ent) return;
         if (historyState.ent === ent) return;   // re-click / focus toggle-off
         if (historyDeviceSel) {
             // The index is re-polled every ~30 s, so a device tracked seconds
@@ -1836,6 +1843,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Resolves to true when this call actually applied a window (callers that
     // then move the cursor must not act on a failed or superseded load).
     async function historyLoad() {
+        // Hidden: nothing to draw and nothing worth fetching. Return without
+        // touching state - the window is restored wholesale when it comes back.
+        if (!historyOn()) return false;
         if (!historyState.ent) {
             // Nothing selected: drop the previous device's window rather than
             // keep drawing its trail under a picker that no longer names it.
@@ -1951,7 +1961,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Drawn whenever the toggle is on, with or without a live tracking session:
     // reviewing yesterday afternoon shouldn't require starting one.
     function drawHistoryOverlay() {
-        if (!historyReady) return;
+        if (!historyReady || !historyOn()) return;
         const data = historyState.data;
         if (!data || !data.count) return;
         const floor = currentFloor();
@@ -2044,7 +2054,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // on a floor switch and does not come back until something else triggers a
     // full repaint - and the status line keeps naming the previous floor.
     function historyAfterFloorChange() {
-        if (!historyReady) return;
+        if (!historyReady || !historyOn()) return;
         historyRender();
         drawHistoryOverlay();
     }
@@ -2103,6 +2113,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (historyRefreshTimer) return;
         let ticks = 0;
         historyRefreshTimer = setInterval(() => {
+            if (!historyOn()) return;
             // Re-poll the index every ~30 s: the picker is otherwise filled
             // once, at startup, so a panel opened before the first fix was
             // recorded would stay stuck on "No recorded devices" forever.
@@ -2117,14 +2128,34 @@ document.addEventListener('DOMContentLoaded', async () => {
         }, HISTORY_REFRESH_MS);
     }
 
+    function historyStopRefresh() {
+        if (historyRefreshTimer) { clearInterval(historyRefreshTimer); historyRefreshTimer = null; }
+    }
+
     // --- wiring --------------------------------------------------------------
-    // The scrubber is a permanent map control - it has no on/off switch, so
-    // this runs once at startup rather than on a toggle. Deferred to the end of
-    // this block (below `historyReady = true`) so its opening repaint draws.
-    async function historyInit() {
-        await historyLoadDevices();
-        historySetLive(true);
-        historyStartRefresh();
+    // Showing/hiding the whole strip AND its overlay. Hiding also stops the
+    // polling: a scrubber nobody can see should not be fetching every 5 s.
+    async function applyHistoryVisibility() {
+        const on = historyOn();
+        if (historyBar) historyBar.style.display = on ? "" : "none";
+        if (on) {
+            await historyLoadDevices();
+            historySetLive(true);
+            historyStartRefresh();
+        } else {
+            historyStopPlayback();
+            historyStopRefresh();
+            if (img.naturalWidth > 0) redrawAll();   // drop the trail with the bar
+        }
+    }
+
+    if (historyToggle) {
+        // Default ON, so only an explicit "off" is remembered.
+        historyToggle.checked = localStorage.getItem("bpsHistory") !== "off";
+        historyToggle.addEventListener("change", () => {
+            localStorage.setItem("bpsHistory", historyToggle.checked ? "on" : "off");
+            applyHistoryVisibility();
+        });
     }
 
     if (historyDeviceSel) {
@@ -2247,7 +2278,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     historyReady = true;
-    historyInit();
+    // Deferred to here (below `historyReady = true`) so the opening repaint draws.
+    applyHistoryVisibility();
 
     if (historyClearBtn) {
         historyClearBtn.addEventListener("click", async () => {

--- a/custom_components/bps/history.py
+++ b/custom_components/bps/history.py
@@ -1,0 +1,680 @@
+"""Bounded position history for tracked devices (the panel time scrubber).
+
+Why BPS keeps this itself rather than leaning on Home Assistant's recorder:
+the headline requirement is a CONFIGURABLE maximum span, and `purge_keep_days`
+is global, day-granularity and at least one day - you cannot keep six hours of
+BPS and ten days of everything else. Writing a 1 Hz position stream into the
+recorder would also add tens of megabytes a day to every install on upgrade,
+and BPS publishes no position entity today, so nothing is recorded anyway.
+
+Shape of the data: points are stored in METRES within their floor's frame plus
+the floor NAME, never in map pixels. Re-exporting a map image at a different
+resolution changes every pixel coordinate but not where the device physically
+was, so the pixel projection is done at render time from the floor's current
+scale. The scale in effect when each floor row was first written is kept
+alongside it, so a later scale change can be detected.
+
+Storage is columnar (`array`), which is the difference between ~17 bytes and
+~264 bytes per point - i.e. between ~2 MB and ~34 MB resident for 24 h across
+three trackers. Durability is append-only NDJSON day files, so a crash can
+only cost the last un-flushed batch, never the whole history the way rewriting
+a single blob could (the lesson of issue #104).
+
+This module imports nothing from the rest of the package, so any writer can use
+it without an import cycle, and it performs no I/O itself - the caller takes
+the lines to append and hands back rows to restore, doing the file access in an
+executor.
+"""
+from array import array
+import bisect
+import json
+import math
+import os
+import time
+
+DOMAIN = "bps"
+
+# Sub-directory under config/.storage. NOT under www/: history must never be
+# web-served, the same reasoning that moved the layout out of www in #104.
+HISTORY_DIRNAME = "bps_history"
+
+# Defaults, all overridable per install from top-level layout keys.
+DEFAULT_MAX_AGE = 6 * 3600           # keep 6 h unless asked for more
+MAX_AGE_LIMIT = 7 * 24 * 3600        # 7 days, the supported ceiling
+DEFAULT_MAX_POINTS = 200_000         # per tracker; OOM guard, independent of age
+DEFAULT_MIN_INTERVAL = 2.0           # s between kept points
+DEFAULT_MIN_MOVE_M = 0.3             # m of movement to be worth keeping
+DEFAULT_HEARTBEAT = 30.0             # s: keep a point even when standing still
+
+_CFG_SPEC = {
+    # layout key            default              lo       hi
+    "history_max_age":      (DEFAULT_MAX_AGE,    60.0,    float(MAX_AGE_LIMIT)),
+    "history_max_points":   (DEFAULT_MAX_POINTS, 500.0,   500_000.0),
+    "history_min_interval": (DEFAULT_MIN_INTERVAL, 0.5,   60.0),
+    "history_min_move_m":   (DEFAULT_MIN_MOVE_M,  0.05,   10.0),
+    "history_heartbeat":    (DEFAULT_HEARTBEAT,   5.0,    600.0),
+}
+
+
+# A dropout longer than this (and longer than the heartbeat allows for) is
+# treated as a break in the record rather than a long straight line: the device
+# was not simply standing still, it was not being heard at all.
+DROPOUT_GAP_FACTOR = 3.0
+DROPOUT_GAP_MIN = 90.0
+
+
+def _finite(value):
+    """`value` as a finite float, or None.
+
+    Coerces rather than type-checks: the solver hands back whatever numpy type
+    the Kalman/clip path produced (np.float32 is NOT a subclass of float, so an
+    isinstance gate would silently record nothing), and a restored row comes
+    from JSON. Rejects bools, and survives a JSON integer with hundreds of
+    digits - float() raises OverflowError there, where math.isfinite() would
+    raise it too and take the whole restore down with it.
+    """
+    if isinstance(value, bool):
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+def history_config(layout):
+    """Resolve the history settings from the layout, clamped to sane ranges."""
+    cfg = {}
+    src = layout if isinstance(layout, dict) else {}
+    for key, (default, lo, hi) in _CFG_SPEC.items():
+        value = src.get(key)
+        # not-bool: isinstance(True, int) holds in Python, so a hand-edited
+        # true/false would otherwise read as a valid 1/0.
+        if isinstance(value, (int, float)) and not isinstance(value, bool) \
+                and math.isfinite(value):
+            value = min(max(float(value), lo), hi)
+        else:
+            value = float(default)
+        cfg[key[len("history_"):]] = value
+    enabled = src.get("history_enabled")
+    cfg["enabled"] = True if enabled is None else bool(enabled)
+    cfg["max_points"] = int(cfg["max_points"])
+    return cfg
+
+
+class _Track:
+    """One tracker's columnar ring buffer."""
+
+    __slots__ = ("t", "x", "y", "f", "gap", "floors", "scales",
+                 "last_kept", "force_gap")
+
+    def __init__(self):
+        self.t = array("d")
+        self.x = array("f")
+        self.y = array("f")
+        self.f = array("B")       # index into self.floors
+        self.gap = array("B")     # 1 = this point STARTS a new polyline
+        self.floors = []          # append-only: index -> floor name
+        self.scales = []          # px/m in effect when that floor was first seen
+        self.last_kept = None     # (t, x, y, floor_index)
+        self.force_gap = False
+
+    def floor_index(self, floor, scale):
+        name = "" if floor is None else str(floor)
+        try:
+            return self.floors.index(name)
+        except ValueError:
+            if len(self.floors) >= 255:   # f is a byte column
+                return 0
+            self.floors.append(name)
+            self.scales.append(float(scale) if scale else 0.0)
+            return len(self.floors) - 1
+
+    def reset(self):
+        """Drop the points but keep the floor/scale tables.
+
+        Used when the clock steps BACKWARDS: the arrays are searched with
+        bisect everywhere (query, evict), so a single out-of-order append makes
+        every one of those return nonsense - the trail vanishes, and evict
+        deletes an arbitrary block instead of the expired head. Losing the
+        buffer is the cheap, safe answer to a clock that just lied to us.
+        """
+        del self.t[:]
+        del self.x[:]
+        del self.y[:]
+        del self.f[:]
+        del self.gap[:]
+        self.last_kept = None
+
+    def append(self, ts, x, y, fi, gap):
+        self.t.append(float(ts))
+        self.x.append(float(x))
+        self.y.append(float(y))
+        self.f.append(fi)
+        self.gap.append(1 if gap else 0)
+        self.last_kept = (float(ts), float(x), float(y), fi)
+
+    def evict(self, max_age, max_points, now):
+        """Drop expired/excess points in BLOCKS (one memmove, not one per point)."""
+        n = len(self.t)
+        if n == 0:
+            return
+        drop = bisect.bisect_left(self.t, now - max_age)
+        at_cap = n - drop > max_points
+        if at_cap:
+            # Drop a BLOCK, not the single point that put us over: at the cap
+            # `n - max_points` is 1 on every record, which would memmove the
+            # whole buffer once per fix - exactly what the amortisation below
+            # exists to avoid, in the one regime where it never gets to run.
+            drop = max(n - max_points, min(n, max(1, max_points // 64)))
+        if drop <= 0:
+            return
+        # Amortise: compacting on every expiry would memmove the whole buffer
+        # once per point. Wait for a block worth ~6% of what we hold (with a
+        # small floor so short buffers still expire promptly) unless the point
+        # cap is forcing our hand. The threshold scales with `n`, NOT with
+        # max_points: a "compact once max_points/10 expired" rule never fires
+        # for a ring that holds far fewer points than the cap (6 h at one point
+        # per 2 s is ~10k against a 200k cap), so max_age would be ignored and
+        # the ring would grow to the cap regardless of the configured window.
+        if not at_cap and drop < max(8, n // 16):
+            return
+        del self.t[:drop]
+        del self.x[:drop]
+        del self.y[:drop]
+        del self.f[:drop]
+        del self.gap[:drop]
+        if self.gap:
+            self.gap[0] = 1       # the new first point starts a polyline
+
+
+class PositionHistory:
+    """Every tracker's history, plus the NDJSON lines waiting to be appended."""
+
+    MAX_PENDING = 50_000          # never let the flush queue grow unbounded
+
+    def __init__(self, cfg=None):
+        self.tracks = {}
+        self.cfg = cfg or history_config({})
+        self._pending = []
+        self.dropped_pending = 0
+
+    def configure(self, cfg):
+        self.cfg = cfg
+
+    # --- recording ---------------------------------------------------------
+    def record(self, ent, ts, x_m, y_m, floor, scale):
+        """Keep this fix if it clears the gate. Returns True when kept.
+
+        Kept when the floor changed (always - the two points live in different
+        frames), or enough time AND movement has passed, or the heartbeat is
+        due so a stationary device still has something to scrub to.
+        """
+        if not self.cfg.get("enabled", True):
+            return False
+        if not isinstance(ent, str) or not ent:
+            return False
+        ts, x_m, y_m = _finite(ts), _finite(x_m), _finite(y_m)
+        if ts is None or x_m is None or y_m is None:
+            return False
+        track = self.tracks.get(ent)
+        if track is None:
+            track = self.tracks[ent] = _Track()
+        fi = track.floor_index(floor, scale)
+
+        gap = False
+        last = track.last_kept
+        if last is None:
+            gap = True
+        else:
+            lt, lx, ly, lf = last
+            if ts < lt:
+                # The clock stepped backwards (NTP correction, a VM resume, a
+                # host with no RTC catching up). Appending here would leave
+                # track.t unsorted and break every bisect that reads it, so
+                # start the buffer over rather than corrupt it.
+                track.reset()
+                fi = track.floor_index(floor, scale)
+                gap = True
+            elif fi != lf:
+                gap = True                  # different pixel frame: break the line
+            else:
+                dt = ts - lt
+                moved = math.hypot(x_m - lx, y_m - ly)
+                if not (dt >= self.cfg["heartbeat"]
+                        or (dt >= self.cfg["min_interval"]
+                            and moved >= self.cfg["min_move_m"])):
+                    return False
+                # Heard again after a silence: the device was not standing
+                # still, it was not being heard, so break the line instead of
+                # drawing one long straight segment across the outage. (The
+                # tracker only gets an explicit mark_gap once it has been
+                # absent for the whole position_timeout, which is much longer.)
+                if dt > max(self.cfg["heartbeat"] * DROPOUT_GAP_FACTOR,
+                            DROPOUT_GAP_MIN):
+                    gap = True
+        if track.force_gap:
+            gap = True
+            track.force_gap = False
+
+        track.append(ts, x_m, y_m, fi, gap)
+        self._queue(ent, ts, x_m, y_m, track.floors[fi], track.scales[fi], gap)
+        track.evict(self.cfg["max_age"], self.cfg["max_points"], ts)
+        return True
+
+    def evict_all(self, now=None):
+        """Age every track, not just the one that recorded.
+
+        record() evicts the track it touched, which is enough while a device
+        keeps reporting - but a tracker that has gone silent (left the house,
+        battery flat), or a history that has since been switched OFF, would
+        otherwise keep serving points long past the configured window. Called
+        from the periodic flush and before every query.
+        """
+        now = time.time() if now is None else now
+        for track in self.tracks.values():
+            track.evict(self.cfg["max_age"], self.cfg["max_points"], now)
+
+    def mark_gap(self, ent):
+        """The next point for this tracker starts a new polyline.
+
+        Used when a tracker is pruned for absence, or across a restart, so the
+        scrubber does not draw a straight line over a gap in the record.
+        """
+        track = self.tracks.get(ent)
+        if track is None:
+            track = self.tracks[ent] = _Track()
+        track.force_gap = True
+
+    def forget(self, ent=None):
+        """Discard the in-memory record for one tracker, or for all of them.
+
+        Also drops that tracker's queued-but-unflushed rows, which would
+        otherwise be appended to disk moments after the clear and reappear on
+        the next restart.
+        """
+        if ent is None:
+            self.tracks.clear()
+            self._pending = []
+            return
+        self.tracks.pop(ent, None)
+        self._pending = [row for row in self._pending if row[1] != ent]
+
+    def mark_all_gaps(self):
+        for track in self.tracks.values():
+            track.force_gap = True
+
+    # --- disk hand-off (the caller performs the actual I/O) ----------------
+    def _queue(self, ent, ts, x, y, floor, scale, gap):
+        if len(self._pending) >= self.MAX_PENDING:
+            self.dropped_pending += 1
+            return
+        row = {"e": ent, "t": round(float(ts), 2), "x": round(float(x), 3),
+               "y": round(float(y), 3), "f": floor}
+        if scale:
+            row["s"] = round(float(scale), 4)
+        if gap:
+            row["g"] = 1
+        # Tagged with its UTC day so the flush can group by segment file, and
+        # with the entity so forget() can drop just that tracker's queued rows
+        # without having to pattern-match the serialised JSON.
+        self._pending.append(
+            (day_key(ts), ent, json.dumps(row, separators=(",", ":"))))
+
+    def drain_pending(self):
+        """Take the queued rows as {day_key: [line, ...]} for the caller to append."""
+        out, self._pending = self._pending, []
+        grouped = {}
+        for day, _ent, line in out:
+            grouped.setdefault(day, []).append(line)
+        return grouped
+
+    def pending_count(self):
+        return len(self._pending)
+
+    def requeue(self, grouped):
+        """Put a drained batch back after a failed write.
+
+        The rows go to the FRONT so they keep their place ahead of anything
+        recorded since, and the pending cap still applies - a disk that stays
+        broken drops the oldest rows rather than growing without bound.
+        """
+        back = []
+        for day, lines in grouped.items():
+            for line in lines:
+                ent = ""
+                try:
+                    ent = json.loads(line).get("e") or ""
+                except ValueError:
+                    pass
+                back.append((day, ent, line))
+        if not back:
+            return
+        self._pending[:0] = back
+        if len(self._pending) > self.MAX_PENDING:
+            over = len(self._pending) - self.MAX_PENDING
+            del self._pending[:over]
+            self.dropped_pending += over
+
+    def adopt(self, other):
+        """Take another PositionHistory's tracks as our own (restore path).
+
+        Used so the parse/build can happen in an executor and only the handover
+        touches the object the event loop reads.
+        """
+        self.tracks = other.tracks
+
+    def load_rows(self, rows, now=None):
+        """Restore from parsed NDJSON rows, ignoring junk rows.
+
+        The rows are sorted by timestamp first: file order is only *usually*
+        chronological (a clock step, or a segment written across a restart, can
+        break it), and every read of these arrays is a bisect that needs them
+        sorted.
+        """
+        now = time.time() if now is None else now
+        cutoff = now - self.cfg["max_age"]
+        clean = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            ent = row.get("e")
+            if not isinstance(ent, str) or not ent:
+                continue
+            ts = _finite(row.get("t"))
+            x, y = _finite(row.get("x")), _finite(row.get("y"))
+            if ts is None or x is None or y is None or ts < cutoff:
+                continue
+            clean.append((ts, ent, x, y, row))
+        clean.sort(key=lambda r: r[0])
+
+        restored = 0
+        for ts, ent, x, y, row in clean:
+            track = self.tracks.get(ent)
+            if track is None:
+                track = self.tracks[ent] = _Track()
+            fi = track.floor_index(row.get("f"), _finite(row.get("s")) or 0.0)
+            track.append(ts, x, y, fi, bool(row.get("g")))
+            restored += 1
+        for track in self.tracks.values():
+            track.evict(self.cfg["max_age"], self.cfg["max_points"], now)
+        return restored
+
+    # --- querying ----------------------------------------------------------
+    def retained(self, ent):
+        """The span actually held for one tracker, or None when empty."""
+        track = self.tracks.get(ent)
+        if track is None or not track.t:
+            return None
+        return {"from": round(track.t[0], 2), "to": round(track.t[-1], 2),
+                "points": len(track.t)}
+
+    def entities(self):
+        return sorted(e for e, tr in self.tracks.items() if tr.t)
+
+    def query(self, ent, frm, to, max_points):
+        """Points for one tracker in [frm, to], decimated to ~max_points.
+
+        Decimation keeps a uniform stride so the trail spans the WHOLE window,
+        and always keeps the first and last point, every gap and every floor
+        change - dropping those would silently join unrelated stretches.
+        """
+        empty = {"ent": ent, "floors": [], "scales": [], "t": [], "x_m": [],
+                 "y_m": [], "f": [], "gap": [], "count": 0, "total": 0,
+                 "stride": 1}
+        track = self.tracks.get(ent)
+        if track is None or not track.t:
+            return empty
+        lo = bisect.bisect_left(track.t, frm)
+        hi = bisect.bisect_right(track.t, to)
+        total = hi - lo
+        if total <= 0:
+            return empty
+        cap = max(2, int(max_points))
+        stride = 1 if total <= cap else -(-total // cap)   # ceil division
+
+        keep = []
+        for i in range(lo, hi):
+            if (i == lo or i == hi - 1 or track.gap[i]
+                    or (i > lo and track.f[i] != track.f[i - 1])
+                    or (i - lo) % stride == 0):
+                keep.append(i)
+        # Breaks and floor changes are force-kept above, so data that flaps
+        # between floors (or a device pruned and re-seen over and over) can
+        # defeat the stride entirely and return the whole buffer - megabytes of
+        # JSON for a request that asked for a few thousand points. Thin the
+        # result uniformly if that happened; the endpoints and the ordering
+        # survive, some breaks do not.
+        hard_cap = cap * 2
+        if len(keep) > hard_cap:
+            step = -(-len(keep) // hard_cap)
+            thinned = keep[::step]
+            if thinned[-1] != keep[-1]:
+                thinned.append(keep[-1])
+            keep = thinned
+            stride = max(stride, step)
+
+        return {
+            "ent": ent,
+            "floors": list(track.floors),
+            "scales": list(track.scales),
+            "t": [round(track.t[i], 2) for i in keep],
+            "x_m": [round(track.x[i], 3) for i in keep],
+            "y_m": [round(track.y[i], 3) for i in keep],
+            "f": [track.f[i] for i in keep],
+            "gap": [track.gap[i] for i in keep],
+            "count": len(keep),
+            "total": total,
+            "stride": stride,
+        }
+
+
+def day_key(ts):
+    """UTC day stamp used for an on-disk segment name."""
+    return time.strftime("%Y%m%d", time.gmtime(ts))
+
+
+# Segments are whole UTC days, so the day containing (now - max_age) still
+# holds in-window rows and must be kept. Both the pruner and the restore use
+# this one boundary, so nothing is kept that is never read back.
+def oldest_live_day(max_age, now=None):
+    now = time.time() if now is None else now
+    return day_key(now - max_age)
+
+
+def expired_day_keys(existing, max_age, now=None):
+    """Which day segments are entirely older than the retention window."""
+    keep_from = oldest_live_day(max_age, now)
+    return sorted(k for k in existing if k < keep_from)
+
+
+# --- on-disk day segments ----------------------------------------------------
+# Plain synchronous file I/O, kept here so the module stays self-contained; the
+# caller runs these in an executor. Appends only: a partial write can lose the
+# tail of one segment, never the whole history.
+
+def segment_path(dirpath, day):
+    return os.path.join(dirpath, "%s.jsonl" % day)
+
+
+def append_segments(dirpath, grouped):
+    """Append {day_key: [line, ...]} to the matching segment files.
+
+    Returns the number of lines written. Creates the directory on demand.
+    """
+    if not grouped:
+        return 0
+    os.makedirs(dirpath, exist_ok=True)
+    written = 0
+    for day, lines in grouped.items():
+        if not lines:
+            continue
+        path = segment_path(dirpath, day)
+        # Binary append, and check the last byte first: a previous append that
+        # died mid-write leaves a line with no trailing newline, and appending
+        # straight onto it would fuse that torn tail and our first row into one
+        # unparseable line -- costing a good row as well as the bad one.
+        with open(path, "a+b") as fh:
+            if fh.tell():
+                fh.seek(-1, os.SEEK_END)
+                if fh.read(1) not in (b"\n", b"\r"):
+                    fh.write(b"\n")
+                fh.seek(0, os.SEEK_END)
+            fh.write(("\n".join(lines) + "\n").encode("utf-8"))
+        written += len(lines)
+    return written
+
+
+def list_day_keys(dirpath):
+    """Day keys of the segments currently on disk, oldest first."""
+    try:
+        names = os.listdir(dirpath)
+    except OSError:
+        return []
+    out = []
+    for name in names:
+        if name.endswith(".jsonl") and len(name) == len("YYYYMMDD.jsonl"):
+            stem = name[:-len(".jsonl")]
+            if stem.isdigit():
+                out.append(stem)
+    return sorted(out)
+
+
+def read_segments(dirpath, days):
+    """Parsed rows from the named segments, oldest first.
+
+    A torn final line (power cut mid-append) is skipped rather than aborting
+    the restore, so one bad line cannot cost the rest of the history.
+    """
+    rows = []
+    for day in days:
+        path = segment_path(dirpath, day)
+        try:
+            # errors="replace": a corrupt byte would otherwise raise
+            # UnicodeDecodeError from inside the iteration - which is NOT an
+            # OSError, so it would escape this guard and cost the entire
+            # restore. Mangled text just fails to parse as JSON below.
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(json.loads(line))
+                    except ValueError:
+                        continue          # torn/garbled line: skip it
+        except OSError:
+            continue
+    return rows
+
+
+def prune_segments(dirpath, max_age, now=None):
+    """Delete segments entirely older than the retention window."""
+    _sweep_temps(dirpath)   # a rewrite that died leaves a full copy behind
+    removed = []
+    for day in expired_day_keys(list_day_keys(dirpath), max_age, now):
+        try:
+            os.remove(segment_path(dirpath, day))
+            removed.append(day)
+        except OSError:
+            pass
+    return removed
+
+
+def restore_recent(dirpath, cfg, now=None):
+    """Rows from the segments that can still be inside the retention window."""
+    oldest = oldest_live_day(cfg["max_age"], now)
+    days = [d for d in list_day_keys(dirpath) if d >= oldest]
+    return read_segments(dirpath, days)
+
+
+def drop_entity(dirpath, ent, cfg, now=None):
+    """Rewrite every segment without one tracker's rows. Returns rows removed.
+
+    Segments are shared by all trackers, so forgetting one means a rewrite.
+    Each file is written to a sibling temp and os.replace()d, so a crash
+    mid-rewrite leaves the original segment intact rather than a truncated one.
+    """
+    removed = 0
+    for day in list_day_keys(dirpath):
+        path = segment_path(dirpath, day)
+        tmp = path + ".tmp"
+        kept = 0
+        try:
+            with open(path, encoding="utf-8", errors="replace") as src, \
+                    open(tmp, "w", encoding="utf-8") as dst:
+                for line in src:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        row = json.loads(stripped)
+                    except ValueError:
+                        continue          # torn line: dropping it is the repair
+                    if isinstance(row, dict) and row.get("e") == ent:
+                        removed += 1
+                        continue
+                    dst.write(stripped + "\n")
+                    kept += 1
+        except OSError:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            continue
+        try:
+            if kept:
+                os.replace(tmp, path)
+            else:
+                os.remove(tmp)            # nothing left: drop the segment
+                os.remove(path)
+        except OSError:
+            pass
+    return removed
+
+
+def clear_segments(dirpath):
+    """Delete every segment. Returns the number of files removed.
+
+    Also sweeps orphaned .tmp files: list_day_keys deliberately ignores them,
+    so a rewrite that died mid-flight would otherwise leave a copy of the
+    record on disk that nothing - not Clear, not the pruner - ever removes.
+    """
+    removed = 0
+    for day in list_day_keys(dirpath):
+        try:
+            os.remove(segment_path(dirpath, day))
+            removed += 1
+        except OSError:
+            pass
+    removed += _sweep_temps(dirpath)
+    return removed
+
+
+def _sweep_temps(dirpath):
+    """Remove leftover .tmp segment files. Returns how many went."""
+    removed = 0
+    try:
+        names = os.listdir(dirpath)
+    except OSError:
+        return 0
+    for name in names:
+        if name.endswith(".jsonl.tmp"):
+            try:
+                os.remove(os.path.join(dirpath, name))
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+def disk_usage(dirpath):
+    """(files, bytes) currently used by the segments, for diagnostics."""
+    files = list_day_keys(dirpath)
+    total = 0
+    for day in files:
+        try:
+            total += os.path.getsize(segment_path(dirpath, day))
+        except OSError:
+            pass
+    return len(files), total

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.8.1"
+    "version": "1.9.0"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.9.1"
+    "version": "1.9.2"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.9.2"
+    "version": "2.0.0"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "1.9.0"
+    "version": "1.9.1"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,13 @@ def make_hass(config_dir=None):
     hass._store_saves = []
     hass._store_delay_saves = []
     hass._store_raise_on_load = set()   # store keys whose async_load should raise
+
+    async def _executor(func, *args):
+        # Run inline: the tests are single-threaded and only need the awaitable
+        # contract, not real off-loop execution.
+        return func(*args)
+
+    hass.async_add_executor_job = _executor
     return hass
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,688 @@
+"""Regression tests for the position history (the map's time scrubber).
+
+Three things have to hold or the feature is worse than useless:
+
+* the recording gate must keep a walk legible while a stationary device costs
+  almost nothing,
+* a query must span the WHOLE requested window after decimation (a trail that
+  silently stops half-way is indistinguishable from the device stopping), and
+* the on-disk record must survive a restart, a torn line, and a clear.
+"""
+import asyncio
+import json
+import os
+
+import bps
+from bps import history as H
+from conftest import make_hass
+
+
+ENT = "phone"
+FLOOR = "Main"
+SCALE = 40.0  # px per metre
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def hist(**over):
+    cfg = H.history_config({})
+    cfg.update(over)
+    return H.PositionHistory(cfg)
+
+
+def all_points(h, ent=ENT):
+    return h.query(ent, 0, 1e12, 10 ** 9)
+
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+def test_defaults_are_the_documented_ones():
+    cfg = H.history_config(None)
+    assert cfg["max_age"] == H.DEFAULT_MAX_AGE
+    assert cfg["min_interval"] == H.DEFAULT_MIN_INTERVAL
+    assert cfg["min_move_m"] == H.DEFAULT_MIN_MOVE_M
+    assert cfg["heartbeat"] == H.DEFAULT_HEARTBEAT
+    assert cfg["enabled"] is True
+
+
+def test_max_age_is_clamped_to_the_supported_ceiling():
+    # An unbounded window would grow the ring until the process dies.
+    assert H.history_config({"history_max_age": 99_999_999})["max_age"] == H.MAX_AGE_LIMIT
+    assert H.history_config({"history_max_age": -5})["max_age"] > 0
+
+
+def test_booleans_are_not_accepted_as_numbers():
+    # isinstance(True, int) holds in Python: a hand-edited `true` must fall
+    # back to the default, not silently configure a 1-metre move threshold.
+    assert H.history_config({"history_min_move_m": True})["min_move_m"] == H.DEFAULT_MIN_MOVE_M
+
+
+def test_disabled_records_nothing():
+    h = hist(enabled=False)
+    assert h.record(ENT, 1000.0, 0.0, 0.0, FLOOR, SCALE) is False
+    assert h.entities() == []
+
+
+# --------------------------------------------------------------------------- #
+# The recording gate
+# --------------------------------------------------------------------------- #
+def test_a_stationary_device_only_costs_its_heartbeat():
+    h = hist()
+    t0 = 1_000_000.0
+    for i in range(120):           # 120 s of standing still, 1 Hz
+        h.record(ENT, t0 + i, 5.0, 5.0, FLOOR, SCALE)
+    # First point + one per 30 s heartbeat.
+    assert all_points(h)["count"] == 4
+
+
+def test_a_walk_is_kept_at_the_minimum_interval():
+    h = hist()
+    t0 = 1_000_000.0
+    for i in range(60):            # 1 m/s for a minute
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    assert all_points(h)["count"] == 30   # every 2 s
+
+
+def test_jitter_below_the_move_threshold_is_dropped():
+    h = hist()
+    t0 = 1_000_000.0
+    for i in range(30):            # 10 cm of noise every 2 s for a minute
+        h.record(ENT, t0 + i * 2, 0.1 * (i % 2), 0.0, FLOOR, SCALE)
+    # Only the first point and the 30 s heartbeat: none of the jitter earns a
+    # point of its own, so a device sitting on a table costs almost nothing.
+    assert all_points(h)["count"] == 2
+
+
+def test_a_floor_change_is_always_kept_and_breaks_the_line():
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 1.0, 1.0, "A", 40.0)
+    # Sub-interval and sub-movement, but a different floor: the two points live
+    # in different pixel frames, so joining them would draw a nonsense segment.
+    assert h.record(ENT, t0 + 0.5, 1.0, 1.0, "B", 50.0) is True
+    got = all_points(h)
+    assert got["count"] == 2
+    assert got["gap"] == [1, 1]
+    assert got["floors"] == ["A", "B"]
+    assert got["scales"] == [40.0, 50.0]
+
+
+def test_clock_going_backwards_restarts_the_buffer():
+    # The arrays are searched with bisect everywhere, so one out-of-order
+    # append would make query() and evict() return nonsense. A clock that steps
+    # backwards therefore starts the buffer over rather than corrupting it.
+    h = hist()
+    for i in range(5):
+        h.record(ENT, 1_000_000.0 + i * 5, float(i), 0.0, FLOOR, SCALE)
+    h.record(ENT, 999_000.0, 9.0, 9.0, FLOOR, SCALE)
+    got = all_points(h)
+    assert got["t"] == [999_000.0]
+    assert got["gap"] == [1]
+    assert list(got["t"]) == sorted(got["t"])
+
+
+def test_a_dropout_breaks_the_line_before_the_prune_timeout():
+    # A device unheard for a couple of minutes was not standing still; joining
+    # across the silence would draw a straight line through whatever it
+    # actually did. The explicit mark_gap only arrives after the much longer
+    # position_timeout, so the recorder has to notice this itself.
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 0.0, 0.0, FLOOR, SCALE)
+    h.record(ENT, t0 + 20, 5.0, 0.0, FLOOR, SCALE)     # normal, no break
+    h.record(ENT, t0 + 200, 9.0, 0.0, FLOOR, SCALE)    # after a silence
+    assert all_points(h)["gap"] == [1, 0, 1]
+
+
+def test_mark_gap_breaks_the_next_segment():
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 0.0, 0.0, FLOOR, SCALE)
+    h.record(ENT, t0 + 5, 5.0, 0.0, FLOOR, SCALE)
+    h.mark_gap(ENT)                      # tracker pruned for absence
+    h.record(ENT, t0 + 600, 40.0, 0.0, FLOOR, SCALE)
+    assert all_points(h)["gap"] == [1, 0, 1]
+
+
+def test_non_finite_and_unnamed_input_is_refused():
+    h = hist()
+    assert h.record(ENT, float("nan"), 0.0, 0.0, FLOOR, SCALE) is False
+    assert h.record(ENT, 1000.0, float("inf"), 0.0, FLOOR, SCALE) is False
+    assert h.record("", 1000.0, 0.0, 0.0, FLOOR, SCALE) is False
+    assert h.entities() == []
+
+
+# --------------------------------------------------------------------------- #
+# Eviction
+# --------------------------------------------------------------------------- #
+def test_points_older_than_the_window_are_evicted():
+    # Regression: compaction used to be gated on `max_points // 10`, so a ring
+    # holding far fewer points than the cap (6 h at one point per 2 s is ~10k
+    # against a 200k cap) never compacted at all and max_age was ignored.
+    h = hist(max_age=100.0)
+    t0 = 1_000_000.0
+    for i in range(0, 4000, 4):        # 1000 fixes; ~25 fit the window
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    got = all_points(h)
+    assert got["t"][-1] == t0 + 3996   # the newest fix is always kept
+    # Compaction is amortised, so a few expired points may linger; what must
+    # hold is that the buffer tracks the WINDOW and not the length of the run.
+    assert got["count"] < 40
+    assert got["t"][-1] - got["t"][0] <= 100.0 * 1.5
+
+
+def test_max_points_bounds_memory_independently_of_age():
+    h = hist(max_age=10 ** 9, max_points=50)
+    t0 = 1_000_000.0
+    for i in range(500):
+        h.record(ENT, t0 + i * 4, float(i), 0.0, FLOOR, SCALE)
+    assert all_points(h)["count"] <= 50
+
+
+def test_the_surviving_head_starts_a_new_line_after_eviction():
+    # Whatever preceded the retained head is gone, so the first kept point must
+    # not be joined to a predecessor that no longer exists.
+    h = hist(max_age=50.0)
+    t0 = 1_000_000.0
+    for i in range(0, 200, 2):
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    assert all_points(h)["gap"][0] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Query + decimation
+# --------------------------------------------------------------------------- #
+def test_query_windows_to_the_requested_range():
+    h = hist(max_age=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(0, 600, 3):
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    got = h.query(ENT, t0 + 100, t0 + 200, 10 ** 9)
+    assert got["count"] > 0
+    assert all(t0 + 100 <= t <= t0 + 200 for t in got["t"])
+
+
+def test_decimation_still_spans_the_whole_window():
+    # The failure this guards against: a naive "first N points" cap makes the
+    # trail stop early, which reads as the device having stopped moving.
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(1000):
+        h.record(ENT, t0 + i * 3, float(i), 0.0, FLOOR, SCALE)
+    got = h.query(ENT, t0, t0 + 10 ** 6, 50)
+    assert got["count"] <= 60
+    assert got["t"][0] == t0
+    assert got["t"][-1] == t0 + 999 * 3
+    assert got["stride"] > 1
+
+
+def test_decimation_never_drops_a_gap_or_a_floor_change():
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(300):
+        floor = "A" if i < 150 else "B"
+        h.record(ENT, t0 + i * 3, float(i), 0.0, floor, SCALE)
+    got = h.query(ENT, t0, t0 + 10 ** 6, 20)
+    # The floor change is a gap, and every gap must survive the stride.
+    assert sum(got["gap"]) >= 2
+    assert set(got["floors"][i] for i in got["f"]) == {"A", "B"}
+
+
+def test_query_of_an_unknown_tracker_is_empty_not_an_error():
+    got = hist().query("nobody", 0, 1e12, 100)
+    assert got["count"] == 0 and got["t"] == []
+
+
+def test_retained_reports_the_actual_span():
+    h = hist(max_age=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(0, 100, 5):
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    span = h.retained(ENT)
+    assert span["from"] == t0 and span["to"] == t0 + 95 and span["points"] == 20
+    assert h.retained("nobody") is None
+
+
+# --------------------------------------------------------------------------- #
+# Disk segments
+# --------------------------------------------------------------------------- #
+def flush_to(h, dirpath):
+    return H.append_segments(dirpath, h.drain_pending())
+
+
+def test_round_trip_through_disk_is_lossless(tmp_path):
+    d = str(tmp_path / "hist")
+    h = hist(max_age=10 ** 9)
+    import time as _t
+    t0 = _t.time() - 500
+    for i in range(100):
+        h.record(ENT, t0 + i * 5, float(i) * 0.5, float(i) * 0.25, FLOOR, SCALE)
+    assert flush_to(h, d) == all_points(h)["count"]
+
+    before = all_points(h)
+    back = hist(max_age=10 ** 9)
+    back.load_rows(H.restore_recent(d, back.cfg))
+    after = all_points(back)
+    assert after["count"] == before["count"]
+    assert max(abs(a - b) for a, b in zip(after["t"], before["t"])) == 0
+    assert max(abs(a - b) for a, b in zip(after["x_m"], before["x_m"])) < 1e-3
+    assert after["floors"] == before["floors"]
+
+
+def test_a_torn_final_line_costs_only_that_line(tmp_path):
+    d = str(tmp_path / "hist")
+    h = hist(max_age=10 ** 9)
+    import time as _t
+    t0 = _t.time() - 200
+    for i in range(20):
+        h.record(ENT, t0 + i * 5, float(i), 0.0, FLOOR, SCALE)
+    flush_to(h, d)
+    day = H.day_key(t0)
+    path = H.segment_path(d, day)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write('{"e":"phone","t":123')      # power cut mid-append
+    back = hist(max_age=10 ** 9)
+    back.load_rows(H.restore_recent(d, back.cfg))
+    assert all_points(back)["count"] == 20
+
+
+def test_restore_ignores_rows_outside_the_window(tmp_path):
+    d = str(tmp_path / "hist")
+    os.makedirs(d, exist_ok=True)
+    import time as _t
+    now = _t.time()
+    lines = [json.dumps({"e": ENT, "t": now - 100, "x": 1.0, "y": 1.0, "f": FLOOR, "s": SCALE}),
+             json.dumps({"e": ENT, "t": now - 10 ** 6, "x": 9.0, "y": 9.0, "f": FLOOR, "s": SCALE})]
+    H.append_segments(d, {H.day_key(now): lines})
+    back = hist()
+    back.load_rows(H.read_segments(d, H.list_day_keys(d)))
+    assert all_points(back)["count"] == 1
+
+
+def test_expired_day_segments_are_pruned(tmp_path):
+    d = str(tmp_path / "hist")
+    import time as _t
+    now = _t.time()
+    H.append_segments(d, {
+        "20200101": [json.dumps({"e": ENT, "t": 1.0, "x": 0, "y": 0, "f": FLOOR})],
+        H.day_key(now): [json.dumps({"e": ENT, "t": now, "x": 0, "y": 0, "f": FLOOR})],
+    })
+    removed = H.prune_segments(d, 6 * 3600, now)
+    assert removed == ["20200101"]
+    assert H.list_day_keys(d) == [H.day_key(now)]
+
+
+def test_drop_entity_rewrites_segments_without_that_tracker(tmp_path):
+    d = str(tmp_path / "hist")
+    import time as _t
+    now = _t.time()
+    day = H.day_key(now)
+    H.append_segments(d, {day: [
+        json.dumps({"e": "a", "t": now - 3, "x": 1, "y": 1, "f": FLOOR}),
+        json.dumps({"e": "b", "t": now - 2, "x": 2, "y": 2, "f": FLOOR}),
+        json.dumps({"e": "a", "t": now - 1, "x": 3, "y": 3, "f": FLOOR}),
+    ]})
+    assert H.drop_entity(d, "a", H.history_config({})) == 2
+    rows = H.read_segments(d, H.list_day_keys(d))
+    assert [r["e"] for r in rows] == ["b"]
+
+
+def test_drop_entity_removes_a_segment_it_empties(tmp_path):
+    d = str(tmp_path / "hist")
+    import time as _t
+    now = _t.time()
+    H.append_segments(d, {H.day_key(now): [
+        json.dumps({"e": "a", "t": now, "x": 1, "y": 1, "f": FLOOR})]})
+    H.drop_entity(d, "a", H.history_config({}))
+    assert H.list_day_keys(d) == []
+    assert not os.path.exists(H.segment_path(d, H.day_key(now)) + ".tmp")
+
+
+def test_forget_drops_only_that_trackers_queued_rows():
+    # A clear must not be undone by a flush of rows queued moments earlier —
+    # and must not take the other trackers' rows down with it.
+    h = hist()
+    t0 = 1_000_000.0
+    h.record("a", t0, 0.0, 0.0, FLOOR, SCALE)
+    h.record("b", t0, 0.0, 0.0, FLOOR, SCALE)
+    h.forget("a")
+    grouped = h.drain_pending()
+    rows = [json.loads(line) for lines in grouped.values() for line in lines]
+    assert [r["e"] for r in rows] == ["b"]
+    assert h.entities() == ["b"]
+
+
+def test_pending_queue_is_bounded():
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    h.MAX_PENDING = 10
+    t0 = 1_000_000.0
+    for i in range(100):
+        h.record(ENT, t0 + i * 5, float(i), 0.0, FLOOR, SCALE)
+    assert h.pending_count() == 10
+    assert h.dropped_pending > 0
+
+
+# --------------------------------------------------------------------------- #
+# The HTTP view + integration wiring
+# --------------------------------------------------------------------------- #
+class _Req:
+    def __init__(self, query=None, body=None):
+        self.query = query or {}
+        self._body = body
+
+    async def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+def api(hass):
+    return bps.BPSHistoryAPI(hass)
+
+
+def seeded_hass(tmp_path, **layout):
+    hass = make_hass(tmp_path)
+    hass.data["bps"] = {"layout": dict(layout)}
+    h = bps.get_position_history(hass)
+    import time as _t
+    t0 = _t.time() - 300
+    for i in range(60):
+        h.record(ENT, t0 + i * 5, float(i) * 0.5, 0.0, FLOOR, SCALE)
+    return hass, h, t0
+
+
+def test_index_lists_what_is_retained(tmp_path):
+    hass, h, _ = seeded_hass(tmp_path)
+    res = run(api(hass).get(_Req()))
+    body = res.json_body
+    assert [t["ent"] for t in body["trackers"]] == [ENT]
+    assert body["trackers"][0]["points"] == h.retained(ENT)["points"]
+    assert body["config"]["max_age"] == H.DEFAULT_MAX_AGE
+
+
+def test_query_returns_metres_and_the_recording_scale(tmp_path):
+    hass, _, t0 = seeded_hass(tmp_path)
+    res = run(api(hass).get(_Req({"entity": ENT, "from": str(t0), "to": str(t0 + 10 ** 6)})))
+    body = res.json_body
+    assert body["count"] > 0
+    assert body["floors"] == [FLOOR] and body["scales"] == [SCALE]
+    assert body["x_m"][0] == 0.0            # metres, not pixels
+    assert body["retained"]["points"] >= body["count"]
+
+
+def test_query_honours_max_points(tmp_path):
+    hass, _, t0 = seeded_hass(tmp_path)
+    res = run(api(hass).get(_Req({"entity": ENT, "from": str(t0),
+                                  "to": str(t0 + 10 ** 6), "max_points": "5"})))
+    assert res.json_body["count"] <= 6
+
+
+def test_junk_query_params_fall_back_instead_of_500ing(tmp_path):
+    hass, _, _ = seeded_hass(tmp_path)
+    res = run(api(hass).get(_Req({"entity": ENT, "from": "yesterday",
+                                  "to": "NaN", "max_points": "1e999"})))
+    assert res.status == 200 and res.json_body["count"] > 0
+
+
+def test_reversed_window_is_normalised(tmp_path):
+    hass, _, t0 = seeded_hass(tmp_path)
+    res = run(api(hass).get(_Req({"entity": ENT, "from": str(t0 + 10 ** 6), "to": str(t0)})))
+    assert res.json_body["count"] > 0
+
+
+def test_layout_settings_reach_the_recorder(tmp_path):
+    hass, h, _ = seeded_hass(tmp_path)
+    hass.data["bps"]["layout"]["history_max_age"] = 900
+    run(api(hass).get(_Req()))
+    assert h.cfg["max_age"] == 900.0
+
+
+def test_post_requires_a_known_action(tmp_path):
+    hass, _, _ = seeded_hass(tmp_path)
+    assert run(api(hass).post(_Req(body={"action": "nope"}))).status == 400
+    assert run(api(hass).post(_Req(body=["not", "an", "object"]))).status == 400
+    assert run(api(hass).post(_Req())).status == 400
+
+
+def test_clear_forgets_memory_and_disk(tmp_path):
+    hass, h, _ = seeded_hass(tmp_path)
+    run(bps.flush_position_history(hass))
+    assert H.list_day_keys(bps.history_dir(hass))
+    res = run(api(hass).post(_Req(body={"action": "clear"})))
+    assert res.status == 200
+    assert h.entities() == []
+    assert H.list_day_keys(bps.history_dir(hass)) == []
+
+
+def test_clear_of_one_tracker_leaves_the_others(tmp_path):
+    hass, h, _ = seeded_hass(tmp_path)
+    import time as _t
+    h.record("other", _t.time(), 1.0, 1.0, FLOOR, SCALE)
+    run(bps.flush_position_history(hass))
+    run(api(hass).post(_Req(body={"action": "clear", "entity": ENT})))
+    assert h.entities() == ["other"]
+    rows = H.read_segments(bps.history_dir(hass), H.list_day_keys(bps.history_dir(hass)))
+    assert {r["e"] for r in rows} == {"other"}
+
+
+def test_restore_after_a_restart_reloads_and_breaks_the_line(tmp_path):
+    hass, h, _ = seeded_hass(tmp_path)
+    kept = h.retained(ENT)["points"]
+    run(bps.flush_position_history(hass))
+
+    # "Restart": same config dir, fresh in-memory history.
+    fresh = make_hass(tmp_path)
+    fresh.data["bps"] = {"layout": {}}
+    run(bps.restore_position_history(fresh))
+    back = bps.get_position_history(fresh)
+    assert back.retained(ENT)["points"] == kept
+    # Nothing must be written back out: the rows are already on disk.
+    assert back.pending_count() == 0
+    # The next fix after an outage of unknown length starts a new polyline.
+    import time as _t
+    back.record(ENT, _t.time(), 99.0, 99.0, FLOOR, SCALE)
+    assert all_points(back, ENT)["gap"][-1] == 1
+
+
+def test_history_is_stored_outside_the_web_root(tmp_path):
+    # www/ is served to anyone who can guess a URL; the movement record is not
+    # something to publish. It lives under .storage with the rest of the state.
+    hass = make_hass(tmp_path)
+    path = bps.history_dir(hass).replace("\\", "/")
+    assert "/.storage/" in path and "/www/" not in path
+
+
+# --------------------------------------------------------------------------- #
+# Regressions from the adversarial review of this feature
+# --------------------------------------------------------------------------- #
+def test_a_reload_does_not_duplicate_the_ring(tmp_path):
+    # async_unload_entry cancels the tracking task but leaves hass.data alone,
+    # so setup re-enters with the SAME PositionHistory. Re-reading the segments
+    # there appended a second copy of every point and left the arrays unsorted,
+    # which breaks every bisect in query() and evict().
+    hass, h, _ = seeded_hass(tmp_path)
+    run(bps.flush_position_history(hass))
+    import time as _t
+    h.record(ENT, _t.time(), 42.0, 42.0, FLOOR, SCALE)   # not yet flushed
+    before = h.retained(ENT)["points"]
+    pending = h.pending_count()
+
+    run(bps.restore_position_history(hass))              # the reload
+
+    assert h.retained(ENT)["points"] == before
+    assert list(h.tracks[ENT].t) == sorted(h.tracks[ENT].t)
+    assert h.pending_count() == pending                  # unflushed rows kept
+
+
+def test_clear_is_not_undone_by_a_concurrent_flush(tmp_path):
+    # The flush drains its rows and writes them in the executor; a clear that
+    # landed in between used to be overwritten by that write, so the forgotten
+    # positions came back on the next restart.
+    hass, h, _ = seeded_hass(tmp_path)
+
+    async def both():
+        await asyncio.gather(
+            bps.flush_position_history(hass),
+            api(hass).post(_Req(body={"action": "clear"})),
+        )
+
+    asyncio.new_event_loop().run_until_complete(both())
+    d = bps.history_dir(hass)
+    assert H.read_segments(d, H.list_day_keys(d)) == []
+    assert h.entities() == []
+
+
+def test_pruning_is_skipped_when_the_retention_cannot_be_trusted(tmp_path):
+    # Pruning deletes days irreversibly. With no layout dict (fresh install, or
+    # a store that failed to load this boot) history_config falls back to the
+    # 6 h default, which would take a configured 7-day record down to six hours.
+    import time as _t
+    hass = make_hass(tmp_path)
+    hass.data["bps"] = {"layout": []}          # not a dict
+    d = bps.history_dir(hass)
+    old_day = H.day_key(_t.time() - 3 * 86400)
+    H.append_segments(d, {old_day: [json.dumps(
+        {"e": ENT, "t": 1.0, "x": 0, "y": 0, "f": FLOOR})]})
+    run(bps.flush_position_history(hass, prune=True))
+    assert H.list_day_keys(d) == [old_day]     # still there
+
+    hass.data["bps"]["layout"] = {"history_max_age": 3600}
+    run(bps.flush_position_history(hass, prune=True))
+    assert H.list_day_keys(d) == []            # now it is safe to prune
+
+
+def test_a_silent_tracker_stops_being_served_past_the_window():
+    # record() only ages the track it touched, so a device that left the house
+    # kept serving its last position long past the configured retention.
+    h = hist(max_age=100.0)
+    t0 = 1_000_000.0
+    for i in range(0, 60, 5):
+        h.record(ENT, t0 + i, float(i), 0.0, FLOOR, SCALE)
+    assert h.retained(ENT)["points"] > 0
+    h.evict_all(now=t0 + 10_000)
+    assert h.retained(ENT) is None
+
+
+def test_query_is_capped_even_when_every_point_is_a_break():
+    # Gaps and floor changes are force-kept, so data that flaps between floors
+    # defeats the stride entirely - megabytes of JSON for a small request.
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(4000):
+        h.record(ENT, t0 + i * 3, float(i), 0.0, "A" if i % 2 else "B", SCALE)
+    got = h.query(ENT, t0, t0 + 10 ** 6, 50)
+    assert got["count"] <= 101          # the hard cap is 2x the request
+    assert got["t"][0] == t0 and got["t"][-1] == t0 + 3999 * 3
+
+
+def test_a_torn_tail_does_not_swallow_the_next_good_row(tmp_path):
+    import time as _t
+    d = str(tmp_path / "hist")
+    now = _t.time()
+    day = H.day_key(now)
+    H.append_segments(d, {day: [json.dumps({"e": ENT, "t": now - 9, "x": 1, "y": 1, "f": FLOOR})]})
+    with open(H.segment_path(d, day), "a", encoding="utf-8") as fh:
+        fh.write('{"e":"phone","t":123')            # died mid-append, no newline
+    H.append_segments(d, {day: [json.dumps({"e": ENT, "t": now - 1, "x": 2, "y": 2, "f": FLOOR})]})
+    rows = H.read_segments(d, [day])
+    # The torn line is lost (unavoidable); the row appended after it is not.
+    assert [r["x"] for r in rows] == [1, 2]
+
+
+def test_one_corrupt_byte_costs_one_line_not_the_restore(tmp_path):
+    # UnicodeDecodeError is not an OSError, so it escaped the guard and took
+    # the whole restore (and per-tracker clear) down with it.
+    import time as _t
+    d = str(tmp_path / "hist")
+    now = _t.time()
+    day = H.day_key(now)
+    H.append_segments(d, {day: [
+        json.dumps({"e": ENT, "t": now - 9, "x": 1, "y": 1, "f": FLOOR}),
+        json.dumps({"e": ENT, "t": now - 8, "x": 2, "y": 2, "f": FLOOR}),
+    ]})
+    with open(H.segment_path(d, day), "ab") as fh:
+        fh.write(b"\xff\xfe not utf-8 at all\n")
+    rows = H.read_segments(d, [day])
+    assert [r["x"] for r in rows] == [1, 2]
+    assert H.drop_entity(d, ENT, H.history_config({})) == 2
+
+
+def test_orphaned_tmp_files_are_swept(tmp_path):
+    # list_day_keys ignores .tmp, so a rewrite that died left a full copy of
+    # the record that neither Clear nor the pruner ever removed.
+    import time as _t
+    d = str(tmp_path / "hist")
+    now = _t.time()
+    H.append_segments(d, {H.day_key(now): [json.dumps(
+        {"e": ENT, "t": now, "x": 1, "y": 1, "f": FLOOR})]})
+    orphan = H.segment_path(d, "20200101") + ".tmp"
+    with open(orphan, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"e": ENT, "t": 1.0, "x": 9, "y": 9, "f": FLOOR}) + "\n")
+    H.prune_segments(d, 3600, now)
+    assert not os.path.exists(orphan)
+    H.clear_segments(d)
+    assert os.listdir(d) == []
+
+
+def test_a_failed_write_puts_the_rows_back():
+    h = hist()
+    t0 = 1_000_000.0
+    for i in range(10):
+        h.record(ENT, t0 + i * 40, float(i), 0.0, FLOOR, SCALE)
+    grouped = h.drain_pending()
+    assert h.pending_count() == 0
+    h.requeue(grouped)
+    assert h.pending_count() == 10
+    rows = [json.loads(line) for lines in h.drain_pending().values() for line in lines]
+    assert [r["e"] for r in rows] == [ENT] * 10
+
+
+def test_coordinates_are_coerced_not_type_checked():
+    # The solver hands back whatever numpy type the Kalman/clip path produced.
+    # np.float32 is NOT a subclass of float, so an isinstance gate would have
+    # silently recorded nothing at all.
+    from decimal import Decimal
+
+    class Float32Like(float):
+        pass
+
+    h = hist()
+    assert h.record(ENT, 1_000_000.0, Float32Like(1.5), Decimal("2.5"), FLOOR, SCALE)
+    got = all_points(h)
+    assert got["x_m"] == [1.5] and got["y_m"] == [2.5]
+
+
+def test_a_giant_json_number_in_a_segment_is_skipped_not_fatal(tmp_path):
+    # math.isfinite() raises OverflowError on an int with hundreds of digits,
+    # which would abort the restore rather than skip the bad row.
+    import time as _t
+    d = str(tmp_path / "hist")
+    now = _t.time()
+    day = H.day_key(now)
+    H.append_segments(d, {day: [
+        '{"e":"phone","t":' + "9" * 400 + ',"x":1,"y":1,"f":"Main"}',
+        json.dumps({"e": ENT, "t": now - 1, "x": 3, "y": 3, "f": FLOOR}),
+    ]})
+    back = hist()
+    assert back.load_rows(H.read_segments(d, [day])) == 1
+    assert all_points(back)["x_m"] == [3.0]
+
+
+def test_prune_keeps_exactly_what_restore_reads_back(tmp_path):
+    # The pruner used a day of extra slack the restore then filtered out, so
+    # the oldest kept segment was never read.
+    import time as _t
+    d = str(tmp_path / "hist")
+    now = _t.time()
+    cfg = H.history_config({"history_max_age": 6 * 3600})
+    for back_days in range(4):
+        day = H.day_key(now - back_days * 86400)
+        H.append_segments(d, {day: [json.dumps(
+            {"e": ENT, "t": now - back_days * 86400, "x": back_days, "y": 0, "f": FLOOR})]})
+    H.prune_segments(d, cfg["max_age"], now)
+    kept = set(H.list_day_keys(d))
+    read = {H.day_key(r["t"]) for r in H.restore_recent(d, cfg, now)}
+    assert kept == read


### PR DESCRIPTION
Closes the "live tracking / past positions" request: a time scrubber on the map that replays where a tracked device has been, with a configurable retention window.

## What you get

Switch **History** on above the map and a scrubber appears:

| control | what it does |
|---|---|
| Device / span | which device, and how far back to load |
| Slider | drag through the loaded window — solid trail up to the marker, faint dashed ghost beyond it |
| Time picker | jump to a moment; the window reloads **centred** on it, so you see the movement *around* that time |
| ▶ + rate | replay forward on its own at 1× to 600× |
| Live | jump back to now and keep following |

**Position history** in the Tracking column sets how long is kept (off, 1 hour … 7 days; 6 hours by default) and **Clear** forgets everything immediately.

## Design notes worth reviewing

- **Not the recorder.** `purge_keep_days` is global and day-granular, so it cannot express "keep six hours of this", and at ~1 fix/s/device this would add tens of megabytes a day to the database for data only this map can use. BPS keeps its own record under `config/.storage/bps_history/` — deliberately **not** `www/`, which is web-served.
- **Metres, not pixels.** Points are stored in metres on their floor plus the scale in force at the time; the pixel projection happens at render time with the *current* scale. Re-export a floor plan at a different resolution and the past still lands where it happened.
- **Cheap when nothing happens.** A point is kept only when the device actually moved, or every 30 s as a heartbeat — a phone on a table costs ~120 points/hour, not 3600. Storage is a columnar ring at ~17 B/point.
- **Breaks stay breaks.** A floor change, a restart, a dropout, or a tracker pruned for absence starts a new polyline instead of drawing a straight segment across the gap.
- **Durability.** Append-only NDJSON day segments; a crash can lose the tail of one segment, never the record (the #104 lesson). All disk work is in the executor and every failure path is swallowed — history must never break or stall tracking.

## Heads-up on the default

Recording is **on by default** with a 6-hour window. That is a location record, so if you would rather it be opt-in, say so and I will flip the default to off — everything else stays the same.

## Verification

- `tests/test_history.py` — 51 tests covering the gate, eviction, decimation, the disk layer, the HTTP handlers and the restart/reload paths. Full suite: **136 passed**.
- Panel driven end-to-end in a browser harness against a synthetic 2 h walk with a 10-minute absence and a floor excursion: trail renders, scrubbing drops the Live latch and follows the cursor, playback advances at the selected rate, the time picker centres the window (|centre − target| < 60 s), off-floor stretches are excluded with a status note, Clear round-trips.

## Review findings fixed in this branch

An adversarial review of the diff (7 lenses, every finding independently verified) confirmed 30 defects, all fixed here. The ones that mattered:

- **Integration reload duplicated the whole ring** and left the arrays unsorted, breaking every `bisect` in `query()`/`evict()` — measured 70 → 130 points, `retained()` reporting 50 s short of the newest point, and `evict()` deleting the entire buffer. Restore is now a no-op on a live ring.
- **Clear could be undone** by a flush that had already drained its rows — the forgotten positions were back on disk and returned after the next restart. All history disk work now runs under one lock, with the drain inside it.
- **Retention was enforced only on the recording path**, so a tracker that went silent kept serving positions forever.
- **Pruning ran against a guessed `max_age`** whenever the layout cache was not a dict, which would have cut a configured 7-day record to six hours. It now skips rather than guess.
- A backwards clock step corrupted the ring; gap-marked points defeated `max_points` entirely (6.2 MB responses measured); `evict()` memmoved the whole buffer once per fix at the cap; a corrupt byte cost the entire restore; a torn tail swallowed the next good row; orphaned `.tmp` files were invisible to both Clear and the pruner; a `np.float32` from the solver would have silently recorded nothing.
- Panel: the trail vanished on a floor switch and never came back; a device with no history kept showing the previous one's trail; the time picker moved the cursor even when the load failed; every untracked device drew in the same red; retention hid every span that could show the whole record; the device picker was filled once and never refreshed.

Version bumped to **1.9.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
