### PR TITLE
Room band: which room the device was in, under the history slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,11 @@ in the Tracking column hides it (and its trail) when it is in the way:
 - **Device** and **how far back** to load, then drag the **slider** to move
   through the recording. The trail is solid up to the marker and a faint dashed
   ghost beyond it, so the moment you are looking at is unmistakable.
+- The **room band** under the slider shows which room the device was in across
+  the whole window, in each zone's own map colour. Rooms it was never in take no
+  space, so a glance answers "when was it in the kitchen?" — hover to read a
+  moment off, click to jump there. A stretch where nothing was recorded is drawn
+  as a hole and reads as *not recorded* rather than guessing the last room.
 - **Click a device** — in the tracked-device list, or its beacon on the map —
   and the scrubber follows it, so the trail on screen belongs to the device you
   just clicked. It works the other way too: picking a device in the scrubber

--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -1383,7 +1383,7 @@ async def update_trilateration_and_zone(hass, new_global_data, entity):
             try:
                 get_position_history(hass).record(
                     entity, time.time(), avg_x / scale, avg_y / scale,
-                    lowest_floor_name, scale)
+                    lowest_floor_name, scale, zone)
             except Exception as e:  # history must never break tracking
                 _LOGGER.debug("Position history record failed for %s: %s", entity, e)
         update_bps_sensor_state(hass, f"sensor.{entity}_bps_zone", zone)

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3385,10 +3385,63 @@ input[type="checkbox"] { accent-color: hsl(var(--sidebar-primary)); }
     color: hsl(142 70% 40%);
     font-weight: 600;
 }
