### PR TITLE
Cut per-tick CPU and the worst event-loop stall

### DIFF
--- a/custom_components/bps/__init__.py
+++ b/custom_components/bps/__init__.py
@@ -7,7 +7,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.frontend import async_remove_panel
 from homeassistant.components import panel_custom
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.template import Template
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import device_registry as dr
@@ -574,11 +573,10 @@ def cleanup_legacy_bps_registry_and_states(hass: HomeAssistant):
         _LOGGER.info("Removing legacy BPS state: %s", entity_id)
         hass.states.async_remove(entity_id)
 
-async def update_tracked_entities(hass, jinja_code):
+async def update_tracked_entities(hass):
     """Update tracked_entities with the result of the Jinja code once per second."""
     global tracked_entities, tracked_listeners, new_global_data
     global secToUpdate
-    template = Template(jinja_code, hass)  # compile once; async_render re-evaluates each tick
     while True:
         # Receiver liveness and the self-localization accuracy sensor are
         # receiver-side diagnostics, independent of how many beacons are being
@@ -617,13 +615,17 @@ async def update_tracked_entities(hass, jinja_code):
                 _LOGGER.warning("BPS position history flush failed: %s", e)
 
         try:
-            tracked_entities = template.async_render()
-            # The template matches every "_distance_to_" sensor; keep only the
-            # ones Bermuda actually owns, so look-alike sensors from other
-            # integrations (e.g. an mmWave sensor's
-            # "_distance_to_detection_object") never become tracked devices.
-            allowed = set(_bermuda_distance_sensor_ids(hass))
-            tracked_entities = [e for e in tracked_entities if e in allowed]
+            # This used to render a Jinja template that selected every
+            # "sensor.*_distance_to_*" and then intersect it with the Bermuda
+            # ones. The intersection was provably the second list: both walk
+            # hass.states.async_all("sensor") and both require "_distance_to_"
+            # in the id, so the template only ever added look-alikes from other
+            # integrations for the next line to discard again. Rendering a
+            # template over every sensor state, once a second, to compute a
+            # superset of a list we already have was the single cost in this
+            # loop that grew with the size of the user's Home Assistant rather
+            # than with the number of beacons.
+            tracked_entities = _bermuda_distance_sensor_ids(hass)
 
             await prune_stale_positions(hass)
 
@@ -1933,20 +1935,10 @@ async def async_setup(hass, config):
         # retained window back before the tracking loop starts appending.
         await restore_position_history(hass)
 
-        jinja_code = """
-        {{
-            states.sensor
-            | selectattr("entity_id", "search", "_distance_to_")
-            | map(attribute="entity_id")
-            | unique
-            | list
-        }}
-        """
-
         old_task = hass.data.get("bps_update_task")
         if old_task:
             old_task.cancel()
-        hass.data["bps_update_task"] = hass.async_create_task(update_tracked_entities(hass, jinja_code))
+        hass.data["bps_update_task"] = hass.async_create_task(update_tracked_entities(hass))
 
         async def handle_homeassistant_stop(event):
             """Stop background work promptly so shutdown cannot drag or leave
@@ -2448,6 +2440,11 @@ class BPSCordsAPI(HomeAssistantView):
         return web.json_response(apitricords)
 
 # Trilateration function
+# Floor on the distance used in the Jacobian's direction vector. Only guards
+# the 0/0 at a fit sitting exactly on a receiver; far below any real geometry.
+_JAC_MIN_DIST = 1e-9
+
+
 def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     """Weighted least-squares position fit.
 
@@ -2478,22 +2475,42 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
         _LOGGER.error("At least three known points are required for trilateration.")
         return None
 
