### PR TITLE
History marker: use the device's own tracker icon

### DIFF
--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1654,6 +1654,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const HISTORY_REFRESH_MS = 5000;   // while latched to Live
     const HISTORY_MAX_POINTS = 3000;   // server decimates to this, spanning the window
+    // The scrubbed marker draws the device's tracker icon at this fraction of
+    // the live icon's size, so a past position is never mistaken for the
+    // present one when both are on screen during a tracking session.
+    const HISTORY_MARKER_SCALE = 0.7;
 
     const historyState = {
         ent: null,
@@ -2025,27 +2029,64 @@ document.addEventListener('DOMContentLoaded', async () => {
             ctx.fill();
         }
 
-        // The scrubbed position. Sized off the canvas like the tracker icons
-        // (the world is a fixed 2000 px wide, so fixed radii would vanish on a
-        // large floor plan). Dimmed to a hollow ring when that fix belongs to
-        // another floor — the coordinates are real, just not for this map.
+        // The scrubbed position, drawn with the DEVICE'S OWN tracker icon — the
+        // same glyph the live map and the Tracking column use — so the marker
+        // reads as "this device, back then" rather than as an anonymous dot.
+        // Three things keep it from being mistaken for the live marker sitting
+        // next to it during a session: it is drawn smaller, it carries a ring
+        // in the device's colour, and it sits on a halo of that colour.
+        // Dimmed when that fix belongs to another floor — the coordinates are
+        // real, just not for this map.
         const here = px(cursor);
         const off = !onFloor(cursor);
-        const r = Math.max(7, canvas.width * 0.008);
-        ctx.beginPath();
-        ctx.arc(here.x, here.y, r * 1.6, 0, Math.PI * 2);
-        ctx.fillStyle = `hsla(${baseHue}, 95%, 60%, ${off ? 0.1 : 0.25})`;
-        ctx.fill();
-        ctx.beginPath();
-        ctx.arc(here.x, here.y, r, 0, Math.PI * 2);
-        ctx.lineWidth = 3;
-        ctx.strokeStyle = "rgba(15, 15, 20, 0.75)";
-        ctx.stroke();
-        ctx.fillStyle = off ? "transparent" : `hsl(${baseHue}, 95%, 60%)`;
-        ctx.fill();
-        ctx.strokeStyle = `hsl(${baseHue}, 95%, 70%)`;
-        ctx.lineWidth = 1.5;
-        ctx.stroke();
+        const fade = off ? 0.35 : 1;
+        const src = historyState.ent ? trackerIconFor(historyState.ent) : null;
+        // Null until the glyph has loaded; getCachedImage repaints on load, so
+        // the dot below is only ever a first-frame stand-in.
+        const glyph = src ? getCachedImage(src) : null;
+
+        if (glyph) {
+            const size = mapIconSize() * HISTORY_MARKER_SCALE;
+            const half = size / 2;
+            ctx.beginPath();
+            ctx.arc(here.x, here.y, half * 1.05, 0, Math.PI * 2);
+            ctx.fillStyle = `hsla(${baseHue}, 95%, 60%, ${off ? 0.12 : 0.3})`;
+            ctx.fill();
+            ctx.save();
+            ctx.globalAlpha = fade;
+            ctx.drawImage(glyph, here.x - half, here.y - half, size, size);
+            // The same 10% colour wash the live icon gets, so the two agree on
+            // which device this is.
+            const tinted = tintedImage(glyph, src, `hsl(${baseHue}, 85%, 45%)`, size);
+            if (tinted) {
+                ctx.globalAlpha = fade * 0.1;
+                ctx.drawImage(tinted, here.x - half, here.y - half, size, size);
+            }
+            ctx.restore();
+            ctx.beginPath();
+            ctx.arc(here.x, here.y, half * 1.05, 0, Math.PI * 2);
+            ctx.lineWidth = Math.max(2, size * 0.05);
+            ctx.strokeStyle = `hsla(${baseHue}, 95%, 62%, ${off ? 0.4 : 0.95})`;
+            ctx.stroke();
+        } else {
+            // Sized off the canvas (the world is a fixed 2000 px wide, so a
+            // fixed radius would vanish on a large floor plan).
+            const r = Math.max(7, canvas.width * 0.008);
+            ctx.beginPath();
+            ctx.arc(here.x, here.y, r * 1.6, 0, Math.PI * 2);
+            ctx.fillStyle = `hsla(${baseHue}, 95%, 60%, ${off ? 0.1 : 0.25})`;
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(here.x, here.y, r, 0, Math.PI * 2);
+            ctx.lineWidth = 3;
+            ctx.strokeStyle = "rgba(15, 15, 20, 0.75)";
+            ctx.stroke();
+            ctx.fillStyle = off ? "transparent" : `hsl(${baseHue}, 95%, 60%)`;
+            ctx.fill();
+            ctx.strokeStyle = `hsl(${baseHue}, 95%, 70%)`;
+            ctx.lineWidth = 1.5;
+            ctx.stroke();
+        }
         ctx.restore();
     }
 
@@ -2567,7 +2608,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ensureTrackerIconsStore();
                 finalcords.tracker_icons[activeDevice] = trackerIconSelector.value;
                 savebuttondiv.appendChild(saveButton);
-                if (pollTrackActive && img.naturalWidth > 0) redrawAll();
+                // NOT gated on pollTrackActive: the history marker draws this
+                // glyph too, and it is painted with or without a session. The
+                // gate left the scrubbed marker showing the old icon until the
+                // user happened to pan, zoom or scrub.
+                if (img.naturalWidth > 0) redrawAll();
             });
         }
 
