### PR TITLE
Keep help tooltips inside the panel horizontally

### DIFF
--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -7,6 +7,9 @@
 .tooltip .tooltip-text {
     visibility: hidden;
     width: 280px;
+    /* Narrower than the tip on a small panel: shifting it sideways can only
+       help while it still fits at all, so let it shrink as the last resort. */
+    max-width: calc(100vw - 16px);
     background-color: black;
     color: #fff;
     text-align: center;

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -6036,6 +6036,23 @@ document.addEventListener('DOMContentLoaded', async () => {
             const icon = tt.getBoundingClientRect();
             const tipH = tip.getBoundingClientRect().height;
             tt.classList.toggle("flip-up", icon.bottom + tipH + 16 > window.innerHeight);
+            // ...and keep it inside the viewport HORIZONTALLY. The tip is
+            // centred on its icon and fixed-width, so an icon anywhere near
+            // either edge pushes half the text out of the frame where it can't
+            // be read (the history bar's sits at the far left of the panel).
+            // Reset the shift before measuring, or each hover compounds the
+            // last one.
+            tip.style.transform = "translateX(-50%)";
+            const box = tip.getBoundingClientRect();
+            const margin = 8;
+            let shift = 0;
+            if (box.left < margin) shift = margin - box.left;
+            else if (box.right > window.innerWidth - margin) {
+                shift = (window.innerWidth - margin) - box.right;
+            }
+            if (shift) {
+                tip.style.transform = `translateX(calc(-50% + ${Math.round(shift)}px))`;
+            }
         });
     });
 

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "2.0.0"
+    "version": "2.0.1"
 }


### PR DESCRIPTION
The history bar's **?** tooltip ran off the left edge — the first characters of every line were cut off and unreadable.

A tooltip is centred on its icon and fixed at 280 px wide, so an icon anywhere near either edge pushes half the text out of the frame. The history bar's icon sits at the far left of the panel, which put its tip at **left −36 px**, regardless of how wide the window is.

The hover handler already measured for the vertical flip (`.flip-up`); it now measures horizontally too and shifts the tip by exactly the overflow, resetting the shift before measuring so repeated hovers don't compound it.

Measured, same tooltip:

| | left edge |
|---|---|
| before | **−36 px** (clipped) |
| after | **8 px** (the margin) |

It's surgical — at a 1400 px viewport, three of the four visible tooltips stay at `translateX(-50%)` and only the history one moves. Every tooltip in the panel now sits fully inside the frame at both 383 px and 1400 px wide.

Also added a `max-width` so a panel narrower than the tip lets it shrink, rather than relying on a shift that can't help — the same belt-and-braces the existing `max-height` gives the vertical case.

Version 2.0.1. Branches off `main`, so it's independent of [#125](https://github.com/maxi1134/BPS-improved/pull/125) and [#126](https://github.com/maxi1134/BPS-improved/pull/126) and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