-    def objective_function(X, known_points): # Define the objective function loss for the least squares method.
-        x, y = X
-        residuals = []
-        weights = []
-        for pt in known_points:
-            xi, yi, ri = pt[0], pt[1], pt[2]
-            wi = pt[3] if len(pt) > 3 else 1.0
-            # Weight radius: the MEASURED slant when supplied (5th element),
-            # else the fit radius. Height correction can legitimately collapse
-            # the projected radius to the minimum while the measured slant is
-            # ~dz (metres) — weighting by the projection handed such a receiver
-            # ~100x influence and the fit snapped onto it (1.7.0 regression).
-            wri = pt[4] if len(pt) > 4 else ri
-            residuals.append(np.sqrt((xi - x)**2 + (yi - y)**2) - ri)
-            weights.append(wi / max(wri, min_weight_radius)**2)  # reliability x geometric (1/r^2) weight
-        return np.sqrt(np.array(weights)) * np.array(residuals)
+    # The per-point arrays are built ONCE here, not rebuilt inside the
+    # objective: least_squares calls the objective (and the Jacobian) many
+    # times per solve, and at this problem size the Python loop that used to
+    # live in there cost far more than the arithmetic it performed.
+    px = np.fromiter((p[0] for p in known_points), dtype=float, count=num_points)
+    py = np.fromiter((p[1] for p in known_points), dtype=float, count=num_points)
+    pr = np.fromiter((p[2] for p in known_points), dtype=float, count=num_points)
+    rel = np.fromiter((p[3] if len(p) > 3 else 1.0 for p in known_points),
+                      dtype=float, count=num_points)
+    # Weight radius: the MEASURED slant when supplied (5th element), else the
+    # fit radius. Height correction can legitimately collapse the projected
+    # radius to the minimum while the measured slant is ~dz (metres) —
+    # weighting by the projection handed such a receiver ~100x influence and
+    # the fit snapped onto it (1.7.0 regression).
+    wrad = np.fromiter((p[4] if len(p) > 4 else p[2] for p in known_points),
+                       dtype=float, count=num_points)
+    # reliability x geometric (1/r^2) weight, pre-rooted: the residual is
+    # sqrt(w) * (distance - r), so sqrt() belongs here rather than per call.
+    sqrt_w = np.sqrt(rel / np.maximum(wrad, min_weight_radius) ** 2)
+
+    def objective_function(X):
+        return sqrt_w * (np.hypot(px - X[0], py - X[1]) - pr)
+
+    def jacobian(X):
+        """Exact derivative of the residual: d/dX sqrt(w)(|X - p| - r).
+
+        Supplying it saves least_squares the finite-difference pass, which
+        costs one extra objective evaluation per unknown per iteration.
+        The distance is floored before dividing: a fit sitting exactly on a
+        receiver has an undefined direction, and a NaN there would poison the
+        whole step rather than just that row.
+        """
+        dx = X[0] - px
+        dy = X[1] - py
+        d = np.maximum(np.hypot(dx, dy), _JAC_MIN_DIST)
+        return np.column_stack((sqrt_w * dx / d, sqrt_w * dy / d))
 
     # Start from the receiver centroid: it is always a plausible position,
     # unlike the map corner, and it must lie inside any given bounds.
@@ -2514,7 +2531,7 @@ def trilaterate(known_points, bounds=None, min_weight_radius=1e-3):
     else:
         lo, hi = [-np.inf, -np.inf], [np.inf, np.inf]
     result = least_squares(
-        objective_function, x0, args=(known_points,),
+        objective_function, x0, jac=jacobian,
         bounds=(lo, hi), method="trf",
         loss="soft_l1", f_scale=SOLVER_ROBUST_F_SCALE,
     )

--- a/custom_components/bps/calibration.py
+++ b/custom_components/bps/calibration.py
@@ -410,6 +410,30 @@ def _true_distance_m(cal: dict, slug_a: str, slug_b: str):
     return horizontal
 
 