@@ -2682,7 +2727,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     ensureTrackerIconsStore();
                     finalcords.tracker_icons[target] = payload.icon_url;
                     savebuttondiv.appendChild(saveButton);
-                    if (pollTrackActive && img.naturalWidth > 0) redrawAll();
+                    if (img.naturalWidth > 0) redrawAll();   // see the selector handler
                     bpsToast("Tracker icon uploaded. Click Save Floor Plan to persist.");
                 } catch (error) {
                     console.error("Icon upload failed:", error);


### PR DESCRIPTION
The scrubbed position was an anonymous coloured dot. It now draws the **same glyph the live map and the Tracking column use** for that device.

Three things keep it from being confused with the live marker sitting beside it during a session: it's drawn at **0.7×**, it carries a **ring** in the device's colour, and it sits on a **halo** of that colour. Off-floor fixes fade to 0.35 like the live overlay does, instead of switching to a hollow ring, and the old dot stays as the stand-in until the glyph has loaded (`getCachedImage` repaints on load, so it's a first-frame thing only).

Verified in a harness with two devices given deliberately different icons — `phone` → `person.svg`, `watch` → `beacon.svg`. Both render their own glyph (1698 vs 913 dark pixels in the same crop: the signature of a filled figure vs line art), and off-floor still fades rather than vanishing (mean luminance 152 vs 75).

### Also fixed, from the review of this change

Changing or uploading a device's icon repainted **only while a tracking session was running**. The history marker is painted with or without one, so it kept drawing the old glyph until the user happened to pan, zoom or scrub — self-correcting within 5 s in Live mode, which made it look intermittent. Both `tracker_icons` mutation sites now repaint unconditionally. Verified with no session: flipping the icon moves the marker's mean luminance 72 → 116 → 72, reproducibly, with nothing else touched.

### Deliberately not fixed

The review also flagged that the marker's size jumps 4× at high zoom when a session starts, since `mapIconSize()` only zoom-compensates while tracking. Two verifiers reached opposite verdicts on this; the dismissing one is right, and the premise checks out — `drawElements()` calls the same `mapIconSize()` for **every receiver icon**, session or not:

| | receiver icon | marker (now) | ratio | marker (proposed fix) | ratio |
|---|---|---|---|---|---|
| zoom 1, no session | 80.0 | 56.0 | 0.70 | 56.0 | 0.700 |
| zoom 8, no session | 80.0 | 56.0 | 0.70 | 14.0 | **0.175** |
| zoom 8, session on | 20.0 | 14.0 | 0.70 | 14.0 | 0.700 |

The whole map already resizes together, and the marker holds a constant 0.7 of a receiver icon in both modes. Always compensating would make it the only icon that *doesn't* move with the others.

Version stays at **2.0.0** — the release is still a draft, so this lands in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