+/* Slider + room band stacked in one flexible column. The thumb is given an
+   explicit width so the band can be inset by exactly half of it and the two
+   share a coordinate system: at any x, the thumb and the band mean the same
+   moment. */
+.bps-history-track {
+    flex: 1 1 260px;
+    min-width: 160px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
 .bps-history-slider {
-    flex: 1 1 220px;
-    min-width: 140px;
+    width: 100%;
+    margin: 0;
     accent-color: hsl(var(--sidebar-primary));
+}
+/* appearance:none is load-bearing, not decoration: without it Chrome ignores
+   width/height on the thumb entirely, and the band's 7px inset below would be
+   guessing at the native thumb's size. Styling it makes the geometry true. */
+.bps-history-slider { -webkit-appearance: none; appearance: none; background: transparent; }
+.bps-history-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: hsl(var(--border));
+}
+.bps-history-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: hsl(var(--border));
+}
+.bps-history-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-top: -5px;                       /* centre on the 4px track */
+    border-radius: 50%;
+    border: none;
+    background: hsl(var(--sidebar-primary));
+}
+.bps-history-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: none;
+    background: hsl(var(--sidebar-primary));
+}
+.bps-history-slider:disabled::-webkit-slider-thumb { background: hsl(var(--muted-foreground)); }
+.bps-history-slider:disabled::-moz-range-thumb { background: hsl(var(--muted-foreground)); }
+.bps-history-zones {
+    display: block;
+    width: calc(100% - 14px);
+    margin: 0 7px;              /* half a thumb at each end: see above */
+    height: 20px;
+    border-radius: 3px;
+    cursor: pointer;
+    background: hsl(var(--muted) / 0.6);
 }
 .bps-history-stamp {
     flex: 0 0 auto;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -289,8 +289,18 @@
                             <button type="button" id="historyLive" class="bps-btn bps-btn-outline is-live" title="Jump to now and keep following">Live</button>
                         </div>
                         <div class="bps-history-row">
-                            <input type="range" id="historySlider" class="bps-history-slider"
-                                   min="0" max="0" value="0" step="1" title="Scrub through the loaded window">
+                            <!-- Slider and room band share one column so they line
+                                 up: both are linear in TIME across the loaded
+                                 window, so the thumb always sits over the room the
+                                 device was in at that moment. -->
+                            <div class="bps-history-track">
+                                <input type="range" id="historySlider" class="bps-history-slider"
+                                       min="0" max="0" value="0" step="any" title="Scrub through the loaded window">
+                                <!-- Which room the device was in, over the window.
+                                     Hover to read one off; click to jump there. -->
+                                <canvas id="historyZones" class="bps-history-zones"
+                                        title="Rooms over the loaded window — hover to read, click to jump"></canvas>
+                            </div>
                             <span id="historyStamp" class="bps-history-stamp">—</span>
                         </div>
                         <div id="historyStatus" class="bps-hint bps-history-status"></div>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -1640,6 +1640,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const historySpanSel = document.getElementById("historySpan");
     const historyAtInput = document.getElementById("historyAt");
     const historySlider = document.getElementById("historySlider");
+    const historyZoneCanvas = document.getElementById("historyZones");
+    let historyHoverX = null;   // pointer position within the band (css px), or null
+    let historySliderDriving = false;  // true while the slider's own handler renders
     const historyStamp = document.getElementById("historyStamp");
     const historyStatus = document.getElementById("historyStatus");
     const historyPlayBtn = document.getElementById("historyPlay");
@@ -1654,6 +1657,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const HISTORY_REFRESH_MS = 5000;   // while latched to Live
     const HISTORY_MAX_POINTS = 3000;   // server decimates to this, spanning the window
+    // gap values from the backend: both break the drawn line, but only DROPOUT
+    // means nothing was recorded across the interval. A floor change breaks the
+    // line (different pixel frame) while the record stays continuous, so the
+    // room band must not punch a hole there.
+    const HISTORY_GAP_DROPOUT = 2;
 
     const historyState = {
         ent: null,
@@ -1912,13 +1920,26 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!historyBar) return;
         const data = historyState.data;
         const count = data && data.count ? data.count : 0;
-        if (historySlider) {
-            historySlider.max = String(Math.max(0, count - 1));
-            historySlider.disabled = count === 0;
-            historySlider.value = String(Math.min(historyState.idx, Math.max(0, count - 1)));
+        // Writing the value back while the user is dragging or keying the
+        // slider snaps the thumb to the nearest recorded point on every event,
+        // which parks it at the edge of a dropout and makes it impossible to
+        // key across one. Playback, Live and click-to-seek still move it.
+        if (historySlider && !historySliderDriving) {
+            // Linear in TIME, not in index: a 10-minute gap has to read as ten
+            // minutes of travel, and the room band below only lines up with the
+            // thumb if both use the same scale. step="any" so the whole window
+            // is reachable whatever its length.
+            const first = count ? data.t[0] : 0;
+            const last = count ? data.t[count - 1] : 0;
+            historySlider.min = String(first);
+            historySlider.max = String(last > first ? last : first + 1);
+            historySlider.disabled = count < 2;
+            const at = count ? data.t[Math.min(historyState.idx, count - 1)] : 0;
+            historySlider.value = String(at);
         }
         if (historyLiveBtn) historyLiveBtn.classList.toggle("is-live", historyState.live);
         if (historyPlayBtn) historyPlayBtn.textContent = historyState.playing ? "❚❚" : "▶";
+        drawHistoryZoneBand();
         if (!count) {
             if (historyStamp) historyStamp.textContent = "—";
             if (historyStatus) {
@@ -1935,11 +1956,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             historyAtInput.value = historyToLocalInput(ts);
         }
         const floorName = data.floors[data.f[Math.min(historyState.idx, count - 1)]] || "";
+        const zoneName = (data.zones && data.zones[data.z ? data.z[Math.min(historyState.idx, count - 1)] : 0]) || "";
         const parts = [
+            zoneName || null,          // the room at the cursor, when recorded
             `${count} point${count === 1 ? "" : "s"}`,
             historyAgeText((data.now || Date.now() / 1000) - ts),
         ];
         if (data.stride > 1) parts.push(`1 in ${data.stride} shown`);
+        // Pointer over the room band: report the moment under it instead. This
+        // lives here so every repaint keeps it, including the Live poll.
+        const hoverTs = historyHoverTime();
+        if (hoverTs !== null) {
+            const room = historyRoomAt(hoverTs);
+            const label = room === null ? "not recorded" : (room || "unknown room");
+            if (historyStatus) {
+                historyStatus.textContent = `${label} at ${historyStampText(hoverTs)}`;
+            }
+            return;
+        }
         // The bar is always on screen, so it is the first thing seen on a fresh
         // panel - before any floor is chosen. Complaining that the fix is "not
         // this floor" or that "this floor has no scale" is nonsense there, so
@@ -1955,6 +1989,182 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
         if (historyStatus) historyStatus.textContent = parts.filter(Boolean).join(" · ");
+    }
+
+    // --- the room band -------------------------------------------------------
+    // A strip under the slider showing which room the device was in, across the
+    // loaded window. Both are linear in time over the same [first, last] range
+    // and the band is inset by half a thumb (see .bps-history-zones), so the
+    // thumb always sits over the room it is pointing at.
+    // A room's colour, matched to the map. Zones are looked up on the floor the
+    // POINT was recorded on, not the floor on screen — the band is a timeline of
+    // rooms and must stay readable while looking at another floor.
+    function historyZoneColor(name, floorName) {
+        if (!name) return null;                       // unknown: caller greys it
+        const floors = (finalcords && finalcords.floor) || [];
+        const floor = floors.find(f => sameFloorName(f.name, floorName));
+        const zones = (floor && floor.zones) || [];
+        const idx = zones.findIndex(z => z && z.entity_id === name);
+        if (idx >= 0) return zoneDisplayColor(zones[idx], idx);
+        // Recorded on a floor we no longer have, or a zone since renamed or
+        // deleted: a stable hash keeps it a consistent colour anyway.
+        let h = 0;
+        for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360;
+        return `hsl(${Math.round((h * 137.508) % 360)}, 55%, 55%)`;
+    }
+
+    // The runs of one room, as {from, to, name, floor} in seconds. A gap flag
+    // ends the run it starts: nothing was recorded across it, so the band must
+    // show a hole rather than imply the device stayed put.
+    function historyZoneRuns() {
+        const data = historyState.data;
+        if (!data || !data.count) return [];
+        const runs = [];
+        for (let i = 0; i < data.count; i++) {
+            const name = (data.zones && data.zones[data.z ? data.z[i] : 0]) || "";
+            const floor = data.floors[data.f[i]] || "";
+            const next = i + 1 < data.count ? i + 1 : -1;
+            // A point's room holds until the next point, EXCEPT across a
+            // dropout — nothing was recorded there, so the band shows a hole.
+            // A plain frame break (a floor change) is not a hole: the record
+            // continues, it just moved to another pixel space.
+            const hole = next >= 0 && data.gap[next] === HISTORY_GAP_DROPOUT;
+            // The last point has no successor, so it gets no width of its own.
+            const to = next >= 0 && !hole ? data.t[next] : data.t[i];
+            const prev = runs[runs.length - 1];
+            if (prev && prev.name === name && prev.floor === floor
+                && Math.abs(prev.to - data.t[i]) < 1e-6) {
+                prev.to = to;                        // extend the current run
+            } else if (to > data.t[i]) {
+                runs.push({ from: data.t[i], to, name, floor });
+            }
+        }
+        return runs;
+    }
+
+    function drawHistoryZoneBand() {
+        const cv = historyZoneCanvas;
+        if (!cv) return;
+        const cssW = cv.clientWidth, cssH = cv.clientHeight;
+        if (!cssW || !cssH) return;
+        // Back the canvas at device resolution so the labels are not fuzzy.
+        const dpr = Math.min(3, window.devicePixelRatio || 1);
+        if (cv.width !== Math.round(cssW * dpr) || cv.height !== Math.round(cssH * dpr)) {
+            cv.width = Math.round(cssW * dpr);
+            cv.height = Math.round(cssH * dpr);
+        }
+        const g = cv.getContext("2d");
+        g.setTransform(dpr, 0, 0, dpr, 0, 0);
+        g.clearRect(0, 0, cssW, cssH);
+
+        const data = historyState.data;
+        const count = data && data.count ? data.count : 0;
+        if (count < 2) return;
+        const t0 = data.t[0], t1 = data.t[count - 1];
+        const span = t1 - t0;
+        if (!(span > 0)) return;
+        const xOf = (t) => ((t - t0) / span) * cssW;
+
+        historyZoneRuns().forEach(run => {
+            const x0 = xOf(run.from);
+            const x1 = Math.max(x0 + 1, xOf(run.to));
+            const color = historyZoneColor(run.name, run.floor);
+            g.fillStyle = color || "hsla(220, 8%, 55%, 0.35)";   // unknown room
+            g.fillRect(x0, 0, x1 - x0, cssH);
+            // Name it when the run is wide enough to read; otherwise the colour
+            // and the hover readout carry it.
+            const w = x1 - x0;
+            if (run.name) {
+                g.font = "10px system-ui, sans-serif";
+                // Only when the WHOLE name fits: a clipped "Bedroo" is worse
+                // than the colour on its own, which the hover readout names.
+                if (g.measureText(run.name).width + 8 <= w) {
+                    g.textBaseline = "middle";
+                    g.fillStyle = "rgba(10, 10, 14, 0.85)";
+                    g.fillText(run.name, x0 + 4, cssH / 2 + 0.5);
+                }
+            }
+        });
+
+        // Where the cursor is, so the band and the map agree without looking up
+        // at the thumb.
+        const at = data.t[Math.min(historyState.idx, count - 1)];
+        const cx = xOf(at);
+        g.fillStyle = "rgba(10, 10, 14, 0.85)";
+        g.fillRect(Math.max(0, Math.min(cssW - 2, cx - 1)), 0, 2, cssH);
+
+        // Only a hairline in the band itself. The readout goes to the status
+        // line below: a label painted here is wide enough to cover two or three
+        // runs — exactly the ones being inspected.
+        if (historyHoverX !== null) {
+            g.fillStyle = "rgba(255, 255, 255, 0.8)";
+            g.fillRect(Math.max(0, Math.min(cssW - 1, historyHoverX)), 0, 1, cssH);
+        }
+    }
+
+    // The moment the pointer is over on the band, or null when it is elsewhere
+    // or there is no window to read.
+    function historyHoverTime() {
+        const data = historyState.data;
+        const count = data && data.count ? data.count : 0;
+        if (historyHoverX === null || count < 2 || !historyZoneCanvas) return null;
+        const w = historyZoneCanvas.clientWidth;
+        if (!w) return null;
+        const frac = Math.max(0, Math.min(1, historyHoverX / w));
+        return data.t[0] + frac * (data.t[count - 1] - data.t[0]);
+    }
+
+    // The room recorded AT a moment, or null when nothing was: inside a
+    // dropout the honest answer is "not recorded", not the room the device was
+    // in before it stopped being heard.
+    function historyRoomAt(ts) {
+        const data = historyState.data;
+        const count = data && data.count ? data.count : 0;
+        if (!count || ts < data.t[0]) return null;
+        const i = historyIndexAt(ts);
+        const next = i + 1;
+        if (ts > data.t[i]
+            && (next >= count || data.gap[next] === HISTORY_GAP_DROPOUT)) return null;
+        return (data.zones && data.zones[data.z ? data.z[i] : 0]) || "";
+    }
+
+    // Time under a pointer event on the band, or null when there is no window.
+    function historyTimeAtBandEvent(event) {
+        const data = historyState.data;
+        const count = data && data.count ? data.count : 0;
+        if (count < 2 || !historyZoneCanvas) return null;
+        const rect = historyZoneCanvas.getBoundingClientRect();
+        if (!rect.width) return null;
+        const t0 = data.t[0], t1 = data.t[count - 1];
+        const frac = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+        return t0 + frac * (t1 - t0);
+    }
+
+    if (historyZoneCanvas) {
+        historyZoneCanvas.addEventListener("mousemove", (event) => {
+            const rect = historyZoneCanvas.getBoundingClientRect();
+            historyHoverX = event.clientX - rect.left;
+            historyRender();          // repaints the band and the readout together
+        });
+        historyZoneCanvas.addEventListener("mouseleave", () => {
+            historyHoverX = null;
+            historyRender();          // puts the real status line back
+        });
+
+        // Click a room to jump to it — the reason the band is worth having.
+        historyZoneCanvas.addEventListener("click", (event) => {
+            const ts = historyTimeAtBandEvent(event);
+            if (ts === null) return;
+            historyState.live = false;
+            historyStopPlayback();
+            historyState.idx = historyIndexAt(ts);
+            historyState.anchor = ts;
+            historyRender();
+            if (img.naturalWidth > 0) redrawAll();
+        });
+        // The band is sized in CSS percentages, so a window resize changes its
+        // pixel width without changing any state.
+        window.addEventListener("resize", () => drawHistoryZoneBand());
     }
 
     // --- the map overlay -----------------------------------------------------
@@ -2196,18 +2406,29 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     if (historySlider) {
         historySlider.addEventListener("input", () => {
-            const idx = parseInt(historySlider.value, 10);
-            if (!Number.isFinite(idx)) return;
-            // Dragging means "show me this moment", so it drops the Live latch
-            // and stops playback — otherwise the two would fight over the cursor.
-            historyState.live = false;
-            historyStopPlayback();
-            historyState.idx = idx;
-            // Remember WHEN we are looking at, not just which index: a later
-            // reload (span change, device change) re-centres on this moment.
-            const t = historyState.data && historyState.data.t;
-            if (t && Number.isFinite(t[idx])) historyState.anchor = t[idx];
-            historyRender();
+            const ts = parseFloat(historySlider.value);
+            if (!Number.isFinite(ts)) return;
+            // The flag has to cover the WHOLE handler, not just the render at
+            // the end: historyStopPlayback() renders too, and that one ran
+            // first and wrote the previous point's time straight back over the
+            // value the user had just dragged to.
+            historySliderDriving = true;
+            try {
+                // Dragging means "show me this moment", so it drops the Live
+                // latch and stops playback - otherwise the two would fight
+                // over the cursor.
+                historyState.live = false;
+                historyStopPlayback();
+                // The slider is continuous but the record is not: land on the
+                // last point at or before the moment dragged to.
+                historyState.idx = historyIndexAt(ts);
+                // Remember WHEN we are looking at, not just which index: a
+                // later reload (span/device change) re-centres on this moment.
+                historyState.anchor = ts;
+                historyRender();
+            } finally {
+                historySliderDriving = false;
+            }
             if (img.naturalWidth > 0) redrawAll();
         });
     }

--- a/custom_components/bps/history.py
+++ b/custom_components/bps/history.py
@@ -62,6 +62,14 @@ _CFG_SPEC = {
 DROPOUT_GAP_FACTOR = 3.0
 DROPOUT_GAP_MIN = 90.0
 
+# Both values break the drawn line; only DROPOUT means "nothing was recorded
+# across this interval". Switching floors breaks the polyline because the two
+# points live in different pixel frames, but the record is continuous there -
+# and the room band must not paint a hole (or say "not recorded") over an
+# interval it has perfectly good data for.
+GAP_FRAME = 1        # new polyline: floor change, clock step, retained head
+GAP_DROPOUT = 2      # ...and the device genuinely was not heard across it
+
 
 def _finite(value):
     """`value` as a finite float, or None.
@@ -105,7 +113,7 @@ def history_config(layout):
 class _Track:
     """One tracker's columnar ring buffer."""
 
-    __slots__ = ("t", "x", "y", "f", "gap", "floors", "scales",
+    __slots__ = ("t", "x", "y", "f", "gap", "z", "floors", "scales", "zones",
                  "last_kept", "force_gap")
 
     def __init__(self):
@@ -114,10 +122,28 @@ class _Track:
         self.y = array("f")
         self.f = array("B")       # index into self.floors
         self.gap = array("B")     # 1 = this point STARTS a new polyline
+        self.z = array("B")       # index into self.zones
         self.floors = []          # append-only: index -> floor name
         self.scales = []          # px/m in effect when that floor was first seen
-        self.last_kept = None     # (t, x, y, floor_index)
+        # Index 0 is ALWAYS "" (not known). Unlike the floor table, an overflow
+        # here must not fall back to index 0 meaning "the first zone we saw" -
+        # saying "no idea" is honest, naming the wrong room is not.
+        self.zones = [""]
+        self.last_kept = None     # (t, x, y, floor_index, zone_index)
         self.force_gap = False
+
+    def zone_index(self, zone):
+        """Intern a zone name. 0 = unknown, and 0 is what overflow gets too."""
+        name = "" if zone is None else str(zone)
+        if not name or name == "unknown":
+            return 0
+        try:
+            return self.zones.index(name)
+        except ValueError:
+            if len(self.zones) >= 255:   # z is a byte column
+                return 0
+            self.zones.append(name)
+            return len(self.zones) - 1
 
     def floor_index(self, floor, scale):
         name = "" if floor is None else str(floor)
@@ -144,15 +170,18 @@ class _Track:
         del self.y[:]
         del self.f[:]
         del self.gap[:]
+        del self.z[:]
         self.last_kept = None
 
-    def append(self, ts, x, y, fi, gap):
+    def append(self, ts, x, y, fi, gap, zi=0):
+        """`gap` is 0, GAP_FRAME or GAP_DROPOUT (both of the latter break the line)."""
         self.t.append(float(ts))
         self.x.append(float(x))
         self.y.append(float(y))
         self.f.append(fi)
-        self.gap.append(1 if gap else 0)
-        self.last_kept = (float(ts), float(x), float(y), fi)
+        self.gap.append(int(gap) if gap else 0)
+        self.z.append(zi)
+        self.last_kept = (float(ts), float(x), float(y), fi, zi)
 
     def evict(self, max_age, max_points, now):
         """Drop expired/excess points in BLOCKS (one memmove, not one per point)."""
@@ -184,8 +213,11 @@ class _Track:
         del self.y[:drop]
         del self.f[:drop]
         del self.gap[:drop]
+        del self.z[:drop]
         if self.gap:
-            self.gap[0] = 1       # the new first point starts a polyline
+            # The retained head starts a polyline, but what preceded it was
+            # dropped for age, not missing from the record: not a dropout.
+            self.gap[0] = GAP_FRAME
 
 
 class PositionHistory:
@@ -203,12 +235,14 @@ class PositionHistory:
         self.cfg = cfg
 
     # --- recording ---------------------------------------------------------
-    def record(self, ent, ts, x_m, y_m, floor, scale):
+    def record(self, ent, ts, x_m, y_m, floor, scale, zone=None):
         """Keep this fix if it clears the gate. Returns True when kept.
 
         Kept when the floor changed (always - the two points live in different
-        frames), or enough time AND movement has passed, or the heartbeat is
-        due so a stationary device still has something to scrub to.
+        frames), when the ZONE changed (so the room band's edges land on the
+        actual crossing rather than up to a heartbeat late), or enough time AND
+        movement has passed, or the heartbeat is due so a stationary device
+        still has something to scrub to.
         """
         if not self.cfg.get("enabled", True):
             return False
@@ -221,13 +255,14 @@ class PositionHistory:
         if track is None:
             track = self.tracks[ent] = _Track()
         fi = track.floor_index(floor, scale)
+        zi = track.zone_index(zone)
 
-        gap = False
+        gap = 0
         last = track.last_kept
         if last is None:
-            gap = True
+            gap = GAP_FRAME
         else:
-            lt, lx, ly, lf = last
+            lt, lx, ly, lf, lz = last
             if ts < lt:
                 # The clock stepped backwards (NTP correction, a VM resume, a
                 # host with no RTC catching up). Appending here would leave
@@ -235,30 +270,44 @@ class PositionHistory:
                 # start the buffer over rather than corrupt it.
                 track.reset()
                 fi = track.floor_index(floor, scale)
-                gap = True
+                zi = track.zone_index(zone)
+                gap = GAP_FRAME
             elif fi != lf:
-                gap = True                  # different pixel frame: break the line
+                gap = GAP_FRAME             # different pixel frame: break the line
             else:
                 dt = ts - lt
                 moved = math.hypot(x_m - lx, y_m - ly)
+                # A room change is worth a point in its own right - it is the
+                # edge the room band draws - so it counts alongside movement.
+                # It is deliberately NOT exempt from min_interval: zone
+                # assignment is pure geometry with no hysteresis, so a device
+                # parked on a boundary flickers between two rooms on BLE noise
+                # alone, and an exempt branch recorded every single fix of it
+                # (measured: 299 rows instead of 20 for a device that moved
+                # 2 cm). Bounded this way the edge is at most min_interval late.
                 if not (dt >= self.cfg["heartbeat"]
                         or (dt >= self.cfg["min_interval"]
-                            and moved >= self.cfg["min_move_m"])):
+                            and (moved >= self.cfg["min_move_m"] or zi != lz))):
                     return False
                 # Heard again after a silence: the device was not standing
                 # still, it was not being heard, so break the line instead of
                 # drawing one long straight segment across the outage. (The
                 # tracker only gets an explicit mark_gap once it has been
                 # absent for the whole position_timeout, which is much longer.)
+                # This runs for a room change too: a silence is still a silence
+                # however the room came out at the end of it.
                 if dt > max(self.cfg["heartbeat"] * DROPOUT_GAP_FACTOR,
                             DROPOUT_GAP_MIN):
-                    gap = True
+                    gap = GAP_DROPOUT
         if track.force_gap:
-            gap = True
+            # mark_gap fires when a tracker was pruned for absence, or across a
+            # restart: in both the device really was unheard for that stretch.
+            gap = GAP_DROPOUT
             track.force_gap = False
 
-        track.append(ts, x_m, y_m, fi, gap)
-        self._queue(ent, ts, x_m, y_m, track.floors[fi], track.scales[fi], gap)
+        track.append(ts, x_m, y_m, fi, gap, zi)
+        self._queue(ent, ts, x_m, y_m, track.floors[fi], track.scales[fi], gap,
+                    track.zones[zi])
         track.evict(self.cfg["max_age"], self.cfg["max_points"], ts)
         return True
 
@@ -305,7 +354,7 @@ class PositionHistory:
             track.force_gap = True
 
     # --- disk hand-off (the caller performs the actual I/O) ----------------
-    def _queue(self, ent, ts, x, y, floor, scale, gap):
+    def _queue(self, ent, ts, x, y, floor, scale, gap, zone=""):
         if len(self._pending) >= self.MAX_PENDING:
             self.dropped_pending += 1
             return
@@ -314,7 +363,9 @@ class PositionHistory:
         if scale:
             row["s"] = round(float(scale), 4)
         if gap:
-            row["g"] = 1
+            row["g"] = int(gap)
+        if zone:
+            row["z"] = zone
         # Tagged with its UTC day so the flush can group by segment file, and
         # with the entity so forget() can drop just that tracker's queued rows
         # without having to pattern-match the serialised JSON.
@@ -394,7 +445,10 @@ class PositionHistory:
             if track is None:
                 track = self.tracks[ent] = _Track()
             fi = track.floor_index(row.get("f"), _finite(row.get("s")) or 0.0)
-            track.append(ts, x, y, fi, bool(row.get("g")))
+            zi = track.zone_index(row.get("z"))
+            g = row.get("g")
+            g = int(g) if isinstance(g, (int, float)) and not isinstance(g, bool) else 0
+            track.append(ts, x, y, fi, GAP_FRAME if g == 1 else (GAP_DROPOUT if g else 0), zi)
             restored += 1
         for track in self.tracks.values():
             track.evict(self.cfg["max_age"], self.cfg["max_points"], now)
@@ -419,9 +473,9 @@ class PositionHistory:
         and always keeps the first and last point, every gap and every floor
         change - dropping those would silently join unrelated stretches.
         """
-        empty = {"ent": ent, "floors": [], "scales": [], "t": [], "x_m": [],
-                 "y_m": [], "f": [], "gap": [], "count": 0, "total": 0,
-                 "stride": 1}
+        empty = {"ent": ent, "floors": [], "scales": [], "zones": [""],
+                 "t": [], "x_m": [], "y_m": [], "f": [], "gap": [], "z": [],
+                 "count": 0, "total": 0, "stride": 1}
         track = self.tracks.get(ent)
         if track is None or not track.t:
             return empty
@@ -437,6 +491,7 @@ class PositionHistory:
         for i in range(lo, hi):
             if (i == lo or i == hi - 1 or track.gap[i]
                     or (i > lo and track.f[i] != track.f[i - 1])
+                    or (i > lo and track.z[i] != track.z[i - 1])
                     or (i - lo) % stride == 0):
                 keep.append(i)
         # Breaks and floor changes are force-kept above, so data that flaps
@@ -458,11 +513,13 @@ class PositionHistory:
             "ent": ent,
             "floors": list(track.floors),
             "scales": list(track.scales),
+            "zones": list(track.zones),
             "t": [round(track.t[i], 2) for i in keep],
             "x_m": [round(track.x[i], 3) for i in keep],
             "y_m": [round(track.y[i], 3) for i in keep],
             "f": [track.f[i] for i in keep],
             "gap": [track.gap[i] for i in keep],
+            "z": [track.z[i] for i in keep],
             "count": len(keep),
             "total": total,
             "stride": stride,

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "2.0.0"
+    "version": "2.1.0"
 }

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -134,7 +134,7 @@ def test_a_dropout_breaks_the_line_before_the_prune_timeout():
     h.record(ENT, t0, 0.0, 0.0, FLOOR, SCALE)
     h.record(ENT, t0 + 20, 5.0, 0.0, FLOOR, SCALE)     # normal, no break
     h.record(ENT, t0 + 200, 9.0, 0.0, FLOOR, SCALE)    # after a silence
-    assert all_points(h)["gap"] == [1, 0, 1]
+    assert all_points(h)["gap"] == [1, 0, H.GAP_DROPOUT]
 
 
 def test_mark_gap_breaks_the_next_segment():
@@ -144,7 +144,8 @@ def test_mark_gap_breaks_the_next_segment():
     h.record(ENT, t0 + 5, 5.0, 0.0, FLOOR, SCALE)
     h.mark_gap(ENT)                      # tracker pruned for absence
     h.record(ENT, t0 + 600, 40.0, 0.0, FLOOR, SCALE)
-    assert all_points(h)["gap"] == [1, 0, 1]
+    # 2 = the device really was unheard across it, not merely a new polyline.
+    assert all_points(h)["gap"] == [1, 0, H.GAP_DROPOUT]
 
 
 def test_non_finite_and_unnamed_input_is_refused():
@@ -484,7 +485,7 @@ def test_restore_after_a_restart_reloads_and_breaks_the_line(tmp_path):
     # The next fix after an outage of unknown length starts a new polyline.
     import time as _t
     back.record(ENT, _t.time(), 99.0, 99.0, FLOOR, SCALE)
-    assert all_points(back, ENT)["gap"][-1] == 1
+    assert all_points(back, ENT)["gap"][-1] == H.GAP_DROPOUT
 
 
 def test_history_is_stored_outside_the_web_root(tmp_path):
@@ -686,3 +687,133 @@ def test_prune_keeps_exactly_what_restore_reads_back(tmp_path):
     kept = set(H.list_day_keys(d))
     read = {H.day_key(r["t"]) for r in H.restore_recent(d, cfg, now)}
     assert kept == read
+
+
+# --------------------------------------------------------------------------- #
+# The recorded room (for the map's room band)
+# --------------------------------------------------------------------------- #
+def test_the_room_is_recorded_and_returned_per_point():
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 0.0, 0.0, FLOOR, SCALE, "Kitchen")
+    h.record(ENT, t0 + 40, 9.0, 0.0, FLOOR, SCALE, "Hall")
+    got = all_points(h)
+    assert [got["zones"][i] for i in got["z"]] == ["Kitchen", "Hall"]
+
+
+def test_index_zero_always_means_unknown():
+    # An overflow or a missing zone must read as "no idea", never as whichever
+    # room happened to be interned first.
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 0.0, 0.0, FLOOR, SCALE, "Kitchen")
+    h.record(ENT, t0 + 40, 9.0, 0.0, FLOOR, SCALE, None)
+    h.record(ENT, t0 + 80, 18.0, 0.0, FLOOR, SCALE, "unknown")
+    got = all_points(h)
+    assert got["zones"][0] == ""
+    assert [got["zones"][i] for i in got["z"]] == ["Kitchen", "", ""]
+
+
+def test_a_room_change_is_kept_as_soon_as_the_interval_allows():
+    # A room change counts alongside movement, so the band's edge lands within
+    # min_interval instead of up to a heartbeat late...
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 1.0, 1.0, FLOOR, SCALE, "Kitchen")
+    assert h.record(ENT, t0 + 2.0, 1.05, 1.0, FLOOR, SCALE, "Hall") is True
+    got = all_points(h)
+    assert [got["zones"][i] for i in got["z"]] == ["Kitchen", "Hall"]
+    # ...and it is the same continuous walk, so it must NOT break the line.
+    assert got["gap"] == [1, 0]
+
+
+def test_a_flickering_room_boundary_cannot_defeat_the_interval():
+    # Zone assignment is pure geometry with no hysteresis, so a device parked on
+    # a boundary flips room on BLE noise alone. Exempting a room change from
+    # min_interval recorded every single fix of that (measured 299 rows instead
+    # of 20 for a device that moved 2 cm).
+    h = hist()
+    t0 = 1_000_000.0
+    for i in range(600):                      # 10 min at 1 Hz, standing still
+        h.record(ENT, t0 + i, 5.0, 5.0, FLOOR, SCALE,
+                 "Kitchen" if i % 2 else "Hall")
+    kept = all_points(h)["count"]
+    assert kept <= 600 / 2 + 2                # bounded by min_interval, not 1 Hz
+
+
+def test_a_silence_still_breaks_the_line_when_the_room_changed():
+    # The room-change keep used to bypass the dropout check, so an outage that
+    # ended in a different room was painted as a solid run of the OLD room and
+    # the trail drew straight through it.
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 1.0, 1.0, FLOOR, SCALE, "Kitchen")
+    h.record(ENT, t0 + 200, 9.0, 1.0, FLOOR, SCALE, "Hall")
+    assert all_points(h)["gap"] == [1, H.GAP_DROPOUT]
+
+
+def test_a_floor_change_is_a_frame_break_not_a_dropout():
+    # Both break the drawn line, but only one means "nothing was recorded":
+    # the room band must not paint a hole over data it has.
+    h = hist()
+    t0 = 1_000_000.0
+    h.record(ENT, t0, 1.0, 1.0, "A", 40.0, "Kitchen")
+    h.record(ENT, t0 + 3, 1.0, 1.0, "B", 50.0, "Landing")
+    assert all_points(h)["gap"] == [H.GAP_FRAME, H.GAP_FRAME]
+
+
+def test_the_255th_zone_reads_as_unknown_not_as_the_first_room():
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(300):
+        h.record(ENT, t0 + i * 40, float(i), 0.0, FLOOR, SCALE, "room%d" % i)
+    got = all_points(h)
+    names = [got["zones"][i] for i in got["z"]]
+    assert names[0] == "room0"
+    assert names[-1] == ""            # past the byte column: unknown, not room0
+    assert len(got["zones"]) == 255
+
+
+def test_rooms_survive_the_disk_round_trip(tmp_path):
+    import time as _t
+    d = str(tmp_path / "hist")
+    h = hist(max_age=10 ** 9)
+    t0 = _t.time() - 400
+    for i in range(20):
+        h.record(ENT, t0 + i * 20, float(i), 0.0, FLOOR, SCALE,
+                 "Kitchen" if i < 10 else "Hall")
+    H.append_segments(d, h.drain_pending())
+    back = hist(max_age=10 ** 9)
+    back.load_rows(H.restore_recent(d, back.cfg))
+    got = all_points(back)
+    names = [got["zones"][i] for i in got["z"]]
+    assert names[:10] == ["Kitchen"] * 10 and names[10:] == ["Hall"] * 10
+
+
+def test_decimation_keeps_every_room_boundary():
+    # The band is drawn from these transitions; a dropped one merges two rooms.
+    h = hist(max_age=10 ** 9, max_points=10 ** 9)
+    t0 = 1_000_000.0
+    for i in range(600):
+        h.record(ENT, t0 + i * 3, float(i), 0.0, FLOOR, SCALE,
+                 "Kitchen" if (i // 50) % 2 == 0 else "Hall")
+    got = h.query(ENT, t0, t0 + 10 ** 6, 20)
+    names = [got["zones"][i] for i in got["z"]]
+    changes = sum(1 for i in range(1, len(names)) if names[i] != names[i - 1])
+    assert changes == 11          # 600/50 - 1 boundaries, all preserved
+
+
+def test_a_query_with_no_points_still_carries_the_zone_table():
+    got = hist().query("nobody", 0, 1e12, 100)
+    assert got["zones"] == [""] and got["z"] == []
+
+
+def test_history_without_a_recorded_room_still_works():
+    # Points written before rooms were recorded restore with no zone at all.
+    h = hist()
+    t0 = 1_000_000.0
+    h.load_rows([{"e": ENT, "t": t0, "x": 1.0, "y": 1.0, "f": FLOOR, "s": SCALE}],
+                now=t0)
+    got = all_points(h)
+    assert got["count"] == 1
+    assert [got["zones"][i] for i in got["z"]] == [""]


### PR DESCRIPTION
A strip under the history slider showing the rooms the device passed through across the loaded window, in each zone's **own map colour**. Rooms it was never in take no space, so a glance answers *when was it in the kitchen?* Hover reads a moment off, click jumps there, a cursor line marks where you are.

<!-- band: Bedroom | Office | Hall | Kitchen | ——hole—— | Hall | Office | Landing | Bedroom -->

### What it needed

**The zone is now recorded with each fix** — interned into a byte column beside the existing floor table, a few bytes per point. Index 0 is always "unknown", and overflow past 255 rooms returns 0 rather than mis-attributing to whichever room was interned first. A room change counts alongside movement in the recording gate, so the band's edges land within `min_interval` instead of up to a heartbeat late.

**The slider had to become a timeline.** It was indexed by *sample* (`min 0, max count-1, step 1`), so a ten-minute dropout occupied one step — exactly like a two-second sample. A band drawn in time under a slider scaled in samples would never line up. It's now `min t[0]` / `max t[last]` / `step="any"`, which also makes dragging honest about duration.

### Review findings fixed

A five-lens review confirmed 11 findings, collapsing to four distinct defects — all introduced by this change, all fixed here:

| defect | evidence |
|---|---|
| **A room change bypassed the dropout check**, so an outage ending in a different room lost its gap flag: the band painted the whole silence as a solid run of the *old* room, hover named a room where nothing was recorded, and the map drew one straight segment across it | `Kitchen→Hall` over a 200 s silence gave `gap=[1,0]` where `Kitchen→Kitchen` gave `[1,1]` |
| **The room-change keep was exempt from `min_interval` entirely.** Zone assignment is pure geometry with no hysteresis, so a device parked on a boundary flips room on BLE noise alone and every fix was recorded | 299 rows instead of 20 for a device that moved 2 cm — ~3.3 MB/day/device against 0.22 MB |
| **A floor change was indistinguishable from a dropout**, so the band punched a false hole and said "not recorded" over a fully-recorded stretch on another floor | `gap` now carries a severity: 1 = new polyline, 2 = nothing recorded. Both break the drawn line; only 2 is a hole. Verified with a 10-min upstairs excursion: one hole in the band, the excursion reads as "Landing" |
| **`historyRender` wrote the slider value back on every input**, so the thumb snapped to the nearest recorded point and couldn't be dragged or keyed across a dropout | The guard has to cover the whole handler, not just its final render — `historyStopPlayback()` renders too, and ran first. Thumb now stays exactly where it's put |

Plus: the band's 7 px inset assumed a 14 px thumb, but `::-webkit-slider-thumb` sizing is **inert without `appearance: none`**, so the geometry was a guess. The thumb and track are now styled explicitly, which makes it true.

### Verification

- 11 new tests (147 total, all passing): the disk round trip, boundary preservation under decimation, the 255-room overflow, the flicker bound, dropout-vs-frame gap severity, and history recorded *before* this change (no zone field at all).
- Harness: a synthetic hour over four rooms with a deliberate 12-minute dropout and a 10-minute upstairs excursion. Clicking each run reports the room clicked; the slider fraction tracks the clicked fraction to within 0.003; hover reads "not recorded" only across the real hole.

### Sequencing note

Version bumped to **2.1.0**. This branches off `main`, so it does **not** include [#125](https://github.com/maxi1134/BPS-improved/pull/125) (history marker uses the device icon), which is still open. The v2.0.0 draft release predates both and its notes don't mention the room band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