+def solve_snapshot(cal: dict) -> dict:
+    """A private copy of everything solve() reads, taken ON the event loop.
+
+    solve() is handed to an executor (it is the single longest blocking call in
+    the integration - tens of milliseconds on a desktop, hundreds on a Pi-class
+    box, per floor). But cal["samples"] is a dict of deques the ingest path
+    appends to on the loop, so iterating it off-thread races that ingest: a new
+    pair key raises "dictionary changed size during iteration", and a deque
+    growing under np.median silently returns a median of a moving set. Copying
+    the two structures it reads is cheap next to the solve and removes the race
+    entirely - the same discipline run_selftest already uses.
+    """
+    return {
+        "samples": {k: list(v) for k, v in (cal.get("samples") or {}).items()},
+        "receivers": dict(cal.get("receivers") or {}),
+    }
+
+
+async def async_solve(hass, cal: dict, floor_name: str):
+    """solve() off the event loop, against a snapshot taken on it."""
+    snap = solve_snapshot(cal)
+    return await hass.async_add_executor_job(solve, snap, floor_name)
+
+
 def solve(cal: dict, floor_name: str):
     """Fit per-receiver corrections for one floor from the collected samples.
 
@@ -637,7 +661,7 @@ async def _sample_loop(hass, cal: dict) -> None:
         except Exception as e:
             _LOGGER.debug("Final calibration dump failed: %s", e)
 
-        result = solve(cal, cal["floor"])
+        result = await async_solve(hass, cal, cal["floor"])
         cal["results"][result["floor"]] = result
         cal["last_solved_at"] = result["solved_at"]
         cal["state"] = "done"
@@ -725,7 +749,7 @@ async def _auto_solve_and_apply_locked(hass, cal: dict) -> None:
         if len(on_floor) < 3:
             continue
         try:
-            result = solve(cal, floor_name)
+            result = await async_solve(hass, cal, floor_name)
         except ValueError:
             continue  # not enough pairs on this floor yet
         cal["results"][floor_name] = result
@@ -1019,7 +1043,7 @@ class BPSCalibrationAPI(HomeAssistantView):
                 # Re-solve from the samples already collected (e.g. after an
                 # early cancel, or to inspect before the window ends).
                 floor_name = data.get("floor") or cal.get("floor")
-                result = solve(cal, floor_name)
+                result = await async_solve(hass, cal, floor_name)
                 cal["results"][result["floor"]] = result
                 cal["last_solved_at"] = result["solved_at"]
                 cal["error"] = None

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "2.1.0"
+    "version": "2.1.1"
 }

--- a/custom_components/bps/manifest.json
+++ b/custom_components/bps/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/maxi1134/BPS-improved/issues",
     "requirements": ["aiofiles>=23.1.0", "numpy>=1.26.4", "scipy>=1.10.1", "shapely>=2.0.2"],
-    "version": "2.1.1"
+    "version": "2.2.0"
 }

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -559,3 +559,76 @@ def test_age_falls_back_to_last_changed_and_fails_open():
         Hass(), {"entity": "cat", "data": {"floor": [
             {"name": "F", "scale": SCALE, "receivers": [rec]}]}}))
     assert rec["distance"] == 3.0
+
+
+# --------------------------------------------------------------------------- #
+# The vectorised objective + analytic Jacobian
+# --------------------------------------------------------------------------- #
+def _weighted_cost(pts, x, y, min_weight_radius=1e-3):
+    """The cost trilaterate() minimises, written independently of it.
+
+    Mirrors scipy's soft_l1: rho(z) = 2*(sqrt(1+z) - 1) applied to the squared
+    residual scaled by f_scale.
+    """
+    total = 0.0
+    fs = bps.SOLVER_ROBUST_F_SCALE
+    for pt in pts:
+        xi, yi, ri = pt[0], pt[1], pt[2]
+        wi = pt[3] if len(pt) > 3 else 1.0
+        wri = pt[4] if len(pt) > 4 else ri
+        w = wi / max(wri, min_weight_radius) ** 2
+        res = (w ** 0.5) * (math.hypot(xi - x, yi - y) - ri)
+        z = (res / fs) ** 2
+        total += 2.0 * ((1.0 + z) ** 0.5 - 1.0)
+    return total
+
+
+def test_the_fit_is_a_local_minimum_of_the_weighted_cost():
+    # Implementation-independent: whatever the objective and Jacobian are
+    # written in, the point that comes back must be a minimum of the cost the
+    # docstring describes. This is what protects the analytic Jacobian — a
+    # wrong derivative still converges, just to the wrong place.
+    cases = [
+        [(0.0, 0.0, 141.4), (200.0, 0.0, 141.4), (100.0, 200.0, 100.0)],
+        [(120.0, 120.0, 210.0, 0.9, 210.0), (640.0, 140.0, 300.0, 0.8, 300.0),
+         (380.0, 420.0, 190.0, 1.0, 190.0), (80.0, 400.0, 330.0, 0.7, 330.0)],
+        [(50.0, 50.0, 90.0), (400.0, 60.0, 260.0), (240.0, 380.0, 180.0),
+         (600.0, 300.0, 400.0), (120.0, 300.0, 130.0)],
+    ]
+    for pts in cases:
+        got = bps.trilaterate(pts)
+        assert got is not None
+        x, y = got
+        here = _weighted_cost(pts, x, y)
+        for dx, dy in ((1.0, 0), (-1.0, 0), (0, 1.0), (0, -1.0),
+                       (0.7, 0.7), (-0.7, -0.7)):
+            assert _weighted_cost(pts, x + dx, y + dy) >= here - 1e-9, (
+                f"moving by ({dx}, {dy}) lowered the cost: not a minimum")
+
+
+def test_a_fit_sitting_exactly_on_a_receiver_is_finite():
+    # The analytic Jacobian divides by the distance from the fit to each
+    # receiver, which is 0 when the fit lands exactly on one. Without the floor
+    # that row is NaN and poisons the whole step.
+    pts = [(100.0, 100.0, 0.0), (300.0, 100.0, 200.0), (100.0, 300.0, 200.0)]
+    got = bps.trilaterate(pts)
+    assert got is not None
+    x, y = got
+    assert math.isfinite(x) and math.isfinite(y)
+    assert abs(x - 100.0) < 1.0 and abs(y - 100.0) < 1.0
+
+
+def test_the_weight_radius_override_still_governs_the_weight():
+    # The 5th element must keep overriding the radius used in the 1/r^2 weight
+    # after vectorisation — this is the 1.7.0 regression guard.
+    truth = [(0.0, 0.0, 300.0), (600.0, 0.0, 300.0), (300.0, 500.0, 250.0)]
+    # A receiver whose projected radius collapsed to ~0 but whose MEASURED
+    # slant was large must not be allowed to dominate.
+    hijack = truth + [(600.0, 500.0, 0.001, 1.0, 400.0)]
+    naive = truth + [(600.0, 500.0, 0.001)]
+    with_override = bps.trilaterate(hijack)
+    without = bps.trilaterate(naive)
+    assert with_override is not None and without is not None
+    # Without the override the fit is dragged onto the collapsed receiver.
+    assert math.hypot(without[0] - 600.0, without[1] - 500.0) < \
+        math.hypot(with_override[0] - 600.0, with_override[1] - 500.0)


### PR DESCRIPTION
Targeted at a **Home Assistant Green** (Rockchip RK3566, 4× Cortex-A55). Measured on x86; an A55 core is roughly 4–8× slower single-threaded, which is what turns a comfortable ~20 ms tick here into one that brushes asyncio's 100 ms `slow_callback_duration` on the target box.

### 1. Vectorised objective + analytic Jacobian in `trilaterate()`

The objective rebuilt two Python lists on every `least_squares` iteration, and scipy was estimating the Jacobian by finite differences — one extra objective evaluation per unknown per iteration. Arrays are now built once per solve; the derivative is exact, `sqrt(w)(X − p)/|X − p|`, with the distance floored before the divide so a fit landing exactly on a receiver gives 0 rather than a NaN that poisons the step.

**1.33 → 0.86 ms per solve (1.55×.)** At the reference topology (2 trackers × 3 candidate floors = 6 solves/tick):

| trackers | now | after | est. on Green |
|---|---|---|---|
| 2 | 8.0 ms | 5.2 ms | ~32–64 → ~21–41 ms |
| 4 | 15.9 ms | 10.3 ms | ~64–128 → ~41–82 ms |
| 8 | 31.9 ms | 20.6 ms | ~128–255 → ~82–165 ms |

**Equivalence** over 1500 randomised configurations — 3–10 receivers, collinear and tightly-clustered geometry, zero and near-zero radii, all three tuple forms, bounded and unbounded, four `min_weight_radius` values:

- zero convergence disagreements
- well-conditioned geometry (receiver spread ≥ 100 px): median delta **5.3e-07 px**, p99 1.6e-04, worst **1.6e-02 px — 0.4 mm** at 40 px/m
- the single 0.1 px outlier is a four-receiver cluster spanning 20 px with no bounds, where the position is barely determined at all

### 2. Dropped the per-tick Jinja render

It selected every `sensor.*_distance_to_*`, and the next line intersected that with the Bermuda-owned ones. But `_bermuda_distance_sensor_ids` applies the same two conditions **plus** a platform check and walks the same `hass.states.async_all("sensor")` — so the intersection was provably that list, same members and same order. The template only ever added look-alikes for the next line to discard.

It was also the only cost in the loop that grew with the size of the user's Home Assistant rather than with the number of beacons.

### 3. Calibration's `solve()` off the loop

The single longest blocking call in the integration — tens of ms per floor on a desktop, **hundreds on a Pi-class box**, every 15 minutes and again on every manual solve.

It runs in the executor now, against a **snapshot taken on the loop**. That part matters: `cal["samples"]` is a dict of deques the ingest path appends to, so iterating it off-thread races that ingest — a new pair key raises *dictionary changed size during iteration*, and a deque growing under `np.median` silently returns the median of a moving set. Same discipline `run_selftest` already uses. All three call sites verified async via the AST.

### Tests

Three added, and **the suite is verified to catch a wrong derivative** — flipping one sign in the Jacobian fails 12 tests, including all three new ones. They're deliberately implementation-independent:

- the returned point must be a local minimum of the weighted `soft_l1` cost, written out separately from the solver
- a fit sitting exactly on a receiver must be finite
- the 5th-element weight-radius override must still stop a collapsed projected radius hijacking the fit (the 1.7.0 regression guard)

**151 passing.** Version 2.1.1.

### Not included

Ranked below these and deferred: caching the per-floor shapely geometry (−2.8 ms/tick, needs invalidation on layout save) and replacing the `deepcopy` with a targeted copy (−0.34 ms/tracker — and note it is **not** waste, `update_receiver_radii` mutates 44 leaf values under `receivers[*]`). Also rejected on measurement: a hand-rolled IRLS Gauss-Newton is a real 6.3× on the solve, but one implementation landed 2.9 m off scipy's answer — that's a numerical-methods project, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
