### PR TITLE
Pre-release audit fixes

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -369,11 +369,18 @@ async def restore_position_history(hass):
         return
     dirpath = history_dir(hass)
     cfg = dict(hist.cfg)
+    # Same rule as the periodic flush: pruning DELETES days irreversibly, so it
+    # must never run on a guessed window. At startup the layout may not have
+    # loaded (or may be unreadable this boot), in which case history_config
+    # hands back the 6 h default - and pruning with that would take a
+    # configured 7-day record down to six hours on every restart.
+    prune_max_age = _history_prunable_max_age(hass, hist)
 
     # Parse AND build the tracks off the loop: the retained window can be
     # hundreds of thousands of rows and this runs during setup.
     def _work():
-        history_mod.prune_segments(dirpath, cfg["max_age"])
+        if prune_max_age is not None:
+            history_mod.prune_segments(dirpath, prune_max_age)
         loaded = history_mod.PositionHistory(cfg)
         loaded.load_rows(history_mod.restore_recent(dirpath, cfg))
         # The rows came FROM disk; nothing here needs writing back out.
@@ -2890,7 +2897,7 @@ class BPSHistoryAPI(HomeAssistantView):
                 # Segments are shared by every tracker, so a per-tracker clear
                 # cannot just delete files: rewrite them without its rows.
                 removed = await hass.async_add_executor_job(
-                    history_mod.drop_entity, dirpath, entity, hist.cfg)
+                    history_mod.drop_entity, dirpath, entity)
             else:
                 removed = await hass.async_add_executor_job(
                     history_mod.clear_segments, dirpath)

--- a/custom_components/bps/frontend/bpsstyle.css
+++ b/custom_components/bps/frontend/bpsstyle.css
@@ -3346,8 +3346,9 @@ input[type="checkbox"] { accent-color: hsl(var(--sidebar-primary)); }
    first row, the scrubber itself on the second. The slider is given the whole
    remaining width because dragging it IS the feature — the timestamp beside it
    is fixed-width and tabular so the digits don't shuffle as you scrub. It is
-   always present (there is no toggle), so it is styled as part of the map's
-   furniture rather than as a panel that appears. */
+   shown by default (the History switch in the Tracking column hides it), so it
+   is styled as part of the map's furniture rather than as a panel that
+   appears. */
 .bps-history-bar {
     display: flex;
     flex-direction: column;

--- a/custom_components/bps/frontend/index.html
+++ b/custom_components/bps/frontend/index.html
@@ -262,7 +262,8 @@
                          UNDER the map: it is a control for what the map is showing, and
                          reading the trail and the time you are scrubbing to together is
                          easier when the eye travels down rather than back up past the
-                         floor plan. Always on screen — there is nothing to switch on. -->
+                         floor plan. Shown by default; the History switch in the
+                         Tracking column hides it when it is in the way. -->
                     <div id="historyBar" class="bps-history-bar">
                         <div class="bps-history-row">
                             <span class="bps-history-title">History</span>

--- a/custom_components/bps/frontend/script.js
+++ b/custom_components/bps/frontend/script.js
@@ -2009,7 +2009,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const floor = floors.find(f => sameFloorName(f.name, floorName));
         const zones = (floor && floor.zones) || [];
         const idx = zones.findIndex(z => z && z.entity_id === name);
-        if (idx >= 0) return zoneDisplayColor(zones[idx], idx);
+        // Honour the map's "Colours: off": the band is a view of the same
+        // zones, so it should go neutral with them rather than stay the only
+        // coloured thing on screen.
+        if (idx >= 0) return zones[idx].uncolored ? null : zoneDisplayColor(zones[idx], idx);
         // Recorded on a floor we no longer have, or a zone since renamed or
         // deleted: a stable hash keeps it a consistent colour anyway.
         let h = 0;
@@ -3652,8 +3655,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const anyColored = zones.some(z => !z.uncolored);
         zones.forEach(z => { z.uncolored = anyColored; });
         savebuttondiv.appendChild(saveButton);
-        clearCanvas();
-        drawElements();
+        // redrawAll, not a bare clearCanvas+drawElements: the history trail and
+        // its marker are painted by drawHistoryOverlay and would be wiped with
+        // nothing to bring them back until the next unrelated repaint.
+        redrawAll();
     });
 
     // Load a saved zone/sub-zone into the polygon editor (reusing the draw

--- a/custom_components/bps/history.py
+++ b/custom_components/bps/history.py
@@ -446,8 +446,10 @@ class PositionHistory:
                 track = self.tracks[ent] = _Track()
             fi = track.floor_index(row.get("f"), _finite(row.get("s")) or 0.0)
             zi = track.zone_index(row.get("z"))
-            g = row.get("g")
-            g = int(g) if isinstance(g, (int, float)) and not isinstance(g, bool) else 0
+            # _finite, not int(): int(float("inf")) raises OverflowError, and
+            # one junk row would take the entire restore down with it - for
+            # good, since the row stays on disk.
+            g = _finite(row.get("g")) or 0
             track.append(ts, x, y, fi, GAP_FRAME if g == 1 else (GAP_DROPOUT if g else 0), zi)
             restored += 1
         for track in self.tracks.values():
@@ -501,11 +503,29 @@ class PositionHistory:
         # result uniformly if that happened; the endpoints and the ordering
         # survive, some breaks do not.
         hard_cap = cap * 2
+        gap_out = {}
         if len(keep) > hard_cap:
             step = -(-len(keep) // hard_cap)
             thinned = keep[::step]
             if thinned[-1] != keep[-1]:
                 thinned.append(keep[-1])
+            # A frame break may be sacrificed here; a DROPOUT may not. The room
+            # band and the trail both promise that nothing is drawn across an
+            # interval where nothing was recorded, and that promise rests
+            # entirely on this flag reaching the client. Re-adding the dropped
+            # index would push us back over the cap this block exists to
+            # enforce, so carry the flag FORWARD onto the next surviving point
+            # instead: the count is unchanged, and the hole can only widen to
+            # the next kept point, which errs toward honesty.
+            survivors = set(thinned)
+            carry = False
+            for i in keep:
+                if i in survivors:
+                    if carry:
+                        gap_out[i] = GAP_DROPOUT
+                        carry = False
+                elif track.gap[i] == GAP_DROPOUT:
+                    carry = True
             keep = thinned
             stride = max(stride, step)
 
@@ -518,7 +538,7 @@ class PositionHistory:
             "x_m": [round(track.x[i], 3) for i in keep],
             "y_m": [round(track.y[i], 3) for i in keep],
             "f": [track.f[i] for i in keep],
-            "gap": [track.gap[i] for i in keep],
+            "gap": [gap_out.get(i, track.gap[i]) for i in keep],
             "z": [track.z[i] for i in keep],
             "count": len(keep),
             "total": total,
@@ -645,7 +665,7 @@ def restore_recent(dirpath, cfg, now=None):
     return read_segments(dirpath, days)
 
 
-def drop_entity(dirpath, ent, cfg, now=None):
+def drop_entity(dirpath, ent):
     """Rewrite every segment without one tracker's rows. Returns rows removed.
 
     Segments are shared by all trackers, so forgetting one means a rewrite.

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -326,7 +326,7 @@ def test_drop_entity_rewrites_segments_without_that_tracker(tmp_path):
         json.dumps({"e": "b", "t": now - 2, "x": 2, "y": 2, "f": FLOOR}),
         json.dumps({"e": "a", "t": now - 1, "x": 3, "y": 3, "f": FLOOR}),
     ]})
-    assert H.drop_entity(d, "a", H.history_config({})) == 2
+    assert H.drop_entity(d, "a") == 2
     rows = H.read_segments(d, H.list_day_keys(d))
     assert [r["e"] for r in rows] == ["b"]
 
@@ -337,7 +337,7 @@ def test_drop_entity_removes_a_segment_it_empties(tmp_path):
     now = _t.time()
     H.append_segments(d, {H.day_key(now): [
         json.dumps({"e": "a", "t": now, "x": 1, "y": 1, "f": FLOOR})]})
-    H.drop_entity(d, "a", H.history_config({}))
+    H.drop_entity(d, "a")
     assert H.list_day_keys(d) == []
     assert not os.path.exists(H.segment_path(d, H.day_key(now)) + ".tmp")
 
@@ -523,6 +523,27 @@ def test_clear_is_not_undone_by_a_concurrent_flush(tmp_path):
     # landed in between used to be overwritten by that write, so the forgotten
     # positions came back on the next restart.
     hass, h, _ = seeded_hass(tmp_path)
+    # Two things have to be arranged or this test is vacuous. conftest's
+    # executor runs INLINE, so the flush would complete atomically before the
+    # clear is entered; and even yielding is not enough, because gather()
+    # resumes the flush first and its append would land BEFORE the delete -
+    # harmless. The damaging order is the other one: the clear deletes the
+    # segments and the flush's already-drained rows are written afterwards,
+    # putting the forgotten positions back on disk. Make the first executor
+    # call (the flush's append) resolve last to construct exactly that.
+    calls = {"n": 0}
+
+    def _ordered(func, *args):
+        delay = 0.05 if calls["n"] == 0 else 0.0
+        calls["n"] += 1
+
+        async def run():
+            await asyncio.sleep(delay)
+            return func(*args)
+
+        return run()
+
+    hass.async_add_executor_job = _ordered
 
     async def both():
         await asyncio.gather(
@@ -608,7 +629,7 @@ def test_one_corrupt_byte_costs_one_line_not_the_restore(tmp_path):
         fh.write(b"\xff\xfe not utf-8 at all\n")
     rows = H.read_segments(d, [day])
     assert [r["x"] for r in rows] == [1, 2]
-    assert H.drop_entity(d, ENT, H.history_config({})) == 2
+    assert H.drop_entity(d, ENT) == 2
 
 
 def test_orphaned_tmp_files_are_swept(tmp_path):
@@ -817,3 +838,26 @@ def test_history_without_a_recorded_room_still_works():
     got = all_points(h)
     assert got["count"] == 1
     assert [got["zones"][i] for i in got["z"]] == [""]
+
+
+def test_thinning_never_swallows_a_dropout():
+    # The hard cap thins the force-kept breaks away when data flaps, and a
+    # DROPOUT flag lost there makes the room band paint a solid room across an
+    # outage and the trail draw straight through it. A frame break may be
+    # sacrificed; a dropout may not.
+    for offset in range(6):        # sweep the dropout across the stride phase
+        h = hist(max_age=10 ** 9, max_points=10 ** 9)
+        t0 = 1_000_000.0
+        t = t0
+        for i in range(4000):
+            # Alternating room on every fix: every point is force-kept, which
+            # is what pushes the response past the cap.
+            if i == 2000 + offset:
+                t += 500.0         # a real silence -> GAP_DROPOUT
+            else:
+                t += 2.0
+            h.record(ENT, t, float(i % 7), 0.0, FLOOR, SCALE,
+                     "Kitchen" if i % 2 else "Hall")
+        got = h.query(ENT, 0, 1e12, 100)
+        assert got["count"] <= 201, "the hard cap must still hold"
+        assert H.GAP_DROPOUT in got["gap"], f"dropout lost at offset {offset}"


### PR DESCRIPTION
An audit of `main` after merging #123, #125, #126 and #127 confirmed eight defects. **The merges themselves were clean** — nothing was lost and the hand-resolved conflict was correct — but these were latent in the merged result, and none should ship in the release.

| severity | defect |
|---|---|
| **HIGH** | `restore_position_history()` pruned day segments against a retention it was never allowed to trust. The periodic flush already refuses to prune when the layout isn't a dict (fresh install, or a store that failed to load this boot) because `history_config` falls back to the 6 h default — restore had no such guard, so a configured 7-day record was cut to six hours **on every restart** until the layout happened to be readable. Irreversible. |
| MEDIUM | The hard-cap thinning in `query()` could silently swallow a `GAP_DROPOUT`. The room band's zone-change force-keep pushes a flapping device past the cap, and the thinning then drops every other kept index — taking real dropouts with it. The band painted a solid room across the outage, hover said a room where the code promises *not recorded*, and the trail drew straight through it. |
| MEDIUM | "Colours: off" repainted with a bare `clearCanvas()+drawElements()`, erasing the history trail and its marker with nothing to bring them back. |
| MEDIUM | `test_clear_is_not_undone_by_a_concurrent_flush` **passed with the lock removed entirely** — it protected nothing. |
| LOW | The room band ignored `zone.uncolored`, staying the only coloured thing on screen with map colours off. |
| LOW | Gap severity parsed on restore with `int()`, which raises `OverflowError` on a non-finite value — one junk row would abort the whole restore, permanently, since the row stays on disk. |
| LOW | `drop_entity()` took `cfg` and `now` and used neither. |
| LOW | Comments still claimed the history bar has no toggle, contradicting the switch restored in the same PR. |

### On the dropout fix

Re-adding a dropped index would push the response back over the cap that block exists to enforce. So a discarded dropout **carries forward** onto the next surviving point: the count is unchanged, and the hole can only widen to the next kept point — which errs toward honesty.

### On the concurrency test

conftest's executor runs inline, so the flush completed atomically before the clear was entered. Yielding wasn't enough either: `gather()` resumes the flush first, so its append landed *before* the delete — harmless. The test now constructs the damaging order explicitly (clear deletes, then the flush's already-drained rows are written back), and is verified to **fail without the lock** — 60 forgotten rows return to disk — and pass with it.

Both new regression tests were checked against a reverted fix to confirm they catch what they claim. **148 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
